### PR TITLE
Added isMultipleOf

### DIFF
--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -72,11 +72,11 @@ export function isUnsafeCheck(check: Check): boolean {
 /**
  * Returns an array index, or -1 if key isn't an index.
  */
-export function toArrayIndex(key: unknown): number {
+export function toArrayIndex(key: any): number {
   if (typeof key === 'string' && '' + +key === key) {
     key = +key;
   }
-  return typeof key === 'number' && key % 1 === 0 && key >= 0 && key < 0xffffffff ? key : -1;
+  return Number.isInteger(key) && key >= 0 && key < 0xffffffff ? key : -1;
 }
 
 /**

--- a/src/test/perf.js
+++ b/src/test/perf.js
@@ -553,6 +553,42 @@ describe(
 );
 
 describe(
+  'number().multipleOf(0.1)',
+  () => {
+    const value = 49.9;
+
+    test('Ajv', measure => {
+      const validate = new Ajv().compile({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'number',
+        multipleOf: 0.1,
+      });
+
+      measure(() => {
+        validate(value);
+      });
+    });
+
+    test('zod', measure => {
+      const type = zod.number().multipleOf(0.1);
+
+      measure(() => {
+        type.parse(value);
+      });
+    });
+
+    test('doubter', measure => {
+      const shape = doubter.number().multipleOf(0.1);
+
+      measure(() => {
+        shape.parse(value);
+      });
+    });
+  },
+  perfOptions
+);
+
+describe(
   'number().gte(1).lte(5)',
   () => {
     const value = 4;


### PR DESCRIPTION
`isMultipleOf` correctly handles IEEE 754 rounding errors.

```
isMultipleOf(49.9, 0.1) // ⮕ true
```