### PR TITLE
Checks array

### DIFF
--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -59,6 +59,7 @@ export const MESSAGE_ENUM = 'Must be equal to one of %s';
 export const MESSAGE_EXCLUSION = 'Must not be equal to %s';
 export const MESSAGE_INSTANCE = 'Must be a class instance';
 export const MESSAGE_INTERSECTION = 'Must conform the intersection';
+export const MESSAGE_JSON = 'Must be a JSON string: %s';
 export const MESSAGE_PREDICATE = 'Must conform the predicate';
 export const MESSAGE_MAP_TYPE = 'Must be a Map';
 export const MESSAGE_NEVER_TYPE = 'Must not be used';

--- a/src/main/dsl/any.ts
+++ b/src/main/dsl/any.ts
@@ -11,7 +11,8 @@ import { ConstraintOptions, Message } from '../shared-types';
 export function any<T = any>(): Shape<T>;
 
 /**
- * Creates a shape that is constrained with a [narrowing predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html).
+ * Creates a shape that is constrained with a
+ * [narrowing predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html).
  *
  * @param cb The type predicate that returns `true` if value conforms the required type, or `false` otherwise.
  * @param options The constraint options or an issue message.

--- a/src/main/dsl/array.ts
+++ b/src/main/dsl/array.ts
@@ -1,12 +1,12 @@
 import { AnyShape, ArrayShape, Shape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the unconstrained array shape.
  *
  * @param options The constraint options or an issue message.
  */
-export function array(options?: TypeConstraintOptions | Message): ArrayShape<null, null>;
+export function array(options?: ConstraintOptions | Message): ArrayShape<null, null>;
 
 /**
  * Creates the array shape with elements that conform the element shape.
@@ -15,14 +15,11 @@ export function array(options?: TypeConstraintOptions | Message): ArrayShape<nul
  * @param options The constraint options or an issue message.
  * @template S The shape of array elements.
  */
