### PR TITLE
Derive subtype at key

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ The type of each type definition can be
 [narrowed using a type predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates):
 
 ```ts
-function isFooOrBar(value: string): value is 'foo' | 'bar' {
-  return value === 'foo' || value === 'bar';
+function isFooOrBar(input: string): input is 'foo' | 'bar' {
+  return input === 'foo' || input === 'bar';
 }
 
 d.string().narrow(isFooOrBar);
@@ -109,8 +109,8 @@ d.string().narrow(isFooOrBar);
 You can use a boolean predicate to validate a specific condition:
 
 ```ts
-function isEven(value: number): boolean {
-  return value & 1 === 0;
+function isEven(input: number): boolean {
+  return input & 1 === 0;
 }
 
 d.number().narrow(isEven);
@@ -122,8 +122,8 @@ d.number().narrow(isEven);
 You can perform custom type transformations.
 
 ```ts
-function toFixed(value: number): string {
-  return value.toFixed(2);
+function toFixed(input: number): string {
+  return input.toFixed(2);
 }
 
 d.number().transform(toFixed);
@@ -132,32 +132,37 @@ d.number().transform(toFixed);
 
 ## Validation errors
 
-If you encounter an error during a [narrowing](#type-narrowing) or [transformation](#type-transformations), throw
-a `ValidationError`:
+If you encounter an error during a [narrowing](#type-narrowing) or a [transformation](#type-transformations), throw
+a `ValidationError` with an array of associated issues:
 
 ```ts
 import * as d from 'doubter';
 import { ValidationError } from 'doubter';
 
-function beautify(value: unknown): string {
-  if (typeof value === 'number') {
-    return value.toFixed(2);
+function toNumber(input: any): number {
+  const output = +input;
+
+  if (isNaN(output)) {
+    throw new ValidationError([
+      {
+        code: 'nan',
+        path: [],
+        input: input,
+        message: 'Must be a number',
+      }
+    ]);
   }
 
-  throw new ValidationError({
-    code: 'unbeautifiable',
-    path: [],
-    input: value,
-    message: 'Expected a number to beautify',
-  });
+  return output;
 }
 
-d.unknown().transform(beautify);
+d.any().transform(toNumber);
+// → Type<number>
 ```
 
 ## Custom messages
 
-Many of the DSL methods support an options argument. You can use it to pass a customized message and metadata that are
+Many of the DSL methods support an `options` argument. You can use it to pass a customized message and metadata that are
 attached to an issue:
 
 ```ts

--- a/src/main/shared-types.ts
+++ b/src/main/shared-types.ts
@@ -17,12 +17,19 @@ export interface Issue {
    */
   input: any;
 
-  message: string;
+  /**
+   * A message associated with an issue. Built-in messages are strings but custom messages can have an arbitrary type.
+   */
+  message: any;
 
   /**
    * An additional param that is specific for {@link code}.
    */
   param?: any;
+
+  /**
+   * An arbitrary metadata that can be used for message formatting.
+   */
   meta?: any;
 }
 
@@ -37,7 +44,14 @@ export interface Dict<T = any> {
 }
 
 export interface ConstraintOptions {
-  message?: string;
+  /**
+   * The custom issue message.
+   */
+  message?: any;
+
+  /**
+   * An arbitrary metadata that is added to an issue.
+   */
   meta?: any;
 }
 

--- a/src/main/types/ArrayType.ts
+++ b/src/main/types/ArrayType.ts
@@ -8,6 +8,7 @@ import {
   isEqual,
   isEqualArray,
   isFast,
+  isInteger,
   promiseAll,
   promiseAllSettled,
   raiseIssue,
@@ -35,6 +36,10 @@ export class ArrayType<X extends AnyType> extends Type<InferType<X>[]> {
    */
   constructor(protected type: X, options?: ConstraintOptions) {
     super(type.async, options);
+  }
+
+  at(key: unknown): AnyType | null {
+    return typeof key === 'number' && isInteger(key) && key > -1 ? this.type : null;
   }
 
   /**

--- a/src/main/types/IntegerType.ts
+++ b/src/main/types/IntegerType.ts
@@ -1,8 +1,6 @@
 import { NumberType } from './NumberType';
-import { raiseIssue } from '../utils';
+import { isInteger, raiseIssue } from '../utils';
 import { ConstraintOptions, ParserOptions } from '../shared-types';
-
-const isInteger = Number.isInteger;
 
 /**
  * The integer type definition.

--- a/src/main/types/LazyType.ts
+++ b/src/main/types/LazyType.ts
@@ -12,10 +12,15 @@ export class LazyType<X extends AnyType> extends Type<InferType<X>> {
   /**
    * Creates a new {@link LazyType} instance.
    *
+   * @param async
    * @param provider Returns the type definition that must be applied to the input value.
    */
   constructor(async: boolean, private provider: () => X) {
     super(async);
+  }
+
+  at(key: unknown): AnyType | null {
+    return (this.type ||= this.provider()).at(key);
   }
 
   parse(input: unknown, options?: ParserOptions): Awaitable<InferType<X>> {

--- a/src/main/types/NullableType.ts
+++ b/src/main/types/NullableType.ts
@@ -1,5 +1,6 @@
 import { AnyType, InferType, Type } from './Type';
 import { Awaitable, ParserOptions } from '../shared-types';
+import { OptionalType } from './OptionalType';
 
 /**
  * The nullable type definition.
@@ -14,6 +15,11 @@ export class NullableType<X extends AnyType> extends Type<InferType<X> | null> {
    */
   constructor(protected type: X) {
     super(type.async);
+  }
+
+  at(key: unknown): AnyType | null {
+    const childType = this.type.at(key);
+    return childType === null ? null : new OptionalType(childType);
   }
 
   parse(input: unknown, options?: ParserOptions): Awaitable<InferType<X> | null> {

--- a/src/main/types/ObjectType.ts
+++ b/src/main/types/ObjectType.ts
@@ -17,8 +17,6 @@ import {
   raiseIssuesIfDefined,
   raiseIssuesOrCaptureForKey,
   raiseIssuesOrPush,
-  returnFalse,
-  returnTrue,
 } from '../utils';
 
 type InferObjectType<P extends Dict<AnyType>, I extends AnyType> = Squash<
@@ -72,6 +70,16 @@ export class ObjectType<P extends Dict<AnyType>, I extends AnyType> extends Type
     this.valueTypes = valueTypes;
     this.propEntries = Object.entries(props);
     this.keysMode = indexerType === null ? ObjectKeysMode.PRESERVE : ObjectKeysMode.INDEXER;
+  }
+
+  at(key: unknown): AnyType | null {
+    if (typeof key !== 'string') {
+      return null;
+    }
+    if (this.keys.includes(key)) {
+      return this.props[key];
+    }
+    return this.indexerType;
   }
 
   /**
@@ -157,6 +165,7 @@ export class ObjectType<P extends Dict<AnyType>, I extends AnyType> extends Type
     const type = cloneObject<ObjectType<any, any>>(this);
     type.keysMode = ObjectKeysMode.EXACT;
     type.exactOptions = options;
+    type.indexerType = null;
     return type;
   }
 
@@ -168,6 +177,7 @@ export class ObjectType<P extends Dict<AnyType>, I extends AnyType> extends Type
   strip(): ObjectType<P, Type<never>> {
     const type = cloneObject<ObjectType<any, any>>(this);
     type.keysMode = ObjectKeysMode.STRIP;
+    type.indexerType = null;
     return type;
   }
 
@@ -179,6 +189,7 @@ export class ObjectType<P extends Dict<AnyType>, I extends AnyType> extends Type
   preserve(): ObjectType<P, Type<any>> {
     const type = cloneObject<ObjectType<any, any>>(this);
     type.keysMode = ObjectKeysMode.PRESERVE;
+    type.indexerType = null;
     return type;
   }
 

--- a/src/main/types/OptionalType.ts
+++ b/src/main/types/OptionalType.ts
@@ -17,6 +17,11 @@ export class OptionalType<X extends AnyType> extends Type<InferType<X> | undefin
     super(type.async);
   }
 
+  at(key: unknown): AnyType | null {
+    const childType = this.type.at(key);
+    return childType === null ? null : new OptionalType(childType);
+  }
+
   parse(input: unknown, options?: ParserOptions): Awaitable<InferType<X> | undefined> {
     const { type, defaultValue } = this;
 

--- a/src/main/types/RecordType.ts
+++ b/src/main/types/RecordType.ts
@@ -20,6 +20,10 @@ export class RecordType<K extends Type<string>, V extends AnyType> extends Type<
     super(keyType.async || valueType.async, options);
   }
 
+  at(key: unknown): AnyType | null {
+    return typeof key === 'string' ? this.valueType : null;
+  }
+
   parse(input: unknown, options?: ParserOptions): Awaitable<Record<InferType<K>, InferType<V>>> {
     if (!isObjectLike(input)) {
       raiseIssue(input, 'type', 'object', this.options, 'Must be an object');

--- a/src/main/types/TupleType.ts
+++ b/src/main/types/TupleType.ts
@@ -8,6 +8,7 @@ import {
   isEqual,
   isEqualArray,
   isFast,
+  isInteger,
   parseAsync,
   promiseAll,
   promiseAllSettled,
@@ -32,6 +33,12 @@ export class TupleType<U extends Several<AnyType>> extends Type<InferTupleType<U
    */
   constructor(protected types: U, options?: ConstraintOptions) {
     super(isAsync(types), options);
+  }
+
+  at(key: unknown): AnyType | null {
+    const { types } = this;
+
+    return typeof key === 'number' && isInteger(key) && key > -1 && key < types.length ? types[key] : null;
   }
 
   parse(input: unknown, options?: ParserOptions): Awaitable<InferTupleType<U>> {

--- a/src/main/types/Type.ts
+++ b/src/main/types/Type.ts
@@ -73,14 +73,14 @@ export abstract class Type<T> {
     return new TransformedType(this, true, transformer);
   }
 
-  refine<O extends T>(refiner: (value: T) => value is O, options?: ConstraintOptions): TransformedType<this, O>;
+  narrow<O extends T>(predicate: (value: T) => value is O, options?: ConstraintOptions): TransformedType<this, O>;
 
-  refine(refiner: (value: T) => unknown, options?: ConstraintOptions): TransformedType<this, T>;
+  narrow(predicate: (value: T) => unknown, options?: ConstraintOptions): TransformedType<this, T>;
 
-  refine(refiner: (value: T) => unknown, options?: ConstraintOptions): TransformedType<this, T> {
+  narrow(predicate: (value: T) => unknown, options?: ConstraintOptions): TransformedType<this, T> {
     return this.transform(input => {
-      if (!refiner(input)) {
-        raiseIssue(input, 'refined', undefined, options, 'Must be refined');
+      if (!predicate(input)) {
+        raiseIssue(input, 'narrow', undefined, options, 'Must be narrowed');
       }
       return input;
     });

--- a/src/main/types/Type.ts
+++ b/src/main/types/Type.ts
@@ -29,6 +29,10 @@ export abstract class Type<T> {
    */
   abstract parse(input: unknown, options?: ParserOptions): Awaitable<T>;
 
+  at(key: unknown): AnyType | null {
+    return null;
+  }
+
   validate(input: unknown, options?: ParserOptions): Issue[] | null {
     if (this.async) {
       throw new Error('Cannot use async type');

--- a/src/main/types/UnionType.ts
+++ b/src/main/types/UnionType.ts
@@ -19,6 +19,25 @@ export class UnionType<U extends Several<AnyType>> extends Type<InferUnionType<U
     super(isAsync(types));
   }
 
+  at(key: unknown): AnyType | null {
+    const childTypes: AnyType[] = [];
+
+    for (const type of this.types) {
+      const childType = type.at(key);
+
+      if (childType !== null) {
+        childTypes.push(childType);
+      }
+    }
+    if (childTypes.length === 0) {
+      return null;
+    }
+    if (childTypes.length === 1) {
+      return childTypes[0];
+    }
+    return new UnionType(childTypes as Several<AnyType>);
+  }
+
   parse(input: unknown, options?: ParserOptions): Awaitable<InferUnionType<U>> {
     const { types } = this;
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -142,6 +142,8 @@ export const isEqual = Object.is;
 
 export const isArray = Array.isArray;
 
+export const isInteger = Number.isInteger;
+
 export const promiseAll = Promise.all.bind(Promise);
 
 export const promiseAllSettled = Promise.allSettled.bind(Promise);
@@ -199,12 +201,4 @@ export function copyObjectEnumerableKeys(input: Dict, keyCount?: number): Dict {
     i++;
   }
   return output;
-}
-
-export function returnTrue() {
-  return true;
-}
-
-export function returnFalse() {
-  return false;
 }

--- a/src/test/types/ArrayType.test.ts
+++ b/src/test/types/ArrayType.test.ts
@@ -276,4 +276,14 @@ describe('ArrayType', () => {
 
     await expect(() => type.validateAsync([1])).rejects.toEqual(new MockError());
   });
+
+  test('returns child type at key', () => {
+    const childType = new NumberType();
+    const type = new ArrayType(childType);
+
+    expect(type.at(1)).toBe(childType);
+    expect(type.at(-1)).toBe(null);
+    expect(type.at(0.5)).toBe(null);
+    expect(type.at('aaa')).toBe(null);
+  });
 });

--- a/src/test/types/LazyType.test.ts
+++ b/src/test/types/LazyType.test.ts
@@ -1,4 +1,4 @@
-import { LazyType, StringType } from '../../main';
+import { ArrayType, LazyType, NumberType, StringType } from '../../main';
 
 describe('LazyType', () => {
   test('uses the type returned from provider to parse the input', () => {
@@ -29,5 +29,15 @@ describe('LazyType', () => {
     type.validate(222);
 
     expect(providerMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns child type at key', () => {
+    const childType = new NumberType();
+    const type = new LazyType(false, () => new ArrayType(childType));
+
+    expect(type.at(1)).toBe(childType);
+    expect(type.at(-1)).toBe(null);
+    expect(type.at(0.5)).toBe(null);
+    expect(type.at('aaa')).toBe(null);
   });
 });

--- a/src/test/types/NullableType.test.ts
+++ b/src/test/types/NullableType.test.ts
@@ -1,4 +1,4 @@
-import { NullableType, StringType } from '../../main';
+import { ArrayType, NullableType, NumberType, OptionalType, StringType } from '../../main';
 
 describe('NullableType', () => {
   test('allows null', () => {
@@ -30,5 +30,15 @@ describe('NullableType', () => {
     const type = new NullableType(new StringType().transformAsync(() => Promise.resolve(222)));
 
     expect(type.async).toBe(true);
+  });
+
+  test('returns child type at key', () => {
+    const childType = new NumberType();
+    const type = new NullableType(new ArrayType(childType));
+
+    expect(type.at(1)).toStrictEqual(new OptionalType(childType));
+    expect(type.at(-1)).toBe(null);
+    expect(type.at(0.5)).toBe(null);
+    expect(type.at('aaa')).toBe(null);
   });
 });

--- a/src/test/types/ObjectType.test.ts
+++ b/src/test/types/ObjectType.test.ts
@@ -213,4 +213,19 @@ describe('ObjectType', () => {
     expect(input).toEqual({ foo: 111 });
     expect(output).toEqual({ foo: 'aaa' });
   });
+
+  test('returns child type at key', () => {
+    const childType = new NumberType();
+    const type = new ObjectType({ foo: childType }, null);
+
+    expect(type.at('foo')).toBe(childType);
+    expect(type.at('bar')).toBe(null);
+  });
+
+  test('returns indexer type at key', () => {
+    const indexerType = new StringType();
+    const type = new ObjectType({}, indexerType);
+
+    expect(type.at('bar')).toBe(indexerType);
+  });
 });

--- a/src/test/types/OptionalType.test.ts
+++ b/src/test/types/OptionalType.test.ts
@@ -1,4 +1,4 @@
-import { OptionalType, StringType } from '../../main';
+import { ArrayType, NumberType, OptionalType, StringType } from '../../main';
 
 describe('OptionalType', () => {
   test('allows undefined', () => {
@@ -45,5 +45,15 @@ describe('OptionalType', () => {
     const type = new OptionalType(new StringType().transformAsync(() => Promise.resolve(222)));
 
     expect(type.async).toBe(true);
+  });
+
+  test('returns child type at key', () => {
+    const childType = new NumberType();
+    const type = new OptionalType(new ArrayType(childType));
+
+    expect(type.at(1)).toStrictEqual(new OptionalType(childType));
+    expect(type.at(-1)).toBe(null);
+    expect(type.at(0.5)).toBe(null);
+    expect(type.at('aaa')).toBe(null);
   });
 });

--- a/src/test/types/RecordType.test.ts
+++ b/src/test/types/RecordType.test.ts
@@ -56,4 +56,12 @@ describe('RecordType', () => {
       },
     ]);
   });
+
+  test('returns child type at key', () => {
+    const childType = new NumberType();
+    const type = new RecordType(new StringType(), childType);
+
+    expect(type.at('aaa')).toBe(childType);
+    expect(type.at(1)).toBe(null);
+  });
 });

--- a/src/test/types/TupleType.test.ts
+++ b/src/test/types/TupleType.test.ts
@@ -58,4 +58,16 @@ describe('tuple', () => {
       },
     ]);
   });
+
+  test('returns child type at key', () => {
+    const childType1 = new StringType();
+    const childType2 = new NumberType();
+    const type = new TupleType([childType1, childType2]);
+
+    expect(type.at(0)).toBe(childType1);
+    expect(type.at(1)).toBe(childType2);
+    expect(type.at(2)).toBe(null);
+    expect(type.at(-1)).toBe(null);
+    expect(type.at('aaa')).toBe(null);
+  });
 });

--- a/src/test/types/UnionType.test.ts
+++ b/src/test/types/UnionType.test.ts
@@ -1,4 +1,4 @@
-import { NumberType, StringType, UnionType } from '../../main';
+import { ArrayType, NumberType, StringType, UnionType } from '../../main';
 
 describe('UnionType', () => {
   test('returns the input as is', () => {
@@ -25,5 +25,21 @@ describe('UnionType', () => {
         meta: undefined,
       },
     ]);
+  });
+
+  test('returns child type at key', () => {
+    const childType1 = new NumberType();
+    const childType2 = new StringType();
+    const type = new UnionType([new ArrayType(childType1), new ArrayType(childType2)]);
+
+    expect(type.at(0)).toStrictEqual(new UnionType([childType1, childType2]));
+    expect(type.at('aaa')).toBe(null);
+  });
+
+  test('returns child type at key excluding nulls', () => {
+    const childType = new NumberType();
+    const type = new UnionType([new ArrayType(childType), new StringType()]);
+
+    expect(type.at(0)).toStrictEqual(childType);
   });
 });


### PR DESCRIPTION
- Added `Type.at(key)` method that returns a subtype of the field under `key`;
- Messages can now be of an arbitrary type;
- Updated docs on narrowing and transformations.