### PR TITLE
Deep partial protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1042,7 +1042,7 @@ shape1.deepPartial();
 // ⮕ Shape<Array<{ name?: string, age?: number } | undefined>>
 ```
 
-Even unions, intersections and lazy shapes can be converted to deep partial:
+Unions, intersections and lazy shapes can also be converted to deep partial:
 
 ```ts
 const shape2 = d.or([

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ npm install --save-prod doubter
 - [Replace](#replace)
 - [Optional and non-optional](#optional-and-non-optional)
 - [Nullable and nullish](#nullable-and-nullish)
+- [Deep partial](#deep-partial)
 - [Fallback value](#fallback-value)
 - [Branded types](#branded-types)
 - [Sub-shape at key](#sub-shape-at-key)
@@ -49,6 +50,7 @@ npm install --save-prod doubter
 - [Guarded functions](#guarded-functions)
 
 [**Type coercion**](#type-coercion)
+
 - [Coerce to string](#coerce-to-string)
 - [Coerce to number](#coerce-to-number)
 - [Coerce to boolean](#coerce-to-boolean)
@@ -1020,6 +1022,55 @@ d.string().nullish();
 ```ts
 d.string().nullish(8080);
 // ⮕ Shape<string | null | undefined, string | 8080>
+```
+
+# Deep partial
+
+All object-like shapes (objects, arrays, maps, sets, promises, etc.) can be converted to a deep partial alternative
+using `deepPartial` method:
+
+```ts
+const shape1 = d.array(
+  d.object({
+    name: d.string(),
+    age: d.number()
+  })
+);
+// ⮕ Shape<{ name: string, age: number }[]>
+
+shape1.deepPartial();
+// ⮕ Shape<Array<{ name?: string, age?: number } | undefined>>
+```
+
+Even unions, intersections and lazy shapes can be converted to deep partial:
+
+```ts
+const shape2 = d.or([
+  d.number(),
+  d.object({ name: d.string() })
+]).deepPartial()
+// ⮕ Shape<number | { name?: string }>
+
+shape2.parse(42);
+// ⮕ 42
+
+shape2.parse({ name: undefined });
+// ⮕ { name: undefined }
+
+shape2.parse({ name: 'Frodo' });
+// ⮕ { name: 'Frodo' }
+
+shape2.parse({ name: 8080 });
+// ❌ ValidationError: type at /name: Must be a string
+```
+
+Deep partial isn't applied to transformed shapes:
+
+```ts
+const shape2 = d.object({
+  years: d.array(d.string()).transform(parseFloat)
+}).deepPartial();
+// ⮕ Shape<{ years?: string[] }, { years?: number[] }>
 ```
 
 # Fallback value

--- a/src/main/dsl/const.ts
+++ b/src/main/dsl/const.ts
@@ -6,7 +6,7 @@ import { ConstShape } from '../shapes';
  *
  * @param value The value to which the input must be strictly equal.
  * @param options The constraint options or an issue message.
- * @template T The value type.
+ * @template T The expected value.
  */
 function const_<T extends Literal>(value: T, options?: ConstraintOptions | Message): ConstShape<T> {
   return new ConstShape(value, options);

--- a/src/main/dsl/enum.ts
+++ b/src/main/dsl/enum.ts
@@ -1,6 +1,6 @@
 import { ConstraintOptions, Literal, Message } from '../shared-types';
 import { EnumShape } from '../shapes';
-import { ReadonlyDict } from '../shapes/Shape';
+import { ReadonlyDict } from '../utils';
 
 /**
  * Creates the shape that constrains input with the list of values.

--- a/src/main/dsl/lazy.ts
+++ b/src/main/dsl/lazy.ts
@@ -3,7 +3,8 @@ import { AnyShape, LazyShape } from '../shapes';
 /**
  * Creates the shape that resolves the underlying shape on-demand.
  *
- * @param shapeProvider The provider that returns the base shape.
+ * @param shapeProvider The provider that returns the resolved shape.
+ * @template S The resolved shape.
  */
 export function lazy<S extends AnyShape>(shapeProvider: () => S): LazyShape<S> {
   return new LazyShape(shapeProvider);

--- a/src/main/dsl/object.ts
+++ b/src/main/dsl/object.ts
@@ -1,6 +1,6 @@
 import { ConstraintOptions, Message } from '../shared-types';
 import { AnyShape, ObjectShape } from '../shapes';
-import { ReadonlyDict } from '../shapes/Shape';
+import { ReadonlyDict } from '../utils';
 
 /**
  * Creates the object shape.

--- a/src/main/shapes/ArrayShape.ts
+++ b/src/main/shapes/ArrayShape.ts
@@ -1,12 +1,4 @@
-import {
-  AnyShape,
-  ApplyResult,
-  InferDeepPartialShape,
-  DeepPartialProtocol,
-  ReplaceShape,
-  toDeepPartial,
-  ValueType,
-} from './Shape';
+import { AnyShape, ApplyResult, DeepPartialProtocol, InferDeepPartialShape, ReplaceShape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import {
   addConstraint,
@@ -18,6 +10,7 @@ import {
   isIterable,
   ok,
   toArrayIndex,
+  toDeepPartial,
   unshiftPath,
 } from '../utils';
 import {

--- a/src/main/shapes/ArrayShape.ts
+++ b/src/main/shapes/ArrayShape.ts
@@ -83,7 +83,7 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
 
     this._options = options;
 
-    if (shapes !== null) {
+    if (shapes !== null && (shapes.length !== 0 || restShape === null)) {
       this._typeIssueFactory = createIssueFactory(CODE_TUPLE, MESSAGE_TUPLE, options, shapes.length);
     } else {
       this._typeIssueFactory = createIssueFactory(CODE_TYPE, MESSAGE_ARRAY_TYPE, options, TYPE_ARRAY);

--- a/src/main/shapes/ArrayShape.ts
+++ b/src/main/shapes/ArrayShape.ts
@@ -1,10 +1,10 @@
 import {
   AnyShape,
   ApplyResult,
-  InferPartialDeepShape,
-  PartialDeepProtocol,
+  InferDeepPartialShape,
+  DeepPartialProtocol,
   ReplaceShape,
-  toPartialDeep,
+  toDeepPartial,
   ValueType,
 } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
@@ -47,13 +47,13 @@ export type InferArray<U extends readonly AnyShape[] | null, R extends AnyShape 
 
 export type ToArray<T> = T extends readonly any[] ? T : never;
 
-export type PartialDeepArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape | null> = ArrayShape<
+export type DeepPartialArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape | null> = ArrayShape<
   U extends readonly AnyShape[]
     ? ToArray<{
-        [K in keyof U]: U[K] extends AnyShape ? ReplaceShape<InferPartialDeepShape<U[K]>, undefined, undefined> : never;
+        [K in keyof U]: U[K] extends AnyShape ? ReplaceShape<InferDeepPartialShape<U[K]>, undefined, undefined> : never;
       }>
     : null,
-  R extends AnyShape ? ReplaceShape<InferPartialDeepShape<R>, undefined, undefined> : null
+  R extends AnyShape ? ReplaceShape<InferDeepPartialShape<R>, undefined, undefined> : null
 >;
 
 /**
@@ -64,7 +64,7 @@ export type PartialDeepArrayShape<U extends readonly AnyShape[] | null, R extend
  */
 export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape | null>
   extends CoercibleShape<InferArray<U, R, 'input'>, InferArray<U, R, 'output'>>
-  implements PartialDeepProtocol<PartialDeepArrayShape<U, R>>
+  implements DeepPartialProtocol<DeepPartialArrayShape<U, R>>
 {
   protected _options;
   protected _typeIssueFactory;
@@ -172,14 +172,14 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
     });
   }
 
-  partialDeep(): PartialDeepArrayShape<U, R> {
+  deepPartial(): DeepPartialArrayShape<U, R> {
     let shapes: AnyShape[] | null = null;
 
     if (this.shapes !== null) {
       shapes = [];
 
       for (const shape of this.shapes) {
-        shapes.push(toPartialDeep(shape).optional());
+        shapes.push(toDeepPartial(shape).optional());
       }
     }
 

--- a/src/main/shapes/ArrayShape.ts
+++ b/src/main/shapes/ArrayShape.ts
@@ -1,4 +1,4 @@
-import { AnyShape, ApplyResult, DeepPartialProtocol, InferDeepPartialShape, ReplaceShape, ValueType } from './Shape';
+import { AnyShape, ApplyResult, DeepPartialProtocol, DeepPartialShape, ReplaceShape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import {
   addConstraint,
@@ -43,10 +43,10 @@ export type ToArray<T> = T extends readonly any[] ? T : never;
 export type DeepPartialArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape | null> = ArrayShape<
   U extends readonly AnyShape[]
     ? ToArray<{
-        [K in keyof U]: U[K] extends AnyShape ? ReplaceShape<InferDeepPartialShape<U[K]>, undefined, undefined> : never;
+        [K in keyof U]: U[K] extends AnyShape ? ReplaceShape<DeepPartialShape<U[K]>, undefined, undefined> : never;
       }>
     : null,
-  R extends AnyShape ? ReplaceShape<InferDeepPartialShape<R>, undefined, undefined> : null
+  R extends AnyShape ? ReplaceShape<DeepPartialShape<R>, undefined, undefined> : null
 >;
 
 /**
@@ -166,17 +166,11 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
   }
 
   deepPartial(): DeepPartialArrayShape<U, R> {
-    let shapes: AnyShape[] | null = null;
+    const shapes = this.shapes !== null ? this.shapes.map(shape => toDeepPartial(shape).optional()) : null;
 
-    if (this.shapes !== null) {
-      shapes = [];
+    const restShape = this.restShape !== null ? toDeepPartial(this.restShape).optional() : null;
 
-      for (const shape of this.shapes) {
-        shapes.push(toDeepPartial(shape).optional());
-      }
-    }
-
-    return new ArrayShape<any, any>(shapes, this.restShape === null ? null : this.restShape.optional(), this._options);
+    return new ArrayShape<any, any>(shapes, restShape, this._options);
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/ConstShape.ts
+++ b/src/main/shapes/ConstShape.ts
@@ -4,22 +4,28 @@ import { createIssueFactory, getValueType } from '../utils';
 import { CODE_CONST, MESSAGE_CONST } from '../constants';
 
 /**
- * The shape that constrains an input to be the exact value.
+ * The shape that constrains an input to exactly equal to the expected value.
  *
- * @template T The value.
+ * @template T The expected value.
  */
 export class ConstShape<T> extends Shape<T> {
-  protected _typeIssueFactory;
   protected _typePredicate: (input: unknown) => boolean;
+  protected _typeIssueFactory;
 
   /**
    * Creates a new {@linkcode ConstShape} instance.
    *
-   * @param value The exact value.
+   * @param value The expected value.
    * @param options The type constraint options or an issue message.
-   * @template T Allowed values.
+   * @template T The expected value.
    */
-  constructor(readonly value: T, options?: ConstraintOptions | Message) {
+  constructor(
+    /**
+     * The expected value.
+     */
+    readonly value: T,
+    options?: ConstraintOptions | Message
+  ) {
     super();
 
     this._typePredicate = value !== value ? Number.isNaN : input => value === input;

--- a/src/main/shapes/EnumShape.ts
+++ b/src/main/shapes/EnumShape.ts
@@ -18,7 +18,8 @@ export class EnumShape<T> extends CoercibleShape<T> {
   readonly values: readonly T[];
 
   /**
-   * Key-value mapping passes as a source to constructor, or `null` if the source was a list of values.
+   * The key-value mapping that was passed as a source arguments to the constructor, or `null` if the source was an
+   * array of values.
    */
   protected _valueMapping: ReadonlyDict<T> | null;
   protected _typeIssueFactory;
@@ -59,11 +60,16 @@ export class EnumShape<T> extends CoercibleShape<T> {
   protected _getInputTypes(): ValueType[] {
     const valueTypes = this.values.map(getValueType);
 
-    if (this._coerced) {
-      return valueTypes.concat(TYPE_STRING, TYPE_ARRAY);
-    } else {
+    if (!this._coerced) {
       return valueTypes;
     }
+
+    if (this._valueMapping !== null) {
+      valueTypes.push(TYPE_STRING);
+    }
+    valueTypes.push(TYPE_ARRAY);
+
+    return valueTypes;
   }
 
   protected _getInputValues(): unknown[] {

--- a/src/main/shapes/EnumShape.ts
+++ b/src/main/shapes/EnumShape.ts
@@ -1,6 +1,6 @@
-import { ApplyResult, ReadonlyDict, ValueType } from './Shape';
+import { ApplyResult, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
-import { createIssueFactory, getValueType, isArray, ok, unique } from '../utils';
+import { createIssueFactory, getValueType, isArray, ok, ReadonlyDict, unique } from '../utils';
 import { CODE_ENUM, MESSAGE_ENUM, TYPE_ARRAY, TYPE_STRING } from '../constants';
 import { CoercibleShape } from './CoercibleShape';
 

--- a/src/main/shapes/IntersectionShape.ts
+++ b/src/main/shapes/IntersectionShape.ts
@@ -1,13 +1,5 @@
-import {
-  AnyShape,
-  ApplyResult,
-  InferDeepPartialShape,
-  DeepPartialProtocol,
-  Shape,
-  toDeepPartial,
-  ValueType,
-} from './Shape';
-import { createIssueFactory, getValueType, isArray, isAsyncShapes, isEqual, ok } from '../utils';
+import { AnyShape, ApplyResult, DeepPartialProtocol, InferDeepPartialShape, Shape, ValueType } from './Shape';
+import { createIssueFactory, getValueType, isArray, isAsyncShapes, isEqual, ok, toDeepPartial } from '../utils';
 import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
 import { CODE_INTERSECTION, MESSAGE_INTERSECTION, TYPE_ARRAY, TYPE_DATE, TYPE_NEVER, TYPE_OBJECT } from '../constants';
 import { ToArray } from './ArrayShape';

--- a/src/main/shapes/IntersectionShape.ts
+++ b/src/main/shapes/IntersectionShape.ts
@@ -1,4 +1,4 @@
-import { AnyShape, ApplyResult, DeepPartialProtocol, InferDeepPartialShape, Shape, ValueType } from './Shape';
+import { AnyShape, ApplyResult, DeepPartialProtocol, DeepPartialShape, Shape, ValueType } from './Shape';
 import { createIssueFactory, getValueType, isArray, isAsyncShapes, isEqual, ok, toDeepPartial } from '../utils';
 import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
 import { CODE_INTERSECTION, MESSAGE_INTERSECTION, TYPE_ARRAY, TYPE_DATE, TYPE_NEVER, TYPE_OBJECT } from '../constants';
@@ -8,7 +8,7 @@ export type ToIntersection<U> = (U extends any ? (k: U) => void : never) extends
 
 export type DeepPartialIntersectionShape<U extends readonly AnyShape[]> = IntersectionShape<
   ToArray<{
-    [K in keyof U]: U[K] extends AnyShape ? InferDeepPartialShape<U[K]> : never;
+    [K in keyof U]: U[K] extends AnyShape ? DeepPartialShape<U[K]> : never;
   }>
 >;
 
@@ -34,8 +34,10 @@ export class IntersectionShape<U extends readonly AnyShape[]>
     return intersectValueTypes(this.shapes.map(shape => shape['_getInputTypes']()));
   }
 
-  deepPartial(): DeepPartialIntersectionShape<U> {
-    return new IntersectionShape(this.shapes.map(toDeepPartial), this._options) as any;
+  deepPartial(): DeepPartialIntersectionShape<U>;
+
+  deepPartial(): Shape {
+    return new IntersectionShape(this.shapes.map(toDeepPartial), this._options);
   }
 
   protected _apply(input: unknown, options: ParseOptions): ApplyResult<ToIntersection<U[number]['output']>> {

--- a/src/main/shapes/IntersectionShape.ts
+++ b/src/main/shapes/IntersectionShape.ts
@@ -32,10 +32,8 @@ export class IntersectionShape<U extends readonly AnyShape[]>
     this._typeIssueFactory = createIssueFactory(CODE_INTERSECTION, MESSAGE_INTERSECTION, options, undefined);
   }
 
-  deepPartial(): DeepPartialIntersectionShape<U>;
-
-  deepPartial(): Shape {
-    return new IntersectionShape(this.shapes.map(toDeepPartialShape), this._options);
+  deepPartial(): DeepPartialIntersectionShape<U> {
+    return new IntersectionShape<any>(this.shapes.map(toDeepPartialShape), this._options);
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/IntersectionShape.ts
+++ b/src/main/shapes/IntersectionShape.ts
@@ -1,10 +1,10 @@
 import {
   AnyShape,
   ApplyResult,
-  InferPartialDeepShape,
-  PartialDeepProtocol,
+  InferDeepPartialShape,
+  DeepPartialProtocol,
   Shape,
-  toPartialDeep,
+  toDeepPartial,
   ValueType,
 } from './Shape';
 import { createIssueFactory, getValueType, isArray, isAsyncShapes, isEqual, ok } from '../utils';
@@ -14,15 +14,15 @@ import { ToArray } from './ArrayShape';
 
 export type ToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
 
-export type PartialDeepIntersectionShape<U extends readonly AnyShape[]> = IntersectionShape<
+export type DeepPartialIntersectionShape<U extends readonly AnyShape[]> = IntersectionShape<
   ToArray<{
-    [K in keyof U]: U[K] extends AnyShape ? InferPartialDeepShape<U[K]> : never;
+    [K in keyof U]: U[K] extends AnyShape ? InferDeepPartialShape<U[K]> : never;
   }>
 >;
 
 export class IntersectionShape<U extends readonly AnyShape[]>
   extends Shape<ToIntersection<U[number]['input']>, ToIntersection<U[number]['output']>>
-  implements PartialDeepProtocol<PartialDeepIntersectionShape<U>>
+  implements DeepPartialProtocol<DeepPartialIntersectionShape<U>>
 {
   protected _options;
   protected _typeIssueFactory;
@@ -42,8 +42,8 @@ export class IntersectionShape<U extends readonly AnyShape[]>
     return intersectValueTypes(this.shapes.map(shape => shape['_getInputTypes']()));
   }
 
-  partialDeep(): PartialDeepIntersectionShape<U> {
-    return new IntersectionShape(this.shapes.map(toPartialDeep), this._options) as any;
+  deepPartial(): DeepPartialIntersectionShape<U> {
+    return new IntersectionShape(this.shapes.map(toDeepPartial), this._options) as any;
   }
 
   protected _apply(input: unknown, options: ParseOptions): ApplyResult<ToIntersection<U[number]['output']>> {

--- a/src/main/shapes/LazyShape.ts
+++ b/src/main/shapes/LazyShape.ts
@@ -1,10 +1,10 @@
 import {
   AnyShape,
   ApplyResult,
-  InferPartialDeepShape,
-  PartialDeepProtocol,
+  InferDeepPartialShape,
+  DeepPartialProtocol,
   Shape,
-  toPartialDeep,
+  toDeepPartial,
   ValueType,
 } from './Shape';
 import { ParseOptions } from '../shared-types';
@@ -18,7 +18,7 @@ import { ERROR_SHAPE_EXPECTED } from '../constants';
  */
 export class LazyShape<S extends AnyShape>
   extends Shape<S['input'], S['output']>
-  implements PartialDeepProtocol<InferPartialDeepShape<S>>
+  implements DeepPartialProtocol<InferDeepPartialShape<S>>
 {
   protected _shapeProvider;
 
@@ -49,8 +49,8 @@ export class LazyShape<S extends AnyShape>
     return shape;
   }
 
-  partialDeep(): InferPartialDeepShape<S> {
-    return toPartialDeep(this.shape);
+  deepPartial(): InferDeepPartialShape<S> {
+    return toDeepPartial(this.shape);
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/LazyShape.ts
+++ b/src/main/shapes/LazyShape.ts
@@ -1,14 +1,6 @@
-import {
-  AnyShape,
-  ApplyResult,
-  InferDeepPartialShape,
-  DeepPartialProtocol,
-  Shape,
-  toDeepPartial,
-  ValueType,
-} from './Shape';
+import { AnyShape, ApplyResult, DeepPartialProtocol, InferDeepPartialShape, Shape, ValueType } from './Shape';
 import { ParseOptions } from '../shared-types';
-import { isArray, returnArray, returnFalse } from '../utils';
+import { isArray, returnArray, returnFalse, toDeepPartial } from '../utils';
 import { ERROR_SHAPE_EXPECTED } from '../constants';
 
 /**

--- a/src/main/shapes/LazyShape.ts
+++ b/src/main/shapes/LazyShape.ts
@@ -10,7 +10,7 @@ import { ERROR_SHAPE_EXPECTED } from '../constants';
  */
 export class LazyShape<S extends AnyShape>
   extends Shape<S['input'], S['output']>
-  implements DeepPartialProtocol<DeepPartialShape<S>>
+  implements DeepPartialProtocol<LazyShape<DeepPartialShape<S>>>
 {
   protected _shapeProvider;
 
@@ -41,8 +41,10 @@ export class LazyShape<S extends AnyShape>
     return shape;
   }
 
-  deepPartial(): DeepPartialShape<S> {
-    return toDeepPartialShape(this.shape);
+  deepPartial(): LazyShape<DeepPartialShape<S>> {
+    const { _shapeProvider } = this;
+
+    return new LazyShape(() => toDeepPartialShape(_shapeProvider()));
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/LazyShape.ts
+++ b/src/main/shapes/LazyShape.ts
@@ -1,4 +1,12 @@
-import { AnyShape, ApplyResult, Shape, ValueType } from './Shape';
+import {
+  AnyShape,
+  ApplyResult,
+  InferPartialDeepShape,
+  PartialDeepProtocol,
+  Shape,
+  toPartialDeep,
+  ValueType,
+} from './Shape';
 import { ParseOptions } from '../shared-types';
 import { isArray, returnArray, returnFalse } from '../utils';
 import { ERROR_SHAPE_EXPECTED } from '../constants';
@@ -8,7 +16,10 @@ import { ERROR_SHAPE_EXPECTED } from '../constants';
  *
  * @template S The base shape.
  */
-export class LazyShape<S extends AnyShape> extends Shape<S['input'], S['output']> {
+export class LazyShape<S extends AnyShape>
+  extends Shape<S['input'], S['output']>
+  implements PartialDeepProtocol<InferPartialDeepShape<S>>
+{
   protected _shapeProvider;
 
   /**
@@ -36,6 +47,10 @@ export class LazyShape<S extends AnyShape> extends Shape<S['input'], S['output']
     Object.defineProperty(this, 'shape', { value: shape });
 
     return shape;
+  }
+
+  partialDeep(): InferPartialDeepShape<S> {
+    return toPartialDeep(this.shape);
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/LazyShape.ts
+++ b/src/main/shapes/LazyShape.ts
@@ -6,7 +6,7 @@ import { ERROR_SHAPE_EXPECTED } from '../constants';
 /**
  * Lazily resolves a shape using the provider.
  *
- * @template S The base shape.
+ * @template S The resolved shape.
  */
 export class LazyShape<S extends AnyShape>
   extends Shape<S['input'], S['output']>
@@ -17,8 +17,8 @@ export class LazyShape<S extends AnyShape>
   /**
    * Creates a new {@linkcode LazyShape} instance.
    *
-   * @param shapeProvider The provider that returns the base shape.
-   * @template S The base shape.
+   * @param shapeProvider The provider that returns the resolved shape.
+   * @template S The resolved shape.
    */
   constructor(shapeProvider: () => S) {
     super();
@@ -27,7 +27,7 @@ export class LazyShape<S extends AnyShape>
   }
 
   /**
-   * The base shape.
+   * The resolved shape.
    */
   get shape(): S {
     const shape = this._shapeProvider();

--- a/src/main/shapes/LazyShape.ts
+++ b/src/main/shapes/LazyShape.ts
@@ -1,6 +1,6 @@
 import { AnyShape, ApplyResult, DeepPartialProtocol, DeepPartialShape, Shape, ValueType } from './Shape';
 import { ParseOptions } from '../shared-types';
-import { isArray, returnArray, returnFalse, toDeepPartial } from '../utils';
+import { isArray, returnArray, returnFalse, toDeepPartialShape } from '../utils';
 import { ERROR_SHAPE_EXPECTED } from '../constants';
 
 /**
@@ -42,7 +42,7 @@ export class LazyShape<S extends AnyShape>
   }
 
   deepPartial(): DeepPartialShape<S> {
-    return toDeepPartial(this.shape);
+    return toDeepPartialShape(this.shape);
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/LazyShape.ts
+++ b/src/main/shapes/LazyShape.ts
@@ -1,4 +1,4 @@
-import { AnyShape, ApplyResult, DeepPartialProtocol, InferDeepPartialShape, Shape, ValueType } from './Shape';
+import { AnyShape, ApplyResult, DeepPartialProtocol, DeepPartialShape, Shape, ValueType } from './Shape';
 import { ParseOptions } from '../shared-types';
 import { isArray, returnArray, returnFalse, toDeepPartial } from '../utils';
 import { ERROR_SHAPE_EXPECTED } from '../constants';
@@ -10,7 +10,7 @@ import { ERROR_SHAPE_EXPECTED } from '../constants';
  */
 export class LazyShape<S extends AnyShape>
   extends Shape<S['input'], S['output']>
-  implements DeepPartialProtocol<InferDeepPartialShape<S>>
+  implements DeepPartialProtocol<DeepPartialShape<S>>
 {
   protected _shapeProvider;
 
@@ -41,7 +41,7 @@ export class LazyShape<S extends AnyShape>
     return shape;
   }
 
-  deepPartial(): InferDeepPartialShape<S> {
+  deepPartial(): DeepPartialShape<S> {
     return toDeepPartial(this.shape);
   }
 

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -18,7 +18,19 @@ import {
   setKeyValue,
   unshiftPath,
 } from '../utils';
-import { AnyShape, ApplyResult, OpaqueExcludeShape, OpaqueReplaceShape, ReadonlyDict, Shape, ValueType } from './Shape';
+import {
+  AnyShape,
+  ApplyResult,
+  Dict,
+  ExcludeShape,
+  InferPartialDeepShape,
+  PartialDeepProtocol,
+  ReadonlyDict,
+  ReplaceShape,
+  Shape,
+  toPartialDeep,
+  ValueType,
+} from './Shape';
 import { EnumShape } from './EnumShape';
 
 // prettier-ignore
@@ -39,11 +51,16 @@ export type OmitBy<T, V> = Omit<T, { [K in keyof T]: V extends Extract<T[K], V> 
 
 export type PickBy<T, V> = Pick<T, { [K in keyof T]: V extends Extract<T[K], V> ? K : never }[keyof T]>;
 
-export type Optional<P extends ReadonlyDict<AnyShape>> = { [K in keyof P]: OpaqueReplaceShape<P[K], undefined> };
+export type Optional<P extends ReadonlyDict<AnyShape>> = { [K in keyof P]: ReplaceShape<P[K], undefined, undefined> };
 
-export type Required<P extends ReadonlyDict<AnyShape>> = { [K in keyof P]: OpaqueExcludeShape<P[K], undefined> };
+export type Required<P extends ReadonlyDict<AnyShape>> = { [K in keyof P]: ExcludeShape<P[K], undefined> };
 
 export type KeysMode = 'preserved' | 'stripped' | 'exact';
+
+export type PartialDeepObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | null> = ObjectShape<
+  { [K in keyof P]: ReplaceShape<InferPartialDeepShape<P[K]>, undefined, undefined> },
+  R extends AnyShape ? ReplaceShape<InferPartialDeepShape<R>, undefined, undefined> : null
+>;
 
 /**
  * The shape of an object.
@@ -52,10 +69,10 @@ export type KeysMode = 'preserved' | 'stripped' | 'exact';
  * @template R The shape that constrains values of
  * [a string index signature](https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures).
  */
-export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | null> extends Shape<
-  InferObject<P, R, 'input'>,
-  InferObject<P, R, 'output'>
-> {
+export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | null>
+  extends Shape<InferObject<P, R, 'input'>, InferObject<P, R, 'output'>>
+  implements PartialDeepProtocol<PartialDeepObjectShape<P, R>>
+{
   /**
    * The array of known object keys.
    */
@@ -158,14 +175,14 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
    * @template K The tuple of keys to pick.
    */
   pick<K extends StringKeyof<P>[]>(keys: K): ObjectShape<Pick<P, K[number]>, R> {
-    const shapes: Record<string, AnyShape> = {};
+    const shapes: Dict<AnyShape> = {};
 
     for (const key in this.shapes) {
       if (keys.includes(key)) {
         shapes[key] = this.shapes[key];
       }
     }
-    return new ObjectShape<any, R>(shapes, this.restShape, this._options, this.keysMode);
+    return new ObjectShape<any, any>(shapes, this.restShape, this._options, this.keysMode);
   }
 
   /**
@@ -178,14 +195,14 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
    * @template K The tuple of keys to omit.
    */
   omit<K extends StringKeyof<P>[]>(keys: K): ObjectShape<Omit<P, K[number]>, R> {
-    const shapes: Record<string, AnyShape> = {};
+    const shapes: Dict<AnyShape> = {};
 
     for (const key in this.shapes) {
       if (!keys.includes(key)) {
         shapes[key] = this.shapes[key];
       }
     }
-    return new ObjectShape<any, R>(shapes, this.restShape, this._options, this.keysMode);
+    return new ObjectShape<any, any>(shapes, this.restShape, this._options, this.keysMode);
   }
 
   /**
@@ -209,17 +226,25 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
   partial<K extends StringKeyof<P>[]>(keys: K): ObjectShape<Omit<P, K[number]> & Optional<Pick<P, K[number]>>, R>;
 
   partial(keys?: string[]) {
-    const shapes: Record<string, AnyShape> = {};
+    const shapes: Dict<AnyShape> = {};
 
     for (const key in this.shapes) {
-      let shape: AnyShape = this.shapes[key];
-
-      if (keys === undefined || keys.includes(key)) {
-        shape = shape.optional();
-      }
-      shapes[key] = shape;
+      shapes[key] = keys === undefined || keys.includes(key) ? this.shapes[key].optional() : this.shapes[key];
     }
-    return new ObjectShape<any, R>(shapes, this.restShape, this._options, this.keysMode);
+    return new ObjectShape<any, any>(shapes, this.restShape, this._options, this.keysMode);
+  }
+
+  /**
+   * Returns an object shape where its keys and keys of all nested shapes are marked as optional.
+   */
+  partialDeep(): PartialDeepObjectShape<P, R> {
+    const shapes: Dict<AnyShape> = {};
+    const restShape = this.restShape === null ? null : this.restShape.optional();
+
+    for (const key in this.shapes) {
+      shapes[key] = toPartialDeep(this.shapes[key]).optional();
+    }
+    return new ObjectShape<any, any>(shapes, restShape, this._options, this.keysMode);
   }
 
   /**
@@ -243,17 +268,12 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
   required<K extends StringKeyof<P>[]>(keys: K): ObjectShape<Omit<P, K[number]> & Required<Pick<P, K[number]>>, R>;
 
   required(keys?: string[]) {
-    const shapes: Record<string, AnyShape> = {};
+    const shapes: Dict<AnyShape> = {};
 
     for (const key in this.shapes) {
-      let shape: AnyShape = this.shapes[key];
-
-      if (keys === undefined || keys.includes(key)) {
-        shape = shape.nonOptional();
-      }
-      shapes[key] = shape;
+      shapes[key] = keys === undefined || keys.includes(key) ? this.shapes[key].nonOptional() : this.shapes[key];
     }
-    return new ObjectShape<any, R>(shapes, this.restShape, this._options, this.keysMode);
+    return new ObjectShape<any, any>(shapes, this.restShape, this._options, this.keysMode);
   }
 
   /**

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -23,9 +23,9 @@ import {
   AnyShape,
   ApplyResult,
   DeepPartialProtocol,
+  DeepPartialShape,
   Dict,
   ExcludeShape,
-  InferDeepPartialShape,
   ReadonlyDict,
   ReplaceShape,
   Shape,
@@ -58,8 +58,8 @@ export type Required<P extends ReadonlyDict<AnyShape>> = { [K in keyof P]: Exclu
 export type KeysMode = 'preserved' | 'stripped' | 'exact';
 
 export type DeepPartialObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | null> = ObjectShape<
-  { [K in keyof P]: ReplaceShape<InferDeepPartialShape<P[K]>, undefined, undefined> },
-  R extends AnyShape ? ReplaceShape<InferDeepPartialShape<R>, undefined, undefined> : null
+  { [K in keyof P]: ReplaceShape<DeepPartialShape<P[K]>, undefined, undefined> },
+  R extends AnyShape ? ReplaceShape<DeepPartialShape<R>, undefined, undefined> : null
 >;
 
 /**

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -23,12 +23,12 @@ import {
   ApplyResult,
   Dict,
   ExcludeShape,
-  InferPartialDeepShape,
-  PartialDeepProtocol,
+  InferDeepPartialShape,
+  DeepPartialProtocol,
   ReadonlyDict,
   ReplaceShape,
   Shape,
-  toPartialDeep,
+  toDeepPartial,
   ValueType,
 } from './Shape';
 import { EnumShape } from './EnumShape';
@@ -57,9 +57,9 @@ export type Required<P extends ReadonlyDict<AnyShape>> = { [K in keyof P]: Exclu
 
 export type KeysMode = 'preserved' | 'stripped' | 'exact';
 
-export type PartialDeepObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | null> = ObjectShape<
-  { [K in keyof P]: ReplaceShape<InferPartialDeepShape<P[K]>, undefined, undefined> },
-  R extends AnyShape ? ReplaceShape<InferPartialDeepShape<R>, undefined, undefined> : null
+export type DeepPartialObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | null> = ObjectShape<
+  { [K in keyof P]: ReplaceShape<InferDeepPartialShape<P[K]>, undefined, undefined> },
+  R extends AnyShape ? ReplaceShape<InferDeepPartialShape<R>, undefined, undefined> : null
 >;
 
 /**
@@ -71,7 +71,7 @@ export type PartialDeepObjectShape<P extends ReadonlyDict<AnyShape>, R extends A
  */
 export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | null>
   extends Shape<InferObject<P, R, 'input'>, InferObject<P, R, 'output'>>
-  implements PartialDeepProtocol<PartialDeepObjectShape<P, R>>
+  implements DeepPartialProtocol<DeepPartialObjectShape<P, R>>
 {
   /**
    * The array of known object keys.
@@ -237,12 +237,12 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
   /**
    * Returns an object shape where its keys and keys of all nested shapes are marked as optional.
    */
-  partialDeep(): PartialDeepObjectShape<P, R> {
+  deepPartial(): DeepPartialObjectShape<P, R> {
     const shapes: Dict<AnyShape> = {};
     const restShape = this.restShape === null ? null : this.restShape.optional();
 
     for (const key in this.shapes) {
-      shapes[key] = toPartialDeep(this.shapes[key]).optional();
+      shapes[key] = toDeepPartial(this.shapes[key]).optional();
     }
     return new ObjectShape<any, any>(shapes, restShape, this._options, this.keysMode);
   }

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -7,6 +7,7 @@ import {
   cloneObjectKnownKeys,
   concatIssues,
   createIssueFactory,
+  Dict,
   enableBitAt,
   isArray,
   isAsyncShapes,
@@ -15,18 +16,17 @@ import {
   isObjectLike,
   isPlainObject,
   ok,
+  ReadonlyDict,
   setKeyValue,
-  toDeepPartial,
+  toDeepPartialShape,
   unshiftPath,
 } from '../utils';
 import {
   AnyShape,
   ApplyResult,
   DeepPartialProtocol,
-  DeepPartialShape,
-  Dict,
   ExcludeShape,
-  ReadonlyDict,
+  OptionalDeepPartialShape,
   ReplaceShape,
   Shape,
   ValueType,
@@ -58,8 +58,8 @@ export type Required<P extends ReadonlyDict<AnyShape>> = { [K in keyof P]: Exclu
 export type KeysMode = 'preserved' | 'stripped' | 'exact';
 
 export type DeepPartialObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | null> = ObjectShape<
-  { [K in keyof P]: ReplaceShape<DeepPartialShape<P[K]>, undefined, undefined> },
-  R extends AnyShape ? ReplaceShape<DeepPartialShape<R>, undefined, undefined> : null
+  { [K in keyof P]: OptionalDeepPartialShape<P[K]> },
+  R extends AnyShape ? OptionalDeepPartialShape<R> : null
 >;
 
 /**
@@ -234,16 +234,15 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
     return new ObjectShape<any, any>(shapes, this.restShape, this._options, this.keysMode);
   }
 
-  /**
-   * Returns an object shape where its keys and keys of all nested shapes are marked as optional.
-   */
   deepPartial(): DeepPartialObjectShape<P, R> {
     const shapes: Dict<AnyShape> = {};
-    const restShape = this.restShape === null ? null : this.restShape.optional();
 
     for (const key in this.shapes) {
-      shapes[key] = toDeepPartial(this.shapes[key]).optional();
+      shapes[key] = toDeepPartialShape(this.shapes[key]).optional();
     }
+
+    const restShape = this.restShape !== null ? toDeepPartialShape(this.restShape).optional() : null;
+
     return new ObjectShape<any, any>(shapes, restShape, this._options, this.keysMode);
   }
 

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -16,19 +16,19 @@ import {
   isPlainObject,
   ok,
   setKeyValue,
+  toDeepPartial,
   unshiftPath,
 } from '../utils';
 import {
   AnyShape,
   ApplyResult,
+  DeepPartialProtocol,
   Dict,
   ExcludeShape,
   InferDeepPartialShape,
-  DeepPartialProtocol,
   ReadonlyDict,
   ReplaceShape,
   Shape,
-  toDeepPartial,
   ValueType,
 } from './Shape';
 import { EnumShape } from './EnumShape';

--- a/src/main/shapes/PromiseShape.ts
+++ b/src/main/shapes/PromiseShape.ts
@@ -1,6 +1,6 @@
-import { AnyShape, ApplyResult, ValueType } from './Shape';
+import { AnyShape, ApplyResult, DeepPartialProtocol, OptionalDeepPartialShape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
-import { createIssueFactory, isArray, isEqual, ok } from '../utils';
+import { createIssueFactory, isArray, isEqual, ok, toDeepPartialShape } from '../utils';
 import { CODE_TYPE, ERROR_REQUIRES_ASYNC, MESSAGE_PROMISE_TYPE, TYPE_OBJECT, TYPE_PROMISE } from '../constants';
 import { CoercibleShape } from './CoercibleShape';
 
@@ -9,7 +9,11 @@ import { CoercibleShape } from './CoercibleShape';
  *
  * @template S The shape of the resolved value.
  */
-export class PromiseShape<S extends AnyShape> extends CoercibleShape<Promise<S['input']>, Promise<S['output']>> {
+export class PromiseShape<S extends AnyShape>
+  extends CoercibleShape<Promise<S['input']>, Promise<S['output']>>
+  implements DeepPartialProtocol<PromiseShape<OptionalDeepPartialShape<S>>>
+{
+  protected _options;
   protected _typeIssueFactory;
 
   /**
@@ -22,7 +26,12 @@ export class PromiseShape<S extends AnyShape> extends CoercibleShape<Promise<S['
   constructor(readonly shape: S, options?: ConstraintOptions | Message) {
     super();
 
+    this._options = options;
     this._typeIssueFactory = createIssueFactory(CODE_TYPE, MESSAGE_PROMISE_TYPE, options, TYPE_PROMISE);
+  }
+
+  deepPartial(): PromiseShape<OptionalDeepPartialShape<S>> {
+    return new PromiseShape<any>(toDeepPartialShape(this.shape).optional(), this._options);
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/SetShape.ts
+++ b/src/main/shapes/SetShape.ts
@@ -1,4 +1,4 @@
-import { AnyShape, ApplyResult, ValueType } from './Shape';
+import { AnyShape, ApplyResult, DeepPartialProtocol, OptionalDeepPartialShape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import {
   addConstraint,
@@ -9,6 +9,7 @@ import {
   isIterable,
   ok,
   toArrayIndex,
+  toDeepPartialShape,
   unshiftPath,
 } from '../utils';
 import {
@@ -29,7 +30,10 @@ import { CoercibleShape } from './CoercibleShape';
  *
  * @template S The value shape.
  */
-export class SetShape<S extends AnyShape> extends CoercibleShape<Set<S['input']>, Set<S['output']>> {
+export class SetShape<S extends AnyShape>
+  extends CoercibleShape<Set<S['input']>, Set<S['output']>>
+  implements DeepPartialProtocol<SetShape<OptionalDeepPartialShape<S>>>
+{
   protected _options;
   protected _typeIssueFactory;
 
@@ -100,6 +104,10 @@ export class SetShape<S extends AnyShape> extends CoercibleShape<Set<S['input']>
         return issueFactory(input, options);
       }
     });
+  }
+
+  deepPartial(): SetShape<OptionalDeepPartialShape<S>> {
+    return new SetShape<any>(toDeepPartialShape(this.shape).optional(), this._options);
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/Shape.ts
+++ b/src/main/shapes/Shape.ts
@@ -467,7 +467,9 @@ export class Shape<I = any, O = I> {
   }
 
   /**
-   * Returns the list of runtime value types that can be processed by the shape. Used for various optimizations.
+   * Returns the list of runtime value types that can be processed by the shape.
+   *
+   * Used for various optimizations. Elements of the returned array don't have to be unique.
    */
   protected _getInputTypes(): ValueType[] {
     return [TYPE_ANY];

--- a/src/main/shapes/Shape.ts
+++ b/src/main/shapes/Shape.ts
@@ -79,7 +79,7 @@ export type DeepPartialShape<S extends AnyShape> = S extends DeepPartialProtocol
 /**
  * Shape that is both optional and deep partial.
  */
-export type OptionalDeepPartialShape<S extends AnyShape> = ReplaceShape<DeepPartialShape<S>, undefined, undefined>;
+export type OptionalDeepPartialShape<S extends AnyShape> = IncludeShape<DeepPartialShape<S>, undefined>;
 
 /**
  * The detected runtime input value type.

--- a/src/main/shapes/Shape.ts
+++ b/src/main/shapes/Shape.ts
@@ -22,6 +22,7 @@ import {
   isUnsafeCheck,
   ok,
   returnTrue,
+  toDeepPartial,
 } from '../utils';
 import { ValidationError } from '../ValidationError';
 import {
@@ -46,15 +47,15 @@ export declare const BRAND: unique symbol;
  */
 export type AnyShape = Shape | Shape<never>;
 
+export interface IncludeShape<S extends AnyShape, T>
+  extends Shape<S['input'] | T, S['output'] | T>,
+    DeepPartialProtocol<IncludeShape<InferDeepPartialShape<S>, T>> {}
+
 export interface DeepPartialProtocol<S extends AnyShape> {
   deepPartial(): S;
 }
 
-export type InferDeepPartialShape<S extends AnyShape> = S extends DeepPartialProtocol<infer S1> ? S1 : S;
-
-export function toDeepPartial<S extends AnyShape>(shape: S): InferDeepPartialShape<S> {
-  return 'deepPartial' in shape && typeof shape.deepPartial === 'function' ? shape.deepPartial() : shape;
-}
+export type InferDeepPartialShape<S extends AnyShape> = S extends DeepPartialProtocol<infer T> ? T : S;
 
 /**
  * The detected runtime input value type.
@@ -312,10 +313,7 @@ export class Shape<I = any, O = I> {
    * @returns The {@linkcode ReplaceShape} instance.
    * @template T The included value.
    */
-  include<T extends Literal>(
-    value: T,
-    options?: ConstraintOptions | Message
-  ): Shape<this['input'] | T, this['output'] | T> {
+  include<T extends Literal>(value: T, options?: ConstraintOptions | Message): IncludeShape<this, T> {
     return this.replace(value, value);
   }
 

--- a/src/main/shapes/Shape.ts
+++ b/src/main/shapes/Shape.ts
@@ -46,14 +46,14 @@ export declare const BRAND: unique symbol;
  */
 export type AnyShape = Shape | Shape<never>;
 
-export interface PartialDeepProtocol<S extends AnyShape> {
-  partialDeep(): S;
+export interface DeepPartialProtocol<S extends AnyShape> {
+  deepPartial(): S;
 }
 
-export type InferPartialDeepShape<S extends AnyShape> = S extends PartialDeepProtocol<infer S1> ? S1 : S;
+export type InferDeepPartialShape<S extends AnyShape> = S extends DeepPartialProtocol<infer S1> ? S1 : S;
 
-export function toPartialDeep<S extends AnyShape>(shape: S): InferPartialDeepShape<S> {
-  return 'partialDeep' in shape && typeof shape.partialDeep === 'function' ? shape.partialDeep() : shape;
+export function toDeepPartial<S extends AnyShape>(shape: S): InferDeepPartialShape<S> {
+  return 'deepPartial' in shape && typeof shape.deepPartial === 'function' ? shape.deepPartial() : shape;
 }
 
 /**
@@ -863,7 +863,7 @@ export class TransformShape<S extends AnyShape, O> extends Shape<S['input'], O> 
  */
 export class PipeShape<I extends AnyShape, O extends Shape<I['output'], any>>
   extends Shape<I['input'], O['output']>
-  implements PartialDeepProtocol<PipeShape<InferPartialDeepShape<I>, InferPartialDeepShape<O>>>
+  implements DeepPartialProtocol<PipeShape<InferDeepPartialShape<I>, InferDeepPartialShape<O>>>
 {
   /**
    * Creates the new {@linkcode PipeShape} instance.
@@ -886,8 +886,8 @@ export class PipeShape<I extends AnyShape, O extends Shape<I['output'], any>>
     super();
   }
 
-  partialDeep(): PipeShape<InferPartialDeepShape<I>, InferPartialDeepShape<O>> {
-    return new PipeShape(toPartialDeep(this.inputShape), toPartialDeep(this.outputShape));
+  deepPartial(): PipeShape<InferDeepPartialShape<I>, InferDeepPartialShape<O>> {
+    return new PipeShape(toDeepPartial(this.inputShape), toDeepPartial(this.outputShape));
   }
 
   protected _requiresAsync(): boolean {
@@ -979,7 +979,7 @@ export class PipeShape<I extends AnyShape, O extends Shape<I['output'], any>>
  */
 export class ReplaceShape<S extends AnyShape, A, B>
   extends Shape<S['input'] | A, Exclude<S['output'], A> | B>
-  implements PartialDeepProtocol<ReplaceShape<InferPartialDeepShape<S>, A, B>>
+  implements DeepPartialProtocol<ReplaceShape<InferDeepPartialShape<S>, A, B>>
 {
   private _result: ApplyResult<B>;
 
@@ -1012,8 +1012,8 @@ export class ReplaceShape<S extends AnyShape, A, B>
     this._result = isEqual(inputValue, outputValue) ? null : ok(outputValue);
   }
 
-  partialDeep(): ReplaceShape<InferPartialDeepShape<S>, A, B> {
-    return new ReplaceShape(toPartialDeep(this.shape), this.inputValue, this.outputValue);
+  deepPartial(): ReplaceShape<InferDeepPartialShape<S>, A, B> {
+    return new ReplaceShape(toDeepPartial(this.shape), this.inputValue, this.outputValue);
   }
 
   protected _requiresAsync(): boolean {
@@ -1091,7 +1091,7 @@ export class ReplaceShape<S extends AnyShape, A, B>
  */
 export class ExcludeShape<S extends AnyShape, T>
   extends Shape<Exclude<S['input'], T>, Exclude<S['output'], T>>
-  implements PartialDeepProtocol<ExcludeShape<InferPartialDeepShape<S>, T>>
+  implements DeepPartialProtocol<ExcludeShape<InferDeepPartialShape<S>, T>>
 {
   protected _typeIssueFactory;
   protected _options;
@@ -1122,8 +1122,8 @@ export class ExcludeShape<S extends AnyShape, T>
     this._options = options;
   }
 
-  partialDeep(): ExcludeShape<InferPartialDeepShape<S>, T> {
-    return new ExcludeShape(toPartialDeep(this.shape), this.excludedValue, this._options);
+  deepPartial(): ExcludeShape<InferDeepPartialShape<S>, T> {
+    return new ExcludeShape(toDeepPartial(this.shape), this.excludedValue, this._options);
   }
 
   protected _requiresAsync(): boolean {
@@ -1204,7 +1204,7 @@ export class ExcludeShape<S extends AnyShape, T>
  */
 export class CatchShape<S extends AnyShape, T>
   extends Shape<S['input'], S['output'] | T>
-  implements PartialDeepProtocol<CatchShape<InferPartialDeepShape<S>, T>>
+  implements DeepPartialProtocol<CatchShape<InferDeepPartialShape<S>, T>>
 {
   private _resultProvider: () => Ok<T>;
 
@@ -1235,8 +1235,8 @@ export class CatchShape<S extends AnyShape, T>
     }
   }
 
-  partialDeep(): CatchShape<InferPartialDeepShape<S>, T> {
-    return new CatchShape(toPartialDeep(this.shape), this.fallback);
+  deepPartial(): CatchShape<InferDeepPartialShape<S>, T> {
+    return new CatchShape(toDeepPartial(this.shape), this.fallback);
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/UnionShape.ts
+++ b/src/main/shapes/UnionShape.ts
@@ -1,5 +1,5 @@
 import { AnyShape, ApplyResult, DeepPartialProtocol, DeepPartialShape, Shape, ValueType } from './Shape';
-import { Issue, Message, ParseOptions, ConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
 import {
   concatIssues,
   createIssueFactory,

--- a/src/main/shapes/UnionShape.ts
+++ b/src/main/shapes/UnionShape.ts
@@ -1,5 +1,5 @@
-import { AnyShape, ApplyResult, DeepPartialProtocol, InferDeepPartialShape, Shape, ValueType } from './Shape';
-import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
+import { AnyShape, ApplyResult, DeepPartialProtocol, DeepPartialShape, Shape, ValueType } from './Shape';
+import { Issue, Message, ParseOptions, ConstraintOptions } from '../shared-types';
 import {
   concatIssues,
   createIssueFactory,
@@ -21,7 +21,7 @@ export type LookupCallback = (input: any) => readonly AnyShape[];
 
 export type DeepPartialUnionShape<U extends readonly AnyShape[]> = UnionShape<
   ToArray<{
-    [K in keyof U]: U[K] extends AnyShape ? InferDeepPartialShape<U[K]> : never;
+    [K in keyof U]: U[K] extends AnyShape ? DeepPartialShape<U[K]> : never;
   }>
 >;
 
@@ -65,8 +65,10 @@ export class UnionShape<U extends readonly AnyShape[]>
     return cb;
   }
 
-  deepPartial(): DeepPartialUnionShape<U> {
-    return new UnionShape(this.shapes.map(toDeepPartial), this._options) as any;
+  deepPartial(): DeepPartialUnionShape<U>;
+
+  deepPartial(): AnyShape {
+    return new UnionShape(this.shapes.map(toDeepPartial), this._options);
   }
 
   at(key: unknown): AnyShape | null {

--- a/src/main/shapes/UnionShape.ts
+++ b/src/main/shapes/UnionShape.ts
@@ -1,10 +1,10 @@
 import {
   AnyShape,
   ApplyResult,
-  InferPartialDeepShape,
-  PartialDeepProtocol,
+  InferDeepPartialShape,
+  DeepPartialProtocol,
   Shape,
-  toPartialDeep,
+  toDeepPartial,
   ValueType,
 } from './Shape';
 import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
@@ -18,9 +18,9 @@ import { ToArray } from './ArrayShape';
  */
 export type LookupCallback = (input: any) => readonly AnyShape[];
 
-export type PartialDeepUnionShape<U extends readonly AnyShape[]> = UnionShape<
+export type DeepPartialUnionShape<U extends readonly AnyShape[]> = UnionShape<
   ToArray<{
-    [K in keyof U]: U[K] extends AnyShape ? InferPartialDeepShape<U[K]> : never;
+    [K in keyof U]: U[K] extends AnyShape ? InferDeepPartialShape<U[K]> : never;
   }>
 >;
 
@@ -31,7 +31,7 @@ export type PartialDeepUnionShape<U extends readonly AnyShape[]> = UnionShape<
  */
 export class UnionShape<U extends readonly AnyShape[]>
   extends Shape<U[number]['input'], U[number]['output']>
-  implements PartialDeepProtocol<PartialDeepUnionShape<U>>
+  implements DeepPartialProtocol<DeepPartialUnionShape<U>>
 {
   protected _options;
   protected _typeIssueFactory;
@@ -64,8 +64,8 @@ export class UnionShape<U extends readonly AnyShape[]>
     return cb;
   }
 
-  partialDeep(): PartialDeepUnionShape<U> {
-    return new UnionShape(this.shapes.map(toPartialDeep), this._options) as any;
+  deepPartial(): DeepPartialUnionShape<U> {
+    return new UnionShape(this.shapes.map(toDeepPartial), this._options) as any;
   }
 
   at(key: unknown): AnyShape | null {

--- a/src/main/shapes/UnionShape.ts
+++ b/src/main/shapes/UnionShape.ts
@@ -63,10 +63,8 @@ export class UnionShape<U extends readonly AnyShape[]>
     return cb;
   }
 
-  deepPartial(): DeepPartialUnionShape<U>;
-
-  deepPartial(): AnyShape {
-    return new UnionShape(this.shapes.map(toDeepPartialShape), this._options);
+  deepPartial(): DeepPartialUnionShape<U> {
+    return new UnionShape<any>(this.shapes.map(toDeepPartialShape), this._options);
   }
 
   at(key: unknown): AnyShape | null {

--- a/src/main/shapes/UnionShape.ts
+++ b/src/main/shapes/UnionShape.ts
@@ -7,12 +7,12 @@ import {
   isArray,
   isAsyncShapes,
   isObjectLike,
-  toDeepPartial,
+  ToArray,
+  toDeepPartialShape,
   unique,
 } from '../utils';
 import { CODE_UNION, MESSAGE_UNION, TYPE_ANY, TYPE_NEVER } from '../constants';
 import { ObjectShape } from './ObjectShape';
-import { ToArray } from './ArrayShape';
 
 /**
  * Returns the list of shapes that are applicable to the input.
@@ -20,9 +20,7 @@ import { ToArray } from './ArrayShape';
 export type LookupCallback = (input: any) => readonly AnyShape[];
 
 export type DeepPartialUnionShape<U extends readonly AnyShape[]> = UnionShape<
-  ToArray<{
-    [K in keyof U]: U[K] extends AnyShape ? DeepPartialShape<U[K]> : never;
-  }>
+  ToArray<{ [K in keyof U]: U[K] extends AnyShape ? DeepPartialShape<U[K]> : never }>
 >;
 
 /**
@@ -68,7 +66,7 @@ export class UnionShape<U extends readonly AnyShape[]>
   deepPartial(): DeepPartialUnionShape<U>;
 
   deepPartial(): AnyShape {
-    return new UnionShape(this.shapes.map(toDeepPartial), this._options);
+    return new UnionShape(this.shapes.map(toDeepPartialShape), this._options);
   }
 
   at(key: unknown): AnyShape | null {

--- a/src/main/shapes/UnionShape.ts
+++ b/src/main/shapes/UnionShape.ts
@@ -1,14 +1,15 @@
-import {
-  AnyShape,
-  ApplyResult,
-  InferDeepPartialShape,
-  DeepPartialProtocol,
-  Shape,
-  toDeepPartial,
-  ValueType,
-} from './Shape';
+import { AnyShape, ApplyResult, DeepPartialProtocol, InferDeepPartialShape, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
-import { concatIssues, createIssueFactory, getValueType, isArray, isAsyncShapes, isObjectLike, unique } from '../utils';
+import {
+  concatIssues,
+  createIssueFactory,
+  getValueType,
+  isArray,
+  isAsyncShapes,
+  isObjectLike,
+  toDeepPartial,
+  unique,
+} from '../utils';
 import { CODE_UNION, MESSAGE_UNION, TYPE_ANY, TYPE_NEVER } from '../constants';
 import { ObjectShape } from './ObjectShape';
 import { ToArray } from './ArrayShape';

--- a/src/main/shapes/index.ts
+++ b/src/main/shapes/index.ts
@@ -18,6 +18,7 @@ export { RecordShape } from './RecordShape';
 export { SetShape } from './SetShape';
 export {
   AnyShape,
+  BrandShape,
   DeepPartialProtocol,
   DeepPartialShape,
   ExcludeShape,

--- a/src/main/shapes/index.ts
+++ b/src/main/shapes/index.ts
@@ -16,18 +16,7 @@ export { ObjectShape, KeysMode } from './ObjectShape';
 export { PromiseShape } from './PromiseShape';
 export { RecordShape } from './RecordShape';
 export { SetShape } from './SetShape';
-export {
-  AnyShape,
-  ExcludeShape,
-  OpaqueExcludeShape,
-  OpaqueReplaceShape,
-  PipeShape,
-  ReplaceShape,
-  Shape,
-  TransformShape,
-  ValueType,
-  CatchShape,
-} from './Shape';
+export { AnyShape, ExcludeShape, PipeShape, ReplaceShape, Shape, TransformShape, ValueType, CatchShape } from './Shape';
 export { StringShape } from './StringShape';
 export { SymbolShape } from './SymbolShape';
 export { UnionShape } from './UnionShape';

--- a/src/main/shapes/index.ts
+++ b/src/main/shapes/index.ts
@@ -16,7 +16,18 @@ export { ObjectShape, KeysMode } from './ObjectShape';
 export { PromiseShape } from './PromiseShape';
 export { RecordShape } from './RecordShape';
 export { SetShape } from './SetShape';
-export { AnyShape, ExcludeShape, PipeShape, ReplaceShape, Shape, TransformShape, ValueType, CatchShape } from './Shape';
+export {
+  AnyShape,
+  DeepPartialProtocol,
+  ExcludeShape,
+  IncludeShape,
+  PipeShape,
+  ReplaceShape,
+  Shape,
+  TransformShape,
+  ValueType,
+  CatchShape,
+} from './Shape';
 export { StringShape } from './StringShape';
 export { SymbolShape } from './SymbolShape';
 export { UnionShape } from './UnionShape';

--- a/src/main/shapes/index.ts
+++ b/src/main/shapes/index.ts
@@ -19,6 +19,7 @@ export { SetShape } from './SetShape';
 export {
   AnyShape,
   DeepPartialProtocol,
+  DeepPartialShape,
   ExcludeShape,
   IncludeShape,
   PipeShape,

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,5 +1,5 @@
 import { Check, CheckCallback, ConstraintOptions, Issue, Message, Ok, ParseOptions } from './shared-types';
-import { AnyShape, ApplyChecksCallback, ReadonlyDict, Shape, ValueType } from './shapes/Shape';
+import { AnyShape, ApplyChecksCallback, InferDeepPartialShape, ReadonlyDict, Shape, ValueType } from './shapes/Shape';
 import { inflateIssue, ValidationError } from './ValidationError';
 import { TYPE_ARRAY, TYPE_DATE, TYPE_NULL } from './constants';
 
@@ -75,6 +75,10 @@ export function toArrayIndex(key: any): number {
     key = +key;
   }
   return Number.isInteger(key) && key >= 0 && key < 0xffffffff ? key : -1;
+}
+
+export function toDeepPartial<S extends AnyShape>(shape: S): InferDeepPartialShape<S> {
+  return 'deepPartial' in shape && typeof shape.deepPartial === 'function' ? shape.deepPartial() : shape;
 }
 
 /**

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,12 +1,4 @@
-import {
-  Check,
-  CheckCallback,
-  ConstraintOptions,
-  Issue,
-  Message,
-  Ok,
-  ParseOptions,
-} from './shared-types';
+import { Check, CheckCallback, ConstraintOptions, Issue, Message, Ok, ParseOptions } from './shared-types';
 import { AnyShape, ApplyChecksCallback, DeepPartialProtocol, DeepPartialShape, Shape, ValueType } from './shapes/Shape';
 import { inflateIssue, ValidationError } from './ValidationError';
 import { TYPE_ARRAY, TYPE_DATE, TYPE_NULL } from './constants';

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,5 +1,21 @@
-import { Check, CheckCallback, ConstraintOptions, Issue, Message, Ok, ParseOptions } from './shared-types';
-import { AnyShape, ApplyChecksCallback, InferDeepPartialShape, ReadonlyDict, Shape, ValueType } from './shapes/Shape';
+import {
+  Check,
+  CheckCallback,
+  ConstraintOptions,
+  Issue,
+  Message,
+  Ok,
+  ParseOptions,
+} from './shared-types';
+import {
+  AnyShape,
+  ApplyChecksCallback,
+  DeepPartialProtocol,
+  DeepPartialShape,
+  ReadonlyDict,
+  Shape,
+  ValueType,
+} from './shapes/Shape';
 import { inflateIssue, ValidationError } from './ValidationError';
 import { TYPE_ARRAY, TYPE_DATE, TYPE_NULL } from './constants';
 
@@ -77,8 +93,12 @@ export function toArrayIndex(key: any): number {
   return Number.isInteger(key) && key >= 0 && key < 0xffffffff ? key : -1;
 }
 
-export function toDeepPartial<S extends AnyShape>(shape: S): InferDeepPartialShape<S> {
-  return 'deepPartial' in shape && typeof shape.deepPartial === 'function' ? shape.deepPartial() : shape;
+/**
+ * Converts the shape to its deep partial alternative if shape implements {@linkcode DeepPartialProtocol}, or returns
+ * the shape as is.
+ */
+export function toDeepPartial<S extends AnyShape & Partial<DeepPartialProtocol<any>>>(shape: S): DeepPartialShape<S> {
+  return typeof shape.deepPartial === 'function' ? shape.deepPartial() : shape;
 }
 
 /**

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -7,17 +7,19 @@ import {
   Ok,
   ParseOptions,
 } from './shared-types';
-import {
-  AnyShape,
-  ApplyChecksCallback,
-  DeepPartialProtocol,
-  DeepPartialShape,
-  ReadonlyDict,
-  Shape,
-  ValueType,
-} from './shapes/Shape';
+import { AnyShape, ApplyChecksCallback, DeepPartialProtocol, DeepPartialShape, Shape, ValueType } from './shapes/Shape';
 import { inflateIssue, ValidationError } from './ValidationError';
 import { TYPE_ARRAY, TYPE_DATE, TYPE_NULL } from './constants';
+
+export interface ReadonlyDict<T = any> {
+  readonly [key: string]: T;
+}
+
+export interface Dict<T = any> {
+  [key: string]: T;
+}
+
+export type ToArray<T> = T extends readonly any[] ? T : never;
 
 export function getValueType(value: unknown): Exclude<ValueType, 'any' | 'never'> {
   const type = typeof value;
@@ -97,7 +99,9 @@ export function toArrayIndex(key: any): number {
  * Converts the shape to its deep partial alternative if shape implements {@linkcode DeepPartialProtocol}, or returns
  * the shape as is.
  */
-export function toDeepPartial<S extends AnyShape & Partial<DeepPartialProtocol<any>>>(shape: S): DeepPartialShape<S> {
+export function toDeepPartialShape<S extends AnyShape & Partial<DeepPartialProtocol<any>>>(
+  shape: S
+): DeepPartialShape<S> {
   return typeof shape.deepPartial === 'function' ? shape.deepPartial() : shape;
 }
 

--- a/src/test/dsl/and.test-d.ts
+++ b/src/test/dsl/and.test-d.ts
@@ -15,7 +15,7 @@ expectType<{ aaa?: string } & { bbb?: number }>(
         bbb: d.number(),
       }),
     ])
-    .partialDeep().output
+    .deepPartial().output
 );
 
 expectType<{ aaa?: Array<string | undefined> } & { bbb?: number }>(
@@ -28,5 +28,5 @@ expectType<{ aaa?: Array<string | undefined> } & { bbb?: number }>(
         bbb: d.number(),
       }),
     ])
-    .partialDeep().output
+    .deepPartial().output
 );

--- a/src/test/dsl/and.test-d.ts
+++ b/src/test/dsl/and.test-d.ts
@@ -1,0 +1,32 @@
+import { expectType } from 'tsd';
+import * as d from 'doubter';
+
+expectType<{ key1: string } & { key2: number }>(
+  d.and([d.object({ key1: d.string() }), d.object({ key2: d.number() })]).output
+);
+
+expectType<{ aaa?: string } & { bbb?: number }>(
+  d
+    .and([
+      d.object({
+        aaa: d.string(),
+      }),
+      d.object({
+        bbb: d.number(),
+      }),
+    ])
+    .partialDeep().output
+);
+
+expectType<{ aaa?: Array<string | undefined> } & { bbb?: number }>(
+  d
+    .and([
+      d.object({
+        aaa: d.array(d.string()),
+      }),
+      d.object({
+        bbb: d.number(),
+      }),
+    ])
+    .partialDeep().output
+);

--- a/src/test/dsl/any.test-d.ts
+++ b/src/test/dsl/any.test-d.ts
@@ -11,14 +11,44 @@ expectType<string | undefined>(d.any<string>().parseOrDefault(111));
 
 expectType<string | true>(d.any<string>().parseOrDefault(111, true));
 
-const brandedShape = d.any<string>().brand();
+const brandShape = d.any<string>().brand();
 
-expectType<(typeof brandedShape)['output']>(brandedShape.output);
+expectType<(typeof brandShape)['output']>(brandShape.output);
 
-expectNotType<(typeof brandedShape)['output']>('aaa');
+expectNotType<(typeof brandShape)['output']>('aaa');
 
 expectType<number | undefined>(d.number().catch().output);
 
 expectType<number | 'aaa'>(d.number().catch('aaa').output);
 
 expectType<number | 'aaa'>(d.number().catch(() => 'aaa').output);
+
+// TransformShape is opaque for deep partial
+expectType<{ aaa?: { bbb: number } }>(
+  d.object({ aaa: d.object({ bbb: d.number() }).transform(value => value) }).deepPartial().output
+);
+
+expectType<{ aaa?: string }>(
+  d
+    .object({ aaa: d.string().transform(parseFloat) })
+    .to(d.object({ aaa: d.number() }))
+    .deepPartial().input
+);
+
+expectType<{ aaa?: number }>(
+  d
+    .object({ aaa: d.string().transform(parseFloat) })
+    .to(d.object({ aaa: d.number() }))
+    .deepPartial().output
+);
+
+expectType<{ aaa?: string }>(
+  d
+    .or([d.object({ aaa: d.string() }), d.const(111)])
+    .exclude(111)
+    .deepPartial().output
+);
+
+expectType<{ aaa?: string } | undefined>(d.object({ aaa: d.string() }).catch().deepPartial().output);
+
+expectType<{ aaa?: string } | 111>(d.object({ aaa: d.string() }).catch(111).deepPartial().output);

--- a/src/test/dsl/any.test-d.ts
+++ b/src/test/dsl/any.test-d.ts
@@ -11,19 +11,13 @@ expectType<string | undefined>(d.any<string>().parseOrDefault(111));
 
 expectType<string | true>(d.any<string>().parseOrDefault(111, true));
 
-const brandShape = d.any<string>().brand();
-
-expectType<(typeof brandShape)['output']>(brandShape.output);
-
-expectNotType<(typeof brandShape)['output']>('aaa');
-
 expectType<number | undefined>(d.number().catch().output);
 
 expectType<number | 'aaa'>(d.number().catch('aaa').output);
 
 expectType<number | 'aaa'>(d.number().catch(() => 'aaa').output);
 
-// TransformShape is opaque for deep partial
+// TransformShape is opaque for deepPartial
 expectType<{ aaa?: { bbb: number } }>(
   d.object({ aaa: d.object({ bbb: d.number() }).transform(value => value) }).deepPartial().output
 );
@@ -52,3 +46,19 @@ expectType<{ aaa?: string }>(
 expectType<{ aaa?: string } | undefined>(d.object({ aaa: d.string() }).catch().deepPartial().output);
 
 expectType<{ aaa?: string } | 111>(d.object({ aaa: d.string() }).catch(111).deepPartial().output);
+
+const brandShape = d.any<string>().brand();
+
+expectType<(typeof brandShape)['output']>(brandShape.output);
+
+expectType<(typeof brandShape)['output']>(brandShape.parse('aaa'));
+
+expectNotType<(typeof brandShape)['output']>('aaa');
+
+expectNotType<(typeof brandShape)['output']>(d.any<string>().brand<'bbb'>().output);
+
+// deepPartial is visible on branded shapes
+expectType<{ aaa?: string }>(d.object({ aaa: d.string() }).brand().deepPartial().output);
+
+// Branded shapes are transparent for deepPartial
+expectType<{ aaa?: { bbb?: string } }>(d.object({ aaa: d.object({ bbb: d.string() }).brand() }).deepPartial().output);

--- a/src/test/dsl/array.test-d.ts
+++ b/src/test/dsl/array.test-d.ts
@@ -1,4 +1,12 @@
 import { expectType } from 'tsd';
 import * as d from 'doubter';
 
+expectType<any[]>(d.array().input);
+
+expectType<any[]>(d.array().output);
+
+expectType<111[]>(d.array(d.const(111)).input);
+
 expectType<111[]>(d.array(d.const(111)).output);
+
+expectType<Array<number | undefined>>(d.array(d.number()).partialDeep().output);

--- a/src/test/dsl/array.test-d.ts
+++ b/src/test/dsl/array.test-d.ts
@@ -9,4 +9,4 @@ expectType<111[]>(d.array(d.const(111)).input);
 
 expectType<111[]>(d.array(d.const(111)).output);
 
-expectType<Array<number | undefined>>(d.array(d.number()).partialDeep().output);
+expectType<Array<number | undefined>>(d.array(d.number()).deepPartial().output);

--- a/src/test/dsl/array.test-d.ts
+++ b/src/test/dsl/array.test-d.ts
@@ -10,3 +10,5 @@ expectType<111[]>(d.array(d.const(111)).input);
 expectType<111[]>(d.array(d.const(111)).output);
 
 expectType<Array<number | undefined>>(d.array(d.number()).deepPartial().output);
+
+expectType<Array<{ aaa?: number } | undefined>>(d.array(d.object({ aaa: d.number() })).deepPartial().output);

--- a/src/test/dsl/lazy.test-d.ts
+++ b/src/test/dsl/lazy.test-d.ts
@@ -2,3 +2,7 @@ import { expectType } from 'tsd';
 import * as d from 'doubter';
 
 expectType<number>(d.lazy(() => d.string().transform(parseFloat)).output);
+
+expectType<{ aaa?: string }>(d.lazy(() => d.object({ aaa: d.string().transform(parseFloat) })).deepPartial().input);
+
+expectType<{ aaa?: number }>(d.lazy(() => d.object({ aaa: d.string().transform(parseFloat) })).deepPartial().output);

--- a/src/test/dsl/map.test-d.ts
+++ b/src/test/dsl/map.test-d.ts
@@ -9,3 +9,9 @@ expectType<Map<'bbb', number>>(
     d.number()
   ).output
 );
+
+expectType<Map<string, number | undefined>>(d.map(d.string(), d.number()).deepPartial().output);
+
+expectType<Map<{ aaa?: string }, { bbb?: number } | undefined>>(
+  d.map(d.object({ aaa: d.string() }), d.object({ bbb: d.number() })).deepPartial().output
+);

--- a/src/test/dsl/object.test-d.ts
+++ b/src/test/dsl/object.test-d.ts
@@ -1,0 +1,45 @@
+import { expectType } from 'tsd';
+import * as d from 'doubter';
+
+expectType<{ aaa: string; bbb: number }>(
+  d.object({
+    aaa: d.string(),
+    bbb: d.number(),
+  }).output
+);
+
+expectType<{ aaa?: string; bbb?: number }>(
+  d
+    .object({
+      aaa: d.string(),
+      bbb: d.number(),
+    })
+    .partial().output
+);
+
+expectType<{ aaa?: string; bbb?: number }>(
+  d
+    .object({
+      aaa: d.string(),
+      bbb: d.number(),
+    })
+    .partialDeep().output
+);
+
+expectType<{ aaa?: string; bbb?: { ccc?: number } }>(
+  d
+    .object({
+      aaa: d.string(),
+      bbb: d.object({ ccc: d.number() }),
+    })
+    .partialDeep().output
+);
+
+expectType<{ aaa?: string; bbb?: Array<number | undefined> }>(
+  d
+    .object({
+      aaa: d.string(),
+      bbb: d.array(d.number()),
+    })
+    .partialDeep().output
+);

--- a/src/test/dsl/object.test-d.ts
+++ b/src/test/dsl/object.test-d.ts
@@ -23,7 +23,7 @@ expectType<{ aaa?: string; bbb?: number }>(
       aaa: d.string(),
       bbb: d.number(),
     })
-    .partialDeep().output
+    .deepPartial().output
 );
 
 expectType<{ aaa?: string; bbb?: { ccc?: number } }>(
@@ -32,7 +32,7 @@ expectType<{ aaa?: string; bbb?: { ccc?: number } }>(
       aaa: d.string(),
       bbb: d.object({ ccc: d.number() }),
     })
-    .partialDeep().output
+    .deepPartial().output
 );
 
 expectType<{ aaa?: string; bbb?: Array<number | undefined> }>(
@@ -41,5 +41,5 @@ expectType<{ aaa?: string; bbb?: Array<number | undefined> }>(
       aaa: d.string(),
       bbb: d.array(d.number()),
     })
-    .partialDeep().output
+    .deepPartial().output
 );

--- a/src/test/dsl/or.test-d.ts
+++ b/src/test/dsl/or.test-d.ts
@@ -1,0 +1,34 @@
+import { expectType } from 'tsd';
+import * as d from 'doubter';
+
+expectType<number | string>(d.or([d.number(), d.string()]).output);
+
+expectType<{ key1: string } | { key2: number }>(
+  d.or([d.object({ key1: d.string() }), d.object({ key2: d.number() })]).output
+);
+
+expectType<{ aaa?: string } | { bbb?: number }>(
+  d
+    .or([
+      d.object({
+        aaa: d.string(),
+      }),
+      d.object({
+        bbb: d.number(),
+      }),
+    ])
+    .partialDeep().output
+);
+
+expectType<{ aaa?: Array<string | undefined> } | { bbb?: number }>(
+  d
+    .or([
+      d.object({
+        aaa: d.array(d.string()),
+      }),
+      d.object({
+        bbb: d.number(),
+      }),
+    ])
+    .partialDeep().output
+);

--- a/src/test/dsl/or.test-d.ts
+++ b/src/test/dsl/or.test-d.ts
@@ -17,7 +17,7 @@ expectType<{ aaa?: string } | { bbb?: number }>(
         bbb: d.number(),
       }),
     ])
-    .partialDeep().output
+    .deepPartial().output
 );
 
 expectType<{ aaa?: Array<string | undefined> } | { bbb?: number }>(
@@ -30,5 +30,5 @@ expectType<{ aaa?: Array<string | undefined> } | { bbb?: number }>(
         bbb: d.number(),
       }),
     ])
-    .partialDeep().output
+    .deepPartial().output
 );

--- a/src/test/dsl/union.test-d.ts
+++ b/src/test/dsl/union.test-d.ts
@@ -1,8 +1,0 @@
-import { expectType } from 'tsd';
-import * as d from 'doubter';
-
-expectType<number | string>(d.or([d.number(), d.string()]).output);
-
-expectType<{ key1: string } | { key2: number }>(
-  d.or([d.object({ key1: d.string() }), d.object({ key2: d.number() })]).output
-);

--- a/src/test/shapes/ArrayShape.test.ts
+++ b/src/test/shapes/ArrayShape.test.ts
@@ -1,4 +1,4 @@
-import { ArrayShape, DeepPartialProtocol, NumberShape, ObjectShape, Shape, StringShape } from '../../main';
+import { ArrayShape, NumberShape, ObjectShape, Shape, StringShape } from '../../main';
 import {
   CODE_ARRAY_MAX,
   CODE_ARRAY_MIN,
@@ -384,21 +384,6 @@ describe('ArrayShape', () => {
   });
 
   describe('deepPartial', () => {
-    test('marks element shapes as deep partial', () => {
-      class MockShape extends Shape implements DeepPartialProtocol<Shape> {
-        deepPartial = jest.fn(() => this);
-      }
-
-      const shape1 = new MockShape();
-      const shape2 = new Shape();
-      const shape3 = new MockShape();
-
-      new ArrayShape([shape1, shape2], shape3).deepPartial();
-
-      expect(shape1.deepPartial).toHaveBeenCalledTimes(1);
-      expect(shape3.deepPartial).toHaveBeenCalledTimes(1);
-    });
-
     test('raises an issue if deep partial tuple length is invalid', () => {
       const arrShape = new ArrayShape(
         [new ObjectShape({ key1: new StringShape() }, null)],

--- a/src/test/shapes/EnumShape.test.ts
+++ b/src/test/shapes/EnumShape.test.ts
@@ -1,5 +1,5 @@
 import { EnumShape } from '../../main';
-import { CODE_ENUM } from '../../main/constants';
+import { CODE_ENUM, TYPE_ARRAY, TYPE_NUMBER, TYPE_STRING } from '../../main/constants';
 import { getEnumValues } from '../../main/shapes/EnumShape';
 
 describe('EnumShape', () => {
@@ -7,6 +7,7 @@ describe('EnumShape', () => {
     const shape = new EnumShape(['aaa', 'bbb']);
 
     expect(shape.values).toEqual(['aaa', 'bbb']);
+    expect(shape['_getInputTypes']()).toEqual([TYPE_STRING, TYPE_STRING]);
   });
 
   test('creates an enum shape from a native numeric enum', () => {
@@ -15,7 +16,10 @@ describe('EnumShape', () => {
       BBB,
     }
 
-    expect(new EnumShape(Foo).values).toEqual([Foo.AAA, Foo.BBB]);
+    const shape = new EnumShape(Foo);
+
+    expect(shape.values).toEqual([Foo.AAA, Foo.BBB]);
+    expect(shape['_getInputTypes']()).toEqual([TYPE_NUMBER, TYPE_NUMBER]);
   });
 
   test('creates an enum shape from a native string enum', () => {
@@ -131,8 +135,21 @@ describe('EnumShape', () => {
       BBB,
     }
 
-    expect(new EnumShape(Foo).coerce().parse('AAA')).toEqual(Foo.AAA);
-    expect(new EnumShape(Foo).parse('AAA', { coerced: true })).toEqual(Foo.AAA);
+    const shape = new EnumShape(Foo);
+
+    expect(shape.coerce()['_getInputTypes']()).toEqual([TYPE_NUMBER, TYPE_NUMBER, TYPE_STRING, TYPE_ARRAY]);
+
+    expect(shape.coerce().parse('AAA')).toEqual(Foo.AAA);
+    expect(shape.parse('AAA', { coerced: true })).toEqual(Foo.AAA);
+  });
+
+  test('coerces from an array', () => {
+    const shape = new EnumShape([111, 222]);
+
+    expect(shape.coerce()['_getInputTypes']()).toEqual([TYPE_NUMBER, TYPE_NUMBER, TYPE_ARRAY]);
+
+    expect(shape.coerce().parse([111])).toBe(111);
+    expect(shape.parse(111, { coerced: true })).toBe(111);
   });
 
   test('applies checks', () => {

--- a/src/test/shapes/IntersectionShape.test.ts
+++ b/src/test/shapes/IntersectionShape.test.ts
@@ -1,13 +1,4 @@
-import {
-  ArrayShape,
-  DeepPartialProtocol,
-  IntersectionShape,
-  NumberShape,
-  ObjectShape,
-  Shape,
-  StringShape,
-  UnionShape,
-} from '../../main';
+import { ArrayShape, IntersectionShape, NumberShape, ObjectShape, Shape, StringShape, UnionShape } from '../../main';
 import {
   CODE_INTERSECTION,
   CODE_TYPE,
@@ -98,20 +89,6 @@ describe('IntersectionShape', () => {
   });
 
   describe('deepPartial', () => {
-    test('marks all shapes as deep partial', () => {
-      class MockShape extends Shape implements DeepPartialProtocol<Shape> {
-        deepPartial = jest.fn(() => this);
-      }
-
-      const shape1 = new MockShape();
-      const shape2 = new MockShape();
-
-      new IntersectionShape([shape1, shape2]).deepPartial();
-
-      expect(shape1.deepPartial).toHaveBeenCalledTimes(1);
-      expect(shape2.deepPartial).toHaveBeenCalledTimes(1);
-    });
-
     test('parses intersected deep partial objects', () => {
       const andShape = new IntersectionShape([
         new ObjectShape({ key1: new StringShape() }, null),
@@ -122,6 +99,16 @@ describe('IntersectionShape', () => {
       expect(andShape.parse({ key1: undefined })).toEqual({ key1: undefined });
       expect(andShape.parse({ key2: 'aaa' })).toEqual({ key2: 'aaa' });
       expect(andShape.parse({ key1: 'aaa', key2: undefined })).toEqual({ key1: 'aaa', key2: undefined });
+    });
+
+    test('does not make shapes optional', () => {
+      const andShape = new IntersectionShape([new NumberShape()]).deepPartial();
+
+      expect(andShape.parse(111)).toBe(111);
+      expect(andShape.try(undefined)).toEqual({
+        ok: false,
+        issues: [{ code: CODE_TYPE, message: MESSAGE_NUMBER_TYPE, param: TYPE_NUMBER, path: [] }],
+      });
     });
   });
 

--- a/src/test/shapes/LazyShape.test.ts
+++ b/src/test/shapes/LazyShape.test.ts
@@ -36,8 +36,14 @@ describe('LazyShape', () => {
       }
 
       const deepPartialShape = new MockShape();
+      const shapeProviderMock = jest.fn(() => new MockShape());
 
-      expect(new LazyShape(() => new MockShape()).deepPartial()).toBe(deepPartialShape);
+      const shape = new LazyShape(shapeProviderMock).deepPartial();
+
+      expect(shapeProviderMock).not.toHaveBeenCalled();
+
+      expect(shape.shape).toBe(deepPartialShape);
+      expect(shapeProviderMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/test/shapes/LazyShape.test.ts
+++ b/src/test/shapes/LazyShape.test.ts
@@ -1,4 +1,4 @@
-import { LazyShape, Shape, StringShape } from '../../main';
+import { DeepPartialProtocol, LazyShape, Shape, StringShape } from '../../main';
 
 describe('LazyShape', () => {
   test('parses values with a shape', () => {
@@ -25,6 +25,20 @@ describe('LazyShape', () => {
     });
     expect(checkMock).toHaveBeenCalledTimes(1);
     expect(checkMock).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false });
+  });
+
+  describe('deepPartial', () => {
+    test('marks shape as deep partial', () => {
+      class MockShape extends Shape implements DeepPartialProtocol<Shape> {
+        deepPartial() {
+          return deepPartialShape;
+        }
+      }
+
+      const deepPartialShape = new MockShape();
+
+      expect(new LazyShape(() => new MockShape()).deepPartial()).toBe(deepPartialShape);
+    });
   });
 
   describe('async', () => {

--- a/src/test/shapes/ObjectShape.test.ts
+++ b/src/test/shapes/ObjectShape.test.ts
@@ -1,4 +1,4 @@
-import { DeepPartialProtocol, ObjectShape, Shape, StringShape } from '../../main';
+import { ObjectShape, Shape, StringShape } from '../../main';
 import {
   CODE_ENUM,
   CODE_EXCLUSION,
@@ -243,27 +243,6 @@ describe('ObjectShape', () => {
   });
 
   describe('deepPartial', () => {
-    test('marks property and rest shapes as deep partial', () => {
-      class MockShape extends Shape implements DeepPartialProtocol<Shape> {
-        deepPartial = jest.fn(() => this);
-      }
-
-      const shape1 = new MockShape();
-      const shape2 = new Shape();
-      const shape3 = new MockShape();
-
-      new ObjectShape(
-        {
-          key1: shape1,
-          key2: shape2,
-        },
-        shape3
-      ).deepPartial();
-
-      expect(shape1.deepPartial).toHaveBeenCalledTimes(1);
-      expect(shape3.deepPartial).toHaveBeenCalledTimes(1);
-    });
-
     test('parses deep partial properties', () => {
       const objShape = new ObjectShape(
         { key1: new ObjectShape({ key2: new StringShape() }, null) },

--- a/src/test/shapes/SetShape.test.ts
+++ b/src/test/shapes/SetShape.test.ts
@@ -1,9 +1,10 @@
-import { SetShape, Shape, StringShape } from '../../main';
+import { ObjectShape, SetShape, Shape, StringShape } from '../../main';
 import {
   CODE_SET_MAX,
   CODE_SET_MIN,
   CODE_TYPE,
   MESSAGE_SET_TYPE,
+  MESSAGE_STRING_TYPE,
   TYPE_ARRAY,
   TYPE_OBJECT,
   TYPE_SET,
@@ -168,6 +169,27 @@ describe('SetShape', () => {
     const setShape = new SetShape(new Shape()).coerce();
 
     expect(setShape.parse(['aaa'])).toEqual(new Set(['aaa']));
+  });
+
+  describe('deepPartial', () => {
+    test('marks value as optional', () => {
+      const setShape = new SetShape(new StringShape()).deepPartial();
+
+      expect(setShape.parse(new Set(['aaa']))).toEqual(new Set(['aaa']));
+      expect(setShape.parse(new Set([undefined]))).toEqual(new Set([undefined]));
+    });
+
+    test('makes value deep partial', () => {
+      const setShape = new SetShape(new ObjectShape({ key1: new StringShape() }, null)).deepPartial();
+
+      expect(setShape.parse(new Set([{}]))).toEqual(new Set([{}]));
+      expect(setShape.parse(new Set([{ key1: undefined }]))).toEqual(new Set([{ key1: undefined }]));
+
+      expect(setShape.try(new Set([{ key1: 111 }]))).toEqual({
+        ok: false,
+        issues: [{ code: CODE_TYPE, input: 111, message: MESSAGE_STRING_TYPE, param: TYPE_STRING, path: [0, 'key1'] }],
+      });
+    });
   });
 
   describe('async', () => {

--- a/src/test/shapes/Shape.test.ts
+++ b/src/test/shapes/Shape.test.ts
@@ -1,4 +1,14 @@
-import { ExcludeShape, Ok, PipeShape, Shape, StringShape, TransformShape, ValidationError } from '../../main';
+import {
+  ExcludeShape,
+  NumberShape,
+  ObjectShape,
+  Ok,
+  PipeShape,
+  Shape,
+  StringShape,
+  TransformShape,
+  ValidationError,
+} from '../../main';
 import { CODE_EXCLUSION, CODE_PREDICATE, MESSAGE_PREDICATE, TYPE_STRING } from '../../main/constants';
 import { CatchShape } from '../../main/shapes/Shape';
 
@@ -497,9 +507,9 @@ describe('PipeShape', () => {
     const applySpy1 = jest.spyOn<Shape, any>(shape1, '_apply');
     const applySpy2 = jest.spyOn<Shape, any>(shape2, '_apply');
 
-    const shape = new PipeShape(shape1, shape2);
+    const pipeShape = new PipeShape(shape1, shape2);
 
-    expect(shape.parse('aaa')).toBe('aaa');
+    expect(pipeShape.parse('aaa')).toBe('aaa');
 
     expect(applySpy1).toHaveBeenCalledTimes(1);
     expect(applySpy1).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false });
@@ -514,9 +524,9 @@ describe('PipeShape', () => {
 
     const applySpy = jest.spyOn<Shape, any>(shape2, '_apply');
 
-    const shape = new PipeShape(shape1, shape2);
+    const pipeShape = new PipeShape(shape1, shape2);
 
-    shape.try('aaa');
+    pipeShape.try('aaa');
 
     expect(applySpy).not.toHaveBeenCalled();
   });
@@ -527,11 +537,70 @@ describe('PipeShape', () => {
 
     const checkMock = jest.fn();
 
-    const shape = new PipeShape(shape1, shape2).check(checkMock);
+    const pipeShape = new PipeShape(shape1, shape2).check(checkMock);
 
-    shape.try('aaa');
+    pipeShape.try('aaa');
 
     expect(checkMock).not.toHaveBeenCalled();
+  });
+
+  describe('deepPartial', () => {
+    test('pipes deep partial objects', () => {
+      const shape1 = new ObjectShape({ key1: new StringShape().transform(parseFloat) }, null);
+      const shape2 = new ObjectShape({ key1: new NumberShape() }, null);
+
+      const pipeShape = new PipeShape(shape1, shape2).deepPartial();
+
+      expect(pipeShape.parse({})).toEqual({});
+      expect(pipeShape.parse({ key1: undefined })).toEqual({ key1: undefined });
+      expect(pipeShape.parse({ key1: '111' })).toEqual({ key1: 111 });
+    });
+  });
+
+  describe('async', () => {
+    test('pipes the output of one shape to the other', async () => {
+      const shape1 = new Shape().transformAsync(value => Promise.resolve(value));
+      const shape2 = new Shape().transformAsync(value => Promise.resolve(value));
+
+      const applyAsyncSpy1 = jest.spyOn<Shape, any>(shape1, '_applyAsync');
+      const applyAsyncSpy2 = jest.spyOn<Shape, any>(shape2, '_applyAsync');
+
+      const pipeShape = new PipeShape(shape1, shape2);
+
+      await expect(pipeShape.parseAsync('aaa')).resolves.toBe('aaa');
+
+      expect(applyAsyncSpy1).toHaveBeenCalledTimes(1);
+      expect(applyAsyncSpy1).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false });
+
+      expect(applyAsyncSpy2).toHaveBeenCalledTimes(1);
+      expect(applyAsyncSpy2).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false });
+    });
+
+    test('does not apply the output shape if the input shape parsing failed', async () => {
+      const shape1 = new Shape().transformAsync(value => Promise.resolve(value)).check(() => [{ code: 'xxx' }]);
+      const shape2 = new Shape().transformAsync(value => Promise.resolve(value));
+
+      const applySpy = jest.spyOn<Shape, any>(shape2, '_apply');
+
+      const pipeShape = new PipeShape(shape1, shape2);
+
+      await pipeShape.tryAsync('aaa');
+
+      expect(applySpy).not.toHaveBeenCalled();
+    });
+
+    test('does not apply checks if the output shape has failed', async () => {
+      const shape1 = new Shape().transformAsync(value => Promise.resolve(value));
+      const shape2 = new Shape().transformAsync(value => Promise.resolve(value)).check(() => [{ code: 'xxx' }]);
+
+      const checkMock = jest.fn();
+
+      const pipeShape = new PipeShape(shape1, shape2).check(checkMock);
+
+      await pipeShape.tryAsync('aaa');
+
+      expect(checkMock).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/test/shapes/Shape.test.ts
+++ b/src/test/shapes/Shape.test.ts
@@ -359,6 +359,12 @@ describe('Shape', () => {
     expect((shape as ExcludeShape<any, any>).excludedValue).toBe(undefined);
   });
 
+  test('branding does not change shape identity', () => {
+    const shape = new Shape();
+
+    expect(shape.brand()).toBe(shape);
+  });
+
   describe('async', () => {
     test('creates an async shape', () => {
       class AsyncShape extends Shape {

--- a/src/test/shapes/UnionShape.test.ts
+++ b/src/test/shapes/UnionShape.test.ts
@@ -155,15 +155,15 @@ describe('UnionShape', () => {
     });
 
     test('parses united deep partial objects', () => {
-      const andShape = new UnionShape([
+      const orShape = new UnionShape([
         new ObjectShape({ key1: new StringShape() }, null),
         new ObjectShape({ key2: new StringShape() }, null),
       ]).deepPartial();
 
-      expect(andShape.parse({})).toEqual({});
-      expect(andShape.parse({ key1: undefined })).toEqual({ key1: undefined });
-      expect(andShape.parse({ key2: 'aaa' })).toEqual({ key2: 'aaa' });
-      expect(andShape.parse({ key1: 'aaa', key2: undefined })).toEqual({ key1: 'aaa', key2: undefined });
+      expect(orShape.parse({})).toEqual({});
+      expect(orShape.parse({ key1: undefined })).toEqual({ key1: undefined });
+      expect(orShape.parse({ key2: 'aaa' })).toEqual({ key2: 'aaa' });
+      expect(orShape.parse({ key1: 'aaa', key2: undefined })).toEqual({ key1: 'aaa', key2: undefined });
     });
   });
 


### PR DESCRIPTION
- Added `DeepPartialProtocol` interface that is implemented by almost all shapes;
- Removed opaque shapes;
- Added `IncludeShape` interface (an alias for `ReplaceShape`) that allows the same value as an input as an output;
- Added `BrandShape` interface that preserves deep partial protocol of the underlying shape.