-export function array<S extends AnyShape | null>(
-  shape: S,
-  options?: TypeConstraintOptions | Message
-): ArrayShape<null, S>;
+export function array<S extends AnyShape | null>(shape: S, options?: ConstraintOptions | Message): ArrayShape<null, S>;
 
 export function array(
-  shape?: AnyShape | TypeConstraintOptions | Message,
-  options?: TypeConstraintOptions | Message
+  shape?: AnyShape | ConstraintOptions | Message,
+  options?: ConstraintOptions | Message
 ): ArrayShape<any, any> {
   if (shape == null || shape instanceof Shape) {
     return new ArrayShape(null, shape || null, options);

--- a/src/main/dsl/bigint.ts
+++ b/src/main/dsl/bigint.ts
@@ -1,11 +1,11 @@
 import { BigIntShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the bigint shape.
  *
  * @param options The constraint options or an issue message.
  */
-export function bigint(options?: TypeConstraintOptions | Message): BigIntShape {
+export function bigint(options?: ConstraintOptions | Message): BigIntShape {
   return new BigIntShape(options);
 }

--- a/src/main/dsl/boolean.ts
+++ b/src/main/dsl/boolean.ts
@@ -1,12 +1,12 @@
 import { BooleanShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the boolean shape.
  *
  * @param options The constraint options or an issue message.
  */
-export function boolean(options?: TypeConstraintOptions | Message): BooleanShape {
+export function boolean(options?: ConstraintOptions | Message): BooleanShape {
   return new BooleanShape(options);
 }
 

--- a/src/main/dsl/const.ts
+++ b/src/main/dsl/const.ts
@@ -1,4 +1,4 @@
-import { Literal, Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Literal, Message } from '../shared-types';
 import { ConstShape } from '../shapes';
 
 /**
@@ -8,7 +8,7 @@ import { ConstShape } from '../shapes';
  * @param options The constraint options or an issue message.
  * @template T The value type.
  */
-function const_<T extends Literal>(value: T, options?: TypeConstraintOptions | Message): ConstShape<T> {
+function const_<T extends Literal>(value: T, options?: ConstraintOptions | Message): ConstShape<T> {
   return new ConstShape(value, options);
 }
 

--- a/src/main/dsl/date.ts
+++ b/src/main/dsl/date.ts
@@ -1,11 +1,11 @@
 import { DateShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the `Date` shape.
  *
  * @param options The constraint options or an issue message.
  */
-export function date(options?: TypeConstraintOptions | Message): DateShape {
+export function date(options?: ConstraintOptions | Message): DateShape {
   return new DateShape(options);
 }

--- a/src/main/dsl/enum.ts
+++ b/src/main/dsl/enum.ts
@@ -1,4 +1,4 @@
-import { Literal, Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Literal, Message } from '../shared-types';
 import { EnumShape } from '../shapes';
 import { ReadonlyDict } from '../shapes/Shape';
 
@@ -12,7 +12,7 @@ import { ReadonlyDict } from '../shapes/Shape';
  */
 function enum_<T extends Literal, U extends readonly [T, ...T[]]>(
   values: U,
-  options?: TypeConstraintOptions | Message
+  options?: ConstraintOptions | Message
 ): EnumShape<U[number]>;
 
 /**
@@ -25,10 +25,10 @@ function enum_<T extends Literal, U extends readonly [T, ...T[]]>(
  */
 function enum_<T extends Literal, U extends ReadonlyDict<T>>(
   valueMapping: U,
-  options?: TypeConstraintOptions | Message
+  options?: ConstraintOptions | Message
 ): EnumShape<U[keyof U]>;
 
-function enum_(source: any[] | ReadonlyDict, options?: TypeConstraintOptions | Message): EnumShape<any> {
+function enum_(source: any[] | ReadonlyDict, options?: ConstraintOptions | Message): EnumShape<any> {
   return new EnumShape(source, options);
 }
 

--- a/src/main/dsl/finite.ts
+++ b/src/main/dsl/finite.ts
@@ -1,11 +1,11 @@
 import { NumberShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the finite number shape.
  *
  * @param options The constraint options or an issue message.
  */
-export function finite(options?: TypeConstraintOptions | Message): NumberShape {
+export function finite(options?: ConstraintOptions | Message): NumberShape {
   return new NumberShape(options).finite();
 }

--- a/src/main/dsl/instanceOf.ts
+++ b/src/main/dsl/instanceOf.ts
@@ -1,5 +1,5 @@
 import { InstanceShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the class instance shape.
@@ -10,7 +10,7 @@ import { Message, TypeConstraintOptions } from '../shared-types';
  */
 export function instanceOf<C extends new (...args: any[]) => any>(
   ctor: C,
-  options?: TypeConstraintOptions | Message
+  options?: ConstraintOptions | Message
 ): InstanceShape<C> {
   return new InstanceShape(ctor, options);
 }

--- a/src/main/dsl/integer.ts
+++ b/src/main/dsl/integer.ts
@@ -1,12 +1,12 @@
 import { NumberShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the integer shape.
  *
  * @param options The constraint options or an issue message.
  */
-export function integer(options?: TypeConstraintOptions | Message): NumberShape {
+export function integer(options?: ConstraintOptions | Message): NumberShape {
   return new NumberShape(options).integer(options);
 }
 

--- a/src/main/dsl/intersection.ts
+++ b/src/main/dsl/intersection.ts
@@ -1,5 +1,5 @@
 import { AnyShape, IntersectionShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates an intersection shape that tries to parse the input with all provided shapes.
@@ -10,7 +10,7 @@ import { Message, TypeConstraintOptions } from '../shared-types';
  */
 export function intersection<U extends [AnyShape, ...AnyShape[]]>(
   shapes: U,
-  options?: TypeConstraintOptions | Message
+  options?: ConstraintOptions | Message
 ): IntersectionShape<U> {
   return new IntersectionShape<U>(shapes, options);
 }

--- a/src/main/dsl/json.ts
+++ b/src/main/dsl/json.ts
@@ -1,11 +1,11 @@
 import { JSONShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the shape that parses JSON strings.
  *
  * @param options The constraint options or an issue message.
  */
-export function json(options?: TypeConstraintOptions | Message): JSONShape {
+export function json(options?: ConstraintOptions | Message): JSONShape {
   return new JSONShape(options);
 }

--- a/src/main/dsl/map.ts
+++ b/src/main/dsl/map.ts
@@ -1,5 +1,5 @@
 import { AnyShape, MapShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the `Map` instance shape.
@@ -13,7 +13,7 @@ import { Message, TypeConstraintOptions } from '../shared-types';
 export function map<K extends AnyShape, V extends AnyShape>(
   keyShape: K,
   valueShape: V,
-  options?: TypeConstraintOptions | Message
+  options?: ConstraintOptions | Message
 ): MapShape<K, V> {
   return new MapShape(keyShape, valueShape, options);
 }

--- a/src/main/dsl/nan.ts
+++ b/src/main/dsl/nan.ts
@@ -1,4 +1,4 @@
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 import { ConstShape } from '../shapes';
 
 /**
@@ -6,6 +6,6 @@ import { ConstShape } from '../shapes';
  *
  * @param options The constraint options or an issue message.
  */
-export function nan(options?: TypeConstraintOptions | Message): ConstShape<number> {
+export function nan(options?: ConstraintOptions | Message): ConstShape<number> {
   return new ConstShape(NaN, options);
 }

--- a/src/main/dsl/never.ts
+++ b/src/main/dsl/never.ts
@@ -1,11 +1,11 @@
 import { NeverShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the shape that always raises an issue.
  *
  * @param options The constraint options or an issue message.
  */
-export function never(options?: TypeConstraintOptions | Message): NeverShape {
+export function never(options?: ConstraintOptions | Message): NeverShape {
   return new NeverShape(options);
 }

--- a/src/main/dsl/null.ts
+++ b/src/main/dsl/null.ts
@@ -1,4 +1,4 @@
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 import { ConstShape } from '../shapes';
 
 /**
@@ -6,7 +6,7 @@ import { ConstShape } from '../shapes';
  *
  * @param options The constraint options or an issue message.
  */
-function null_(options?: TypeConstraintOptions | Message): ConstShape<null> {
+function null_(options?: ConstraintOptions | Message): ConstShape<null> {
   return new ConstShape(null, options);
 }
 

--- a/src/main/dsl/number.ts
+++ b/src/main/dsl/number.ts
@@ -1,11 +1,11 @@
 import { NumberShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the number shape.
  *
  * @param options The constraint options or an issue message.
  */
-export function number(options?: TypeConstraintOptions | Message): NumberShape {
+export function number(options?: ConstraintOptions | Message): NumberShape {
   return new NumberShape(options);
 }

--- a/src/main/dsl/object.ts
+++ b/src/main/dsl/object.ts
@@ -1,4 +1,4 @@
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 import { AnyShape, ObjectShape } from '../shapes';
 import { ReadonlyDict } from '../shapes/Shape';
 
@@ -10,7 +10,7 @@ import { ReadonlyDict } from '../shapes/Shape';
  */
 export function object<P extends ReadonlyDict<AnyShape>>(
   shapes: P,
-  options?: TypeConstraintOptions | Message
+  options?: ConstraintOptions | Message
 ): ObjectShape<P, null> {
   return new ObjectShape(shapes, null, options);
 }

--- a/src/main/dsl/promise.ts
+++ b/src/main/dsl/promise.ts
@@ -1,5 +1,5 @@
 import { AnyShape, PromiseShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the `Promise` instance shape.
@@ -8,6 +8,6 @@ import { Message, TypeConstraintOptions } from '../shared-types';
  * @param options The constraint options or an issue message.
  * @template S The shape of the resolved value.
  */
-export function promise<S extends AnyShape>(shape: S, options?: TypeConstraintOptions | Message): PromiseShape<S> {
+export function promise<S extends AnyShape>(shape: S, options?: ConstraintOptions | Message): PromiseShape<S> {
   return new PromiseShape(shape, options);
 }

--- a/src/main/dsl/record.ts
+++ b/src/main/dsl/record.ts
@@ -1,5 +1,5 @@
 import { AnyShape, RecordShape, Shape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the shape that describes an object with string keys and values that conform the given shape.
@@ -8,10 +8,7 @@ import { Message, TypeConstraintOptions } from '../shared-types';
  * @param options The constraint options or an issue message.
  * @template V The value shape.
  */
-export function record<V extends AnyShape>(
-  valueShape: V,
-  options?: TypeConstraintOptions | Message
-): RecordShape<null, V>;
+export function record<V extends AnyShape>(valueShape: V, options?: ConstraintOptions | Message): RecordShape<null, V>;
 
 /**
  * Creates the shape that describes an object with string keys and values that conform the given shape.
@@ -25,13 +22,13 @@ export function record<V extends AnyShape>(
 export function record<K extends Shape<string, PropertyKey>, V extends AnyShape>(
   keyShape: K,
   valueShape: V,
-  options?: TypeConstraintOptions | Message
+  options?: ConstraintOptions | Message
 ): RecordShape<K, V>;
 
 export function record(
   keyShape: AnyShape,
-  valueShape?: AnyShape | TypeConstraintOptions | Message,
-  options?: TypeConstraintOptions | Message
+  valueShape?: AnyShape | ConstraintOptions | Message,
+  options?: ConstraintOptions | Message
 ) {
   if (valueShape instanceof Shape) {
     return new RecordShape(keyShape, valueShape, options);

--- a/src/main/dsl/set.ts
+++ b/src/main/dsl/set.ts
@@ -1,5 +1,5 @@
 import { AnyShape, SetShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the `Set` instance shape.
@@ -8,6 +8,6 @@ import { Message, TypeConstraintOptions } from '../shared-types';
  * @param options The constraint options or an issue message.
  * @template S The value shape.
  */
-export function set<S extends AnyShape>(shape: S, options?: TypeConstraintOptions | Message): SetShape<S> {
+export function set<S extends AnyShape>(shape: S, options?: ConstraintOptions | Message): SetShape<S> {
   return new SetShape(shape, options);
 }

--- a/src/main/dsl/string.ts
+++ b/src/main/dsl/string.ts
@@ -1,11 +1,11 @@
 import { StringShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the string shape.
  *
  * @param options The constraint options or an issue message.
  */
-export function string(options?: TypeConstraintOptions | Message): StringShape {
+export function string(options?: ConstraintOptions | Message): StringShape {
   return new StringShape(options);
 }

--- a/src/main/dsl/symbol.ts
+++ b/src/main/dsl/symbol.ts
@@ -1,11 +1,11 @@
 import { SymbolShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the symbol shape.
  *
  * @param options The constraint options or an issue message.
  */
-export function symbol(options?: TypeConstraintOptions | Message): SymbolShape {
+export function symbol(options?: ConstraintOptions | Message): SymbolShape {
   return new SymbolShape(options);
 }

--- a/src/main/dsl/tuple.ts
+++ b/src/main/dsl/tuple.ts
@@ -1,5 +1,5 @@
 import { AnyShape, ArrayShape, Shape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates the tuple shape.
@@ -10,7 +10,7 @@ import { Message, TypeConstraintOptions } from '../shared-types';
  */
 export function tuple<U extends readonly [AnyShape, ...AnyShape[]]>(
   shapes: U,
-  options?: TypeConstraintOptions | Message
+  options?: ConstraintOptions | Message
 ): ArrayShape<U, null>;
 
 /**
@@ -25,13 +25,13 @@ export function tuple<U extends readonly [AnyShape, ...AnyShape[]]>(
 export function tuple<U extends readonly [AnyShape, ...AnyShape[]], R extends AnyShape | null>(
   shapes: U,
   restShape: R,
-  options?: TypeConstraintOptions | Message
+  options?: ConstraintOptions | Message
 ): ArrayShape<U, R>;
 
 export function tuple(
   shapes: [AnyShape, ...AnyShape[]],
-  restShape?: AnyShape | TypeConstraintOptions | Message | null,
-  options?: TypeConstraintOptions | Message
+  restShape?: AnyShape | ConstraintOptions | Message | null,
+  options?: ConstraintOptions | Message
 ): ArrayShape<[AnyShape, ...AnyShape[]], AnyShape | null> {
   if (restShape == null || restShape instanceof Shape) {
     return new ArrayShape(shapes, restShape || null, options);

--- a/src/main/dsl/undefined.ts
+++ b/src/main/dsl/undefined.ts
@@ -1,4 +1,4 @@
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 import { ConstShape } from '../shapes';
 
 /**
@@ -6,7 +6,7 @@ import { ConstShape } from '../shapes';
  *
  * @param options The constraint options or an issue message.
  */
-function undefined_(options?: TypeConstraintOptions | Message): ConstShape<undefined> {
+function undefined_(options?: ConstraintOptions | Message): ConstShape<undefined> {
   return new ConstShape(undefined, options);
 }
 

--- a/src/main/dsl/union.ts
+++ b/src/main/dsl/union.ts
@@ -1,5 +1,5 @@
 import { AnyShape, UnionShape } from '../shapes';
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 
 /**
  * Creates a union shape that tries to parse the input with one of the provided shapes.
@@ -10,7 +10,7 @@ import { Message, TypeConstraintOptions } from '../shared-types';
  */
 export function union<U extends [AnyShape, ...AnyShape[]]>(
   shapes: U,
-  options?: TypeConstraintOptions | Message
+  options?: ConstraintOptions | Message
 ): UnionShape<U> {
   return new UnionShape<U>(shapes, options);
 }

--- a/src/main/dsl/void.ts
+++ b/src/main/dsl/void.ts
@@ -1,4 +1,4 @@
-import { Message, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message } from '../shared-types';
 import { ConstShape } from '../shapes';
 
 /**
@@ -6,7 +6,7 @@ import { ConstShape } from '../shapes';
  *
  * @param options The constraint options or an issue message.
  */
-function void_(options?: TypeConstraintOptions | Message): ConstShape<void> {
+function void_(options?: ConstraintOptions | Message): ConstShape<void> {
   return new ConstShape(undefined, options);
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,5 @@
 export * from './dsl';
 export * from './shapes';
 export * from './shared-types';
-export { guard, guardAsync } from './guard';
+export * from './guard';
 export { ValidationError } from './ValidationError';
-export { createIssueFactory } from './utils';

--- a/src/main/shapes/ArrayShape.ts
+++ b/src/main/shapes/ArrayShape.ts
@@ -1,6 +1,7 @@
 import { AnyShape, ApplyResult, ValueType } from './Shape';
-import { ConstraintOptions, Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import {
+  addConstraint,
   concatIssues,
   createIssueFactory,
   isArray,
@@ -8,7 +9,6 @@ import {
   isEqual,
   isIterable,
   ok,
-  setCheck,
   toArrayIndex,
   unshiftPath,
 } from '../utils';
@@ -70,7 +70,7 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
      * The shape of rest elements or `null` if there are no rest elements.
      */
     readonly restShape: R,
-    options?: TypeConstraintOptions | Message
+    options?: ConstraintOptions | Message
   ) {
     super();
 
@@ -131,7 +131,7 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
   min(length: number, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_ARRAY_MIN, MESSAGE_ARRAY_MIN, options, length);
 
-    return setCheck(this, CODE_ARRAY_MIN, options, length, (input, options) => {
+    return addConstraint(this, CODE_ARRAY_MIN, length, (input, options) => {
       if (input.length < length) {
         return issueFactory(input, options);
       }
@@ -148,7 +148,7 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
   max(length: number, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_ARRAY_MAX, MESSAGE_ARRAY_MAX, options, length);
 
-    return setCheck(this, CODE_ARRAY_MAX, options, length, (input, options) => {
+    return addConstraint(this, CODE_ARRAY_MAX, length, (input, options) => {
       if (input.length > length) {
         return issueFactory(input, options);
       }

--- a/src/main/shapes/BigIntShape.ts
+++ b/src/main/shapes/BigIntShape.ts
@@ -1,5 +1,5 @@
 import { ApplyResult, ValueType } from './Shape';
-import { Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory, isArray, ok } from '../utils';
 import {
   CODE_TYPE,
@@ -25,7 +25,7 @@ export class BigIntShape extends CoercibleShape<bigint> {
    *
    * @param options The type constraint options or the type issue message.
    */
-  constructor(options?: TypeConstraintOptions | Message) {
+  constructor(options?: ConstraintOptions | Message) {
     super();
 
     this._typeIssueFactory = createIssueFactory(CODE_TYPE, MESSAGE_BIGINT_TYPE, options, TYPE_BIGINT);

--- a/src/main/shapes/BooleanShape.ts
+++ b/src/main/shapes/BooleanShape.ts
@@ -1,5 +1,5 @@
 import { ApplyResult, ValueType } from './Shape';
-import { Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory, isArray, ok } from '../utils';
 import {
   CODE_TYPE,
@@ -24,7 +24,7 @@ export class BooleanShape extends CoercibleShape<boolean> {
    *
    * @param options The type constraint options or the type issue message.
    */
-  constructor(options?: TypeConstraintOptions | Message) {
+  constructor(options?: ConstraintOptions | Message) {
     super();
 
     this._typeIssueFactory = createIssueFactory(CODE_TYPE, MESSAGE_BOOLEAN_TYPE, options, TYPE_BOOLEAN);

--- a/src/main/shapes/ConstShape.ts
+++ b/src/main/shapes/ConstShape.ts
@@ -1,5 +1,5 @@
 import { ApplyResult, Shape, ValueType } from './Shape';
-import { Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory, getValueType } from '../utils';
 import { CODE_CONST, MESSAGE_CONST } from '../constants';
 
@@ -19,7 +19,7 @@ export class ConstShape<T> extends Shape<T> {
    * @param options The type constraint options or an issue message.
    * @template T Allowed values.
    */
-  constructor(readonly value: T, options?: TypeConstraintOptions | Message) {
+  constructor(readonly value: T, options?: ConstraintOptions | Message) {
     super();
 
     this._typePredicate = value !== value ? Number.isNaN : input => value === input;

--- a/src/main/shapes/DateShape.ts
+++ b/src/main/shapes/DateShape.ts
@@ -1,5 +1,5 @@
 import { ApplyResult, ValueType } from './Shape';
-import { Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory, isArray, isDate, ok } from '../utils';
 import { CODE_TYPE, MESSAGE_DATE_TYPE, TYPE_ARRAY, TYPE_DATE, TYPE_NUMBER, TYPE_STRING } from '../constants';
 import { CoercibleShape } from './CoercibleShape';
@@ -15,7 +15,7 @@ export class DateShape extends CoercibleShape<Date> {
    *
    * @param options The type constraint options or the type issue message.
    */
-  constructor(options?: TypeConstraintOptions | Message) {
+  constructor(options?: ConstraintOptions | Message) {
     super();
 
     this._typeIssueFactory = createIssueFactory(CODE_TYPE, MESSAGE_DATE_TYPE, options, TYPE_DATE);

--- a/src/main/shapes/EnumShape.ts
+++ b/src/main/shapes/EnumShape.ts
@@ -1,5 +1,5 @@
 import { ApplyResult, ReadonlyDict, ValueType } from './Shape';
-import { Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory, getValueType, isArray, ok, unique } from '../utils';
 import { CODE_ENUM, MESSAGE_ENUM, TYPE_ARRAY, TYPE_STRING } from '../constants';
 import { CoercibleShape } from './CoercibleShape';
@@ -35,7 +35,7 @@ export class EnumShape<T> extends CoercibleShape<T> {
      * The list of allowed values, a const key-value mapping, or an enum object.
      */
     readonly source: readonly T[] | ReadonlyDict<T>,
-    options?: TypeConstraintOptions | Message
+    options?: ConstraintOptions | Message
   ) {
     super();
 

--- a/src/main/shapes/InstanceShape.ts
+++ b/src/main/shapes/InstanceShape.ts
@@ -1,5 +1,5 @@
 import { ApplyResult, Shape, ValueType } from './Shape';
-import { Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory } from '../utils';
 import { CODE_INSTANCE, MESSAGE_INSTANCE, TYPE_ARRAY, TYPE_OBJECT } from '../constants';
 
@@ -18,7 +18,7 @@ export class InstanceShape<C extends new (...args: any[]) => any> extends Shape<
    * @param options The type constraint options or the type issue message.
    * @template C The class constructor.
    */
-  constructor(readonly ctor: C, options?: TypeConstraintOptions | Message) {
+  constructor(readonly ctor: C, options?: ConstraintOptions | Message) {
     super();
 
     this._typeIssueFactory = createIssueFactory(CODE_INSTANCE, MESSAGE_INSTANCE, options, ctor);

--- a/src/main/shapes/IntersectionShape.ts
+++ b/src/main/shapes/IntersectionShape.ts
@@ -1,6 +1,6 @@
 import { AnyShape, ApplyResult, Shape, ValueType } from './Shape';
 import { createIssueFactory, getValueType, isArray, isAsyncShapes, isEqual, ok } from '../utils';
-import { Issue, Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
 import { CODE_INTERSECTION, MESSAGE_INTERSECTION, TYPE_ARRAY, TYPE_DATE, TYPE_NEVER, TYPE_OBJECT } from '../constants';
 
 export type ToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
@@ -11,7 +11,7 @@ export class IntersectionShape<U extends readonly AnyShape[]> extends Shape<
 > {
   protected _typeIssueFactory;
 
-  constructor(readonly shapes: U, options?: TypeConstraintOptions | Message) {
+  constructor(readonly shapes: U, options?: ConstraintOptions | Message) {
     super();
 
     this._typeIssueFactory = createIssueFactory(CODE_INTERSECTION, MESSAGE_INTERSECTION, options, undefined);

--- a/src/main/shapes/JSONShape.ts
+++ b/src/main/shapes/JSONShape.ts
@@ -1,7 +1,7 @@
 import { ApplyResult, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { cloneObject, createIssueFactory, ok } from '../utils';
-import { CODE_JSON, CODE_TYPE, MESSAGE_STRING_TYPE, TYPE_STRING } from '../constants';
+import { CODE_JSON, CODE_TYPE, MESSAGE_JSON, MESSAGE_STRING_TYPE, TYPE_STRING } from '../constants';
 
 /**
  * The shape of a value deserialized from a JSON string.
@@ -20,7 +20,7 @@ export class JSONShape extends Shape<string, any> {
     super();
 
     this._typeIssueFactory = createIssueFactory(CODE_TYPE, MESSAGE_STRING_TYPE, options, TYPE_STRING);
-    this._jsonIssueFactory = createIssueFactory(CODE_JSON, param => param, options);
+    this._jsonIssueFactory = createIssueFactory(CODE_JSON, MESSAGE_JSON, options);
   }
 
   /**

--- a/src/main/shapes/JSONShape.ts
+++ b/src/main/shapes/JSONShape.ts
@@ -1,5 +1,5 @@
 import { ApplyResult, Shape, ValueType } from './Shape';
-import { Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { cloneObject, createIssueFactory, ok } from '../utils';
 import { CODE_JSON, CODE_TYPE, MESSAGE_STRING_TYPE, TYPE_STRING } from '../constants';
 
@@ -16,7 +16,7 @@ export class JSONShape extends Shape<string, any> {
    *
    * @param options The type constraint options or the type issue message.
    */
-  constructor(options?: TypeConstraintOptions | Message) {
+  constructor(options?: ConstraintOptions | Message) {
     super();
 
     this._typeIssueFactory = createIssueFactory(CODE_TYPE, MESSAGE_STRING_TYPE, options, TYPE_STRING);

--- a/src/main/shapes/MapShape.ts
+++ b/src/main/shapes/MapShape.ts
@@ -1,5 +1,5 @@
 import { AnyShape, ApplyResult, ValueType } from './Shape';
-import { Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import {
   concatIssues,
   createIssueFactory,
@@ -43,7 +43,7 @@ export class MapShape<K extends AnyShape, V extends AnyShape> extends CoercibleS
      * The value shape.
      */
     readonly valueShape: V,
-    options?: TypeConstraintOptions | Message
+    options?: ConstraintOptions | Message
   ) {
     super();
 

--- a/src/main/shapes/NeverShape.ts
+++ b/src/main/shapes/NeverShape.ts
@@ -1,5 +1,5 @@
 import { ApplyResult, Shape, ValueType } from './Shape';
-import { Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory } from '../utils';
 import { CODE_TYPE, MESSAGE_NEVER_TYPE, TYPE_NEVER } from '../constants';
 
@@ -14,7 +14,7 @@ export class NeverShape extends Shape<never> {
    *
    * @param options The type constraint options or the type issue message.
    */
-  constructor(options?: TypeConstraintOptions | Message) {
+  constructor(options?: ConstraintOptions | Message) {
     super();
 
     this._typeIssueFactory = createIssueFactory(CODE_TYPE, MESSAGE_NEVER_TYPE, options, TYPE_NEVER);

--- a/src/main/shapes/NumberShape.ts
+++ b/src/main/shapes/NumberShape.ts
@@ -96,7 +96,7 @@ export class NumberShape extends CoercibleShape<number> {
   gt(value: number, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_NUMBER_GT, MESSAGE_NUMBER_GT, options, value);
 
-    return addConstraint(this.deleteCheck(CODE_NUMBER_GTE), CODE_NUMBER_GT, value, (input, options) => {
+    return addConstraint(this, CODE_NUMBER_GT, value, (input, options) => {
       if (input <= value) {
         return issueFactory(input, options);
       }
@@ -113,7 +113,7 @@ export class NumberShape extends CoercibleShape<number> {
   lt(value: number, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_NUMBER_LT, MESSAGE_NUMBER_LT, options, value);
 
-    return addConstraint(this.deleteCheck(CODE_NUMBER_LTE), CODE_NUMBER_LT, value, (input, options) => {
+    return addConstraint(this, CODE_NUMBER_LT, value, (input, options) => {
       if (input >= value) {
         return issueFactory(input, options);
       }
@@ -130,7 +130,7 @@ export class NumberShape extends CoercibleShape<number> {
   gte(value: number, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_NUMBER_GTE, MESSAGE_NUMBER_GTE, options, value);
 
-    return addConstraint(this.deleteCheck(CODE_NUMBER_GT), CODE_NUMBER_GTE, value, (input, options) => {
+    return addConstraint(this, CODE_NUMBER_GTE, value, (input, options) => {
       if (input < value) {
         return issueFactory(input, options);
       }
@@ -147,7 +147,7 @@ export class NumberShape extends CoercibleShape<number> {
   lte(value: number, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_NUMBER_LTE, MESSAGE_NUMBER_LTE, options, value);
 
-    return addConstraint(this.deleteCheck(CODE_NUMBER_LT), CODE_NUMBER_LTE, value, (input, options) => {
+    return addConstraint(this, CODE_NUMBER_LTE, value, (input, options) => {
       if (input > value) {
         return issueFactory(input, options);
       }

--- a/src/main/shapes/NumberShape.ts
+++ b/src/main/shapes/NumberShape.ts
@@ -1,6 +1,6 @@
 import { ApplyResult, Shape, ValueType } from './Shape';
-import { ConstraintOptions, Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
-import { cloneObject, createIssueFactory, isArray, isNumber, ok, setCheck } from '../utils';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
+import { addConstraint, cloneObject, createIssueFactory, isArray, isNumber, ok } from '../utils';
 import {
   CODE_NUMBER_FINITE,
   CODE_NUMBER_GT,
@@ -40,7 +40,7 @@ export class NumberShape extends CoercibleShape<number> {
    *
    * @param options The type constraint options or the type issue message.
    */
-  constructor(options?: TypeConstraintOptions | Message) {
+  constructor(options?: ConstraintOptions | Message) {
     super();
 
     this._typeIssueFactory = createIssueFactory(CODE_TYPE, MESSAGE_NUMBER_TYPE, options, TYPE_NUMBER);
@@ -96,7 +96,7 @@ export class NumberShape extends CoercibleShape<number> {
   gt(value: number, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_NUMBER_GT, MESSAGE_NUMBER_GT, options, value);
 
-    return setCheck(this.deleteCheck(CODE_NUMBER_GTE), CODE_NUMBER_GT, options, value, (input, options) => {
+    return addConstraint(this.deleteCheck(CODE_NUMBER_GTE), CODE_NUMBER_GT, value, (input, options) => {
       if (input <= value) {
         return issueFactory(input, options);
       }
@@ -113,7 +113,7 @@ export class NumberShape extends CoercibleShape<number> {
   lt(value: number, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_NUMBER_LT, MESSAGE_NUMBER_LT, options, value);
 
-    return setCheck(this.deleteCheck(CODE_NUMBER_LTE), CODE_NUMBER_LT, options, value, (input, options) => {
+    return addConstraint(this.deleteCheck(CODE_NUMBER_LTE), CODE_NUMBER_LT, value, (input, options) => {
       if (input >= value) {
         return issueFactory(input, options);
       }
@@ -130,7 +130,7 @@ export class NumberShape extends CoercibleShape<number> {
   gte(value: number, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_NUMBER_GTE, MESSAGE_NUMBER_GTE, options, value);
 
-    return setCheck(this.deleteCheck(CODE_NUMBER_GT), CODE_NUMBER_GTE, options, value, (input, options) => {
+    return addConstraint(this.deleteCheck(CODE_NUMBER_GT), CODE_NUMBER_GTE, value, (input, options) => {
       if (input < value) {
         return issueFactory(input, options);
       }
@@ -147,7 +147,7 @@ export class NumberShape extends CoercibleShape<number> {
   lte(value: number, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_NUMBER_LTE, MESSAGE_NUMBER_LTE, options, value);
 
-    return setCheck(this.deleteCheck(CODE_NUMBER_LT), CODE_NUMBER_LTE, options, value, (input, options) => {
+    return addConstraint(this.deleteCheck(CODE_NUMBER_LT), CODE_NUMBER_LTE, value, (input, options) => {
       if (input > value) {
         return issueFactory(input, options);
       }
@@ -164,7 +164,7 @@ export class NumberShape extends CoercibleShape<number> {
   multipleOf(value: number, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_NUMBER_MULTIPLE_OF, MESSAGE_NUMBER_MULTIPLE_OF, options, value);
 
-    return setCheck(this, CODE_NUMBER_MULTIPLE_OF, options, value, (input, options) => {
+    return addConstraint(this, CODE_NUMBER_MULTIPLE_OF, value, (input, options) => {
       if (!isMultipleOf(input, value)) {
         return issueFactory(input, options);
       }

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -1,4 +1,4 @@
-import { Issue, Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
 import { CODE_TYPE, CODE_UNKNOWN_KEYS, MESSAGE_OBJECT_TYPE, MESSAGE_UNKNOWN_KEYS, TYPE_OBJECT } from '../constants';
 import {
   Bits,
@@ -95,7 +95,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
      * [a string index signature](https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures).
      */
     readonly restShape: R,
-    options?: TypeConstraintOptions | Message,
+    options?: ConstraintOptions | Message,
     keysMode: KeysMode = 'preserved'
   ) {
     super();
@@ -264,7 +264,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
    * @param options The constraint options or an issue message.
    * @returns The new object shape.
    */
-  exact(options?: TypeConstraintOptions | Message): ObjectShape<P, null> {
+  exact(options?: ConstraintOptions | Message): ObjectShape<P, null> {
     const shape = new ObjectShape(this.shapes, null, this._options, 'exact');
 
     shape._exactIssueFactory = createIssueFactory(CODE_UNKNOWN_KEYS, MESSAGE_UNKNOWN_KEYS, options);

--- a/src/main/shapes/PromiseShape.ts
+++ b/src/main/shapes/PromiseShape.ts
@@ -1,5 +1,5 @@
 import { AnyShape, ApplyResult, ValueType } from './Shape';
-import { Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory, isArray, isEqual, ok } from '../utils';
 import { CODE_TYPE, ERROR_REQUIRES_ASYNC, MESSAGE_PROMISE_TYPE, TYPE_OBJECT, TYPE_PROMISE } from '../constants';
 import { CoercibleShape } from './CoercibleShape';
@@ -19,7 +19,7 @@ export class PromiseShape<S extends AnyShape> extends CoercibleShape<Promise<S['
    * @param options The type constraint options or the type issue message.
    * @template S The shape of the resolved value.
    */
-  constructor(readonly shape: S, options?: TypeConstraintOptions | Message) {
+  constructor(readonly shape: S, options?: ConstraintOptions | Message) {
     super();
 
     this._typeIssueFactory = createIssueFactory(CODE_TYPE, MESSAGE_PROMISE_TYPE, options, TYPE_PROMISE);

--- a/src/main/shapes/RecordShape.ts
+++ b/src/main/shapes/RecordShape.ts
@@ -1,5 +1,5 @@
 import { AnyShape, ApplyResult, Shape, ValueType } from './Shape';
-import { Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import {
   cloneObjectEnumerableKeys,
   concatIssues,
@@ -49,7 +49,7 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
      * The value shape.
      */
     readonly valueShape: V,
-    options?: TypeConstraintOptions | Message
+    options?: ConstraintOptions | Message
   ) {
     super();
 

--- a/src/main/shapes/SetShape.ts
+++ b/src/main/shapes/SetShape.ts
@@ -1,13 +1,13 @@
 import { AnyShape, ApplyResult, ValueType } from './Shape';
-import { ConstraintOptions, Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import {
+  addConstraint,
   concatIssues,
   createIssueFactory,
   isArray,
   isEqual,
   isIterable,
   ok,
-  setCheck,
   toArrayIndex,
   unshiftPath,
 } from '../utils';
@@ -45,7 +45,7 @@ export class SetShape<S extends AnyShape> extends CoercibleShape<Set<S['input']>
      * The value shape
      */
     readonly shape: S,
-    options?: TypeConstraintOptions | Message
+    options?: ConstraintOptions | Message
   ) {
     super();
 
@@ -78,7 +78,7 @@ export class SetShape<S extends AnyShape> extends CoercibleShape<Set<S['input']>
   min(size: number, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_SET_MIN, MESSAGE_SET_MIN, options, size);
 
-    return setCheck(this, CODE_SET_MIN, options, size, (input, options) => {
+    return addConstraint(this, CODE_SET_MIN, size, (input, options) => {
       if (input.size < size) {
         return issueFactory(input, options);
       }
@@ -95,7 +95,7 @@ export class SetShape<S extends AnyShape> extends CoercibleShape<Set<S['input']>
   max(size: number, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_SET_MAX, MESSAGE_SET_MAX, options, size);
 
-    return setCheck(this, CODE_SET_MAX, options, size, (input, options) => {
+    return addConstraint(this, CODE_SET_MAX, size, (input, options) => {
       if (input.size > size) {
         return issueFactory(input, options);
       }

--- a/src/main/shapes/StringShape.ts
+++ b/src/main/shapes/StringShape.ts
@@ -1,6 +1,6 @@
 import { ApplyResult, ValueType } from './Shape';
-import { ConstraintOptions, Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
-import { createIssueFactory, isArray, isDate, ok, setCheck } from '../utils';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
+import { addConstraint, createIssueFactory, isArray, isDate, ok } from '../utils';
 import {
   CODE_STRING_MAX,
   CODE_STRING_MIN,
@@ -31,7 +31,7 @@ export class StringShape extends CoercibleShape<string> {
    *
    * @param options The type constraint options or the type issue message.
    */
-  constructor(options?: TypeConstraintOptions | Message) {
+  constructor(options?: ConstraintOptions | Message) {
     super();
 
     this._typeIssueFactory = createIssueFactory(CODE_TYPE, MESSAGE_STRING_TYPE, options, TYPE_STRING);
@@ -58,7 +58,7 @@ export class StringShape extends CoercibleShape<string> {
   min(length: number, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_STRING_MIN, MESSAGE_STRING_MIN, options, length);
 
-    return setCheck(this, CODE_STRING_MIN, options, length, (input, options) => {
+    return addConstraint(this, CODE_STRING_MIN, length, (input, options) => {
       if (input.length < length) {
         return issueFactory(input, options);
       }
@@ -75,7 +75,7 @@ export class StringShape extends CoercibleShape<string> {
   max(length: number, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_STRING_MAX, MESSAGE_STRING_MAX, options, length);
 
-    return setCheck(this, CODE_STRING_MAX, options, length, (input, options) => {
+    return addConstraint(this, CODE_STRING_MAX, length, (input, options) => {
       if (input.length > length) {
         return issueFactory(input, options);
       }
@@ -92,7 +92,7 @@ export class StringShape extends CoercibleShape<string> {
   regex(re: RegExp, options?: ConstraintOptions | Message): this {
     const issueFactory = createIssueFactory(CODE_STRING_REGEX, MESSAGE_STRING_REGEX, options, re);
 
-    return setCheck(this, CODE_STRING_REGEX, options, re, (input, options) => {
+    return addConstraint(this, CODE_STRING_REGEX, re, (input, options) => {
       re.lastIndex = 0;
 
       if (!re.test(input)) {

--- a/src/main/shapes/SymbolShape.ts
+++ b/src/main/shapes/SymbolShape.ts
@@ -1,5 +1,5 @@
 import { ApplyResult, Shape, ValueType } from './Shape';
-import { Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory } from '../utils';
 import { CODE_TYPE, MESSAGE_SYMBOL_TYPE, TYPE_SYMBOL } from '../constants';
 
@@ -14,7 +14,7 @@ export class SymbolShape extends Shape<symbol> {
    *
    * @param options The type constraint options or the type issue message.
    */
-  constructor(options?: TypeConstraintOptions | Message) {
+  constructor(options?: ConstraintOptions | Message) {
     super();
 
     this._typeIssueFactory = createIssueFactory(CODE_TYPE, MESSAGE_SYMBOL_TYPE, options, TYPE_SYMBOL);

--- a/src/main/shapes/UnionShape.ts
+++ b/src/main/shapes/UnionShape.ts
@@ -1,5 +1,5 @@
 import { AnyShape, ApplyResult, Shape, ValueType } from './Shape';
-import { Issue, Message, ParseOptions, TypeConstraintOptions } from '../shared-types';
+import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
 import { concatIssues, createIssueFactory, getValueType, isArray, isAsyncShapes, isObjectLike, unique } from '../utils';
 import { CODE_UNION, MESSAGE_UNION, TYPE_ANY, TYPE_NEVER } from '../constants';
 import { ObjectShape } from './ObjectShape';
@@ -30,7 +30,7 @@ export class UnionShape<U extends readonly AnyShape[]> extends Shape<U[number]['
      * The list of shapes that comprise a union.
      */
     readonly shapes: U,
-    options?: TypeConstraintOptions | Message
+    options?: ConstraintOptions | Message
   ) {
     super();
 

--- a/src/main/shared-types.ts
+++ b/src/main/shared-types.ts
@@ -126,21 +126,6 @@ export type MessageCallback = (param: any, code: any, input: any, meta: any, opt
 export type Message = MessageCallback | string;
 
 /**
- * Options that are applicable for the type constraint.
- */
-export interface TypeConstraintOptions {
-  /**
-   * The custom issue message.
-   */
-  message?: Message | Literal;
-
-  /**
-   * An arbitrary metadata that is added to an issue.
-   */
-  meta?: any;
-}
-
-/**
  * Options that are applicable for the built-in type-specific constraints.
  */
 export interface ConstraintOptions {
@@ -153,9 +138,11 @@ export interface ConstraintOptions {
    * An arbitrary metadata that is added to an issue.
    */
   meta?: any;
+}
 
+export interface RefineOptions extends ConstraintOptions {
   /**
-   * If `true` then the constraint would be executed even if the preceding check failed, otherwise the constraint is
+   * If `true` then the predicate would be executed even if the preceding check failed, otherwise the predicate is
    * ignored.
    */
   unsafe?: boolean;

--- a/src/main/shared-types.ts
+++ b/src/main/shared-types.ts
@@ -32,6 +32,11 @@ export type CheckCallback<T = any> = (
  */
 export interface Check {
   /**
+   * The check key, unique in the scope of the shape.
+   */
+  readonly key: any;
+
+  /**
    * The callback that validates the shape output and returns the list of issues or throws a {@linkcode Validation} error.
    */
   readonly callback: CheckCallback;

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,13 +1,4 @@
-import {
-  Check,
-  CheckCallback,
-  ConstraintOptions,
-  Issue,
-  Message,
-  MessageCallback,
-  Ok,
-  ParseOptions,
-} from './shared-types';
+import { Check, CheckCallback, ConstraintOptions, Issue, Message, Ok, ParseOptions } from './shared-types';
 import { AnyShape, ApplyChecksCallback, ReadonlyDict, Shape, ValueType } from './shapes/Shape';
 import { inflateIssue, ValidationError } from './ValidationError';
 import { TYPE_ARRAY, TYPE_DATE, TYPE_NULL } from './constants';
@@ -109,7 +100,7 @@ export function addConstraint<S extends Shape>(
  */
 export function createIssueFactory(
   code: string,
-  defaultMessage: MessageCallback | string,
+  defaultMessage: string,
   options: ConstraintOptions | Message | undefined,
   param: unknown
 ): (input: unknown, options: Readonly<ParseOptions>) => Issue[];
@@ -124,13 +115,13 @@ export function createIssueFactory(
  */
 export function createIssueFactory(
   code: string,
-  defaultMessage: MessageCallback | string,
+  defaultMessage: string,
   options: ConstraintOptions | Message | undefined
 ): (input: unknown, options: Readonly<ParseOptions>, param: unknown) => Issue[];
 
 export function createIssueFactory(
   code: string,
-  defaultMessage: MessageCallback | string,
+  defaultMessage: string,
   options: ConstraintOptions | Message | undefined,
   param?: any
 ): (input: unknown, options: Readonly<ParseOptions>, param: unknown) => Issue[] {

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -97,6 +97,20 @@ export function setCheck<S extends Shape>(
   param: unknown,
   cb: CheckCallback<S['output']>
 ): S {
+  return appendCheck(shape, key, options, param, true, cb);
+}
+
+/**
+ * The convenient shortcut to add built-in checks to shapes.
+ */
+export function appendCheck<S extends Shape>(
+  shape: S,
+  key: unknown,
+  options: ConstraintOptions | Message | undefined,
+  param: unknown,
+  unsafe: boolean,
+  cb: CheckCallback<S['output']>
+): S {
   return shape.check(cb, {
     key,
     unsafe: options !== null && typeof options === 'object' && options.unsafe,

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -7,7 +7,6 @@ import {
   MessageCallback,
   Ok,
   ParseOptions,
-  TypeConstraintOptions,
 } from './shared-types';
 import { AnyShape, ApplyChecksCallback, ReadonlyDict, Shape, ValueType } from './shapes/Shape';
 import { inflateIssue, ValidationError } from './ValidationError';
@@ -88,34 +87,15 @@ export function toArrayIndex(key: any): number {
 }
 
 /**
- * The convenient shortcut to add built-in checks to shapes.
+ * The shortcut to add built-in constraints to shapes.
  */
-export function setCheck<S extends Shape>(
+export function addConstraint<S extends Shape>(
   shape: S,
-  key: unknown,
-  options: ConstraintOptions | Message | undefined,
+  key: string,
   param: unknown,
   cb: CheckCallback<S['output']>
 ): S {
-  return appendCheck(shape, key, options, param, true, cb);
-}
-
-/**
- * The convenient shortcut to add built-in checks to shapes.
- */
-export function appendCheck<S extends Shape>(
-  shape: S,
-  key: unknown,
-  options: ConstraintOptions | Message | undefined,
-  param: unknown,
-  unsafe: boolean,
-  cb: CheckCallback<S['output']>
-): S {
-  return shape.check(cb, {
-    key,
-    unsafe: options !== null && typeof options === 'object' && options.unsafe,
-    param,
-  });
+  return shape.check(cb, { key, unsafe: true, param });
 }
 
 /**
@@ -128,9 +108,9 @@ export function appendCheck<S extends Shape>(
  * @returns The callback that takes an input and returns an array with a single issue.
  */
 export function createIssueFactory(
-  code: unknown,
+  code: string,
   defaultMessage: MessageCallback | string,
-  options: TypeConstraintOptions | Message | undefined,
+  options: ConstraintOptions | Message | undefined,
   param: unknown
 ): (input: unknown, options: Readonly<ParseOptions>) => Issue[];
 
@@ -143,15 +123,15 @@ export function createIssueFactory(
  * @returns The callback that takes an input and a param, and returns an array with a single issue.
  */
 export function createIssueFactory(
-  code: unknown,
-  defaultMessage: Message,
-  options: TypeConstraintOptions | Message | undefined
+  code: string,
+  defaultMessage: MessageCallback | string,
+  options: ConstraintOptions | Message | undefined
 ): (input: unknown, options: Readonly<ParseOptions>, param: unknown) => Issue[];
 
 export function createIssueFactory(
-  code: unknown,
-  defaultMessage: Message,
-  options: TypeConstraintOptions | Message | undefined,
+  code: string,
+  defaultMessage: MessageCallback | string,
+  options: ConstraintOptions | Message | undefined,
   param?: any
 ): (input: unknown, options: Readonly<ParseOptions>, param: unknown) => Issue[] {
   const paramKnown = arguments.length === 4;

--- a/src/test/dsl/any.test.ts
+++ b/src/test/dsl/any.test.ts
@@ -8,6 +8,6 @@ describe('any', () => {
   test('returns a shape with a refinement', () => {
     const cb = () => true;
 
-    expect(d.any(cb).getCheck(cb)).toEqual({ callback: expect.any(Function), unsafe: false, param: cb });
+    expect(d.any(cb).getCheck(cb)).toEqual({ key: cb, callback: expect.any(Function), unsafe: false, param: cb });
   });
 });

--- a/src/test/shapes/JSONShape.test.ts
+++ b/src/test/shapes/JSONShape.test.ts
@@ -21,7 +21,7 @@ describe('JSONShape', () => {
           code: CODE_JSON,
           path: [],
           input: 'aaa',
-          message: 'Unexpected token a in JSON at position 0',
+          message: 'Must be a JSON string: Unexpected token a in JSON at position 0',
           param: 'Unexpected token a in JSON at position 0',
         },
       ],

--- a/src/test/shapes/NumberShape.test.ts
+++ b/src/test/shapes/NumberShape.test.ts
@@ -158,14 +158,6 @@ describe('NumberShape', () => {
     });
   });
 
-  test('respects mutually exclusive checks', () => {
-    expect(new NumberShape().gt(0).gte(0).getCheck(CODE_NUMBER_GT)).toBe(undefined);
-    expect(new NumberShape().gte(0).gt(0).getCheck(CODE_NUMBER_GTE)).toBe(undefined);
-
-    expect(new NumberShape().lt(0).lte(0).getCheck(CODE_NUMBER_LT)).toBe(undefined);
-    expect(new NumberShape().lte(0).lt(0).getCheck(CODE_NUMBER_LTE)).toBe(undefined);
-  });
-
   test('allows NaN', () => {
     expect(new NumberShape().nan().try(NaN)).toEqual({ ok: true, value: NaN });
   });

--- a/src/test/shapes/NumberShape.test.ts
+++ b/src/test/shapes/NumberShape.test.ts
@@ -142,7 +142,7 @@ describe('NumberShape', () => {
   });
 
   test('raises multiple issues in verbose mode', () => {
-    expect(new NumberShape().gt(2).multipleOf(3, { unsafe: true }).try(1, { verbose: true })).toEqual({
+    expect(new NumberShape().gt(2).multipleOf(3).try(1, { verbose: true })).toEqual({
       ok: false,
       issues: [
         { code: CODE_NUMBER_GT, path: [], input: 1, param: 2, message: 'Must be greater than 2' },
@@ -152,7 +152,7 @@ describe('NumberShape', () => {
   });
 
   test('raises a single issue', () => {
-    expect(new NumberShape().gt(2).multipleOf(3, { unsafe: true }).try(1)).toEqual({
+    expect(new NumberShape().gt(2).multipleOf(3).try(1)).toEqual({
       ok: false,
       issues: [{ code: CODE_NUMBER_GT, path: [], input: 1, param: 2, message: 'Must be greater than 2' }],
     });

--- a/src/test/shapes/Shape.test.ts
+++ b/src/test/shapes/Shape.test.ts
@@ -15,7 +15,7 @@ describe('Shape', () => {
 
     expect(shape1).not.toBe(shape2);
     expect(shape1.getCheck(cb)).toBe(undefined);
-    expect(shape2.getCheck(cb)).toEqual({ callback: cb, unsafe: false });
+    expect(shape2.getCheck(cb)).toEqual({ key: cb, callback: cb, unsafe: false });
   });
 
   test('deletes a check', () => {

--- a/src/test/shapes/Shape.test.ts
+++ b/src/test/shapes/Shape.test.ts
@@ -184,6 +184,36 @@ describe('Shape', () => {
     expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa');
   });
 
+  test('does not invoke safe predicate if the preceding check failed', () => {
+    const cbMock = jest.fn().mockReturnValue(false);
+
+    const shape = new Shape().check(() => [{ code: 'xxx' }]).refine(cbMock);
+
+    expect(shape.try('aaa', { verbose: true })).toEqual({
+      ok: false,
+      issues: [{ code: 'xxx', path: [] }],
+    });
+
+    expect(cbMock).toHaveBeenCalledTimes(0);
+  });
+
+  test('invokes an unsafe predicate', () => {
+    const cbMock = jest.fn().mockReturnValue(false);
+
+    const shape = new Shape().check(() => [{ code: 'xxx' }]).refine(cbMock, { unsafe: true });
+
+    expect(shape.try('aaa', { verbose: true })).toEqual({
+      ok: false,
+      issues: [
+        { code: 'xxx', path: [] },
+        { code: CODE_PREDICATE, path: [], input: 'aaa', message: MESSAGE_PREDICATE, param: cbMock },
+      ],
+    });
+
+    expect(cbMock).toHaveBeenCalledTimes(1);
+    expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa');
+  });
+
   test('returns issues if predicate fails', () => {
     const cb = () => false;
 

--- a/src/test/shapes/StringShape.test.ts
+++ b/src/test/shapes/StringShape.test.ts
@@ -109,7 +109,7 @@ describe('StringShape', () => {
   });
 
   test('raises multiple issues in verbose mode', () => {
-    expect(new StringShape({}).min(3).regex(/aaaa/, { unsafe: true }).try('aa', { verbose: true })).toEqual({
+    expect(new StringShape({}).min(3).regex(/aaaa/).try('aa', { verbose: true })).toEqual({
       ok: false,
       issues: [
         {
@@ -133,7 +133,7 @@ describe('StringShape', () => {
   });
 
   test('raises a single issue', () => {
-    expect(new StringShape().min(3).regex(/aaaa/, { unsafe: true }).try('aa')).toEqual({
+    expect(new StringShape().min(3).regex(/aaaa/).try('aa')).toEqual({
       ok: false,
       issues: [
         {

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -250,7 +250,9 @@ describe('createApplyChecksCallback', () => {
     test('returns issues', () => {
       const cbMock = jest.fn(() => [{ code: 'xxx' }]);
 
-      const applyChecks = createApplyChecksCallback([{ callback: cbMock, param: undefined, unsafe: false }]);
+      const applyChecks = createApplyChecksCallback([
+        { key: cbMock, callback: cbMock, param: undefined, unsafe: false },
+      ]);
 
       expect(applyChecks!(111, null, { verbose: false, coerced: false })).toEqual([{ code: 'xxx', path: [] }]);
       expect(cbMock).toHaveBeenCalledTimes(1);
@@ -260,7 +262,9 @@ describe('createApplyChecksCallback', () => {
     test('unsafe check merges issues', () => {
       const cbMock = jest.fn(() => [{ code: 'xxx' }]);
 
-      const applyChecks = createApplyChecksCallback([{ callback: cbMock, param: undefined, unsafe: true }]);
+      const applyChecks = createApplyChecksCallback([
+        { key: cbMock, callback: cbMock, param: undefined, unsafe: true },
+      ]);
 
       const issues: Issue[] = [];
 
@@ -273,7 +277,9 @@ describe('createApplyChecksCallback', () => {
     test('safe check is not called when issues present', () => {
       const cbMock = jest.fn(() => [{ code: 'xxx' }]);
 
-      const applyChecks = createApplyChecksCallback([{ callback: cbMock, param: undefined, unsafe: false }]);
+      const applyChecks = createApplyChecksCallback([
+        { key: cbMock, callback: cbMock, param: undefined, unsafe: false },
+      ]);
 
       const issues: Issue[] = [];
 
@@ -287,7 +293,9 @@ describe('createApplyChecksCallback', () => {
         throw new Error('expected');
       });
 
-      const applyChecks = createApplyChecksCallback([{ callback: cbMock, param: undefined, unsafe: false }]);
+      const applyChecks = createApplyChecksCallback([
+        { key: cbMock, callback: cbMock, param: undefined, unsafe: false },
+      ]);
 
       expect(() => applyChecks!(111, null, {})).toThrow(new Error('expected'));
     });
@@ -297,7 +305,9 @@ describe('createApplyChecksCallback', () => {
         throw new ValidationError([{ code: 'xxx' }]);
       });
 
-      const applyChecks = createApplyChecksCallback([{ callback: cbMock, param: undefined, unsafe: false }]);
+      const applyChecks = createApplyChecksCallback([
+        { key: cbMock, callback: cbMock, param: undefined, unsafe: false },
+      ]);
 
       expect(applyChecks!(111, null, { verbose: false, coerced: false })).toEqual([{ code: 'xxx', path: [] }]);
     });
@@ -311,10 +321,10 @@ describe('createApplyChecksCallback', () => {
       const cbMock4 = jest.fn(() => [{ code: 'DDD' }]);
 
       const applyChecks = createApplyChecksCallback([
-        { callback: cbMock1, param: undefined, unsafe: true },
-        { callback: cbMock2, param: undefined, unsafe: true },
-        { callback: cbMock3, param: undefined, unsafe: true },
-        { callback: cbMock4, param: undefined, unsafe: true },
+        { key: cbMock1, callback: cbMock1, param: undefined, unsafe: true },
+        { key: cbMock2, callback: cbMock2, param: undefined, unsafe: true },
+        { key: cbMock3, callback: cbMock3, param: undefined, unsafe: true },
+        { key: cbMock4, callback: cbMock4, param: undefined, unsafe: true },
       ]);
 
       expect(applyChecks!(111, null, { verbose: false, coerced: false })).toEqual([{ code: 'BBB', path: [] }]);
@@ -333,10 +343,10 @@ describe('createApplyChecksCallback', () => {
       const cbMock4 = jest.fn(() => [{ code: 'DDD' }]);
 
       const applyChecks = createApplyChecksCallback([
-        { callback: cbMock1, param: undefined, unsafe: true },
-        { callback: cbMock2, param: undefined, unsafe: true },
-        { callback: cbMock3, param: undefined, unsafe: true },
-        { callback: cbMock4, param: undefined, unsafe: true },
+        { key: cbMock1, callback: cbMock1, param: undefined, unsafe: true },
+        { key: cbMock2, callback: cbMock2, param: undefined, unsafe: true },
+        { key: cbMock3, callback: cbMock3, param: undefined, unsafe: true },
+        { key: cbMock4, callback: cbMock4, param: undefined, unsafe: true },
       ]);
 
       expect(applyChecks!(111, null, { verbose: true })).toEqual([
@@ -361,10 +371,10 @@ describe('createApplyChecksCallback', () => {
       const cbMock4 = jest.fn(() => [{ code: 'DDD' }]);
 
       const applyChecks = createApplyChecksCallback([
-        { callback: cbMock1, param: undefined, unsafe: false },
-        { callback: cbMock2, param: undefined, unsafe: true },
-        { callback: cbMock3, param: undefined, unsafe: false },
-        { callback: cbMock4, param: undefined, unsafe: true },
+        { key: cbMock1, callback: cbMock1, param: undefined, unsafe: false },
+        { key: cbMock2, callback: cbMock2, param: undefined, unsafe: true },
+        { key: cbMock3, callback: cbMock3, param: undefined, unsafe: false },
+        { key: cbMock4, callback: cbMock4, param: undefined, unsafe: true },
       ]);
 
       expect(applyChecks!(111, null, { verbose: true })).toEqual([


### PR DESCRIPTION
- Checks are stored in an array;
- All built-in checks (aka constraints) are now always unsafe;
- Removed `TypeConstraintOptions` in favor of `ConstraintOptions`;
- Removed `createIssueFactory` export.