### PR TITLE
Preserve unsafe checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,20 +549,21 @@ checks failed. Consider an object with a custom check:
 
 ```ts
 const userShape = d.object({
-  age: d.string(),
+  age: d.number(),
   yearsOfExperience: d.number()
 }).check(value => {
-  if (value.yearsOfExperience > value.age) {
+  if (value.age < value.yearsOfExperience) {
     return { code: 'inconsistentAge' };
   }
 });
+// ⮕ Shape<{ age: number, yearsOfExperience: number }>
 ```
 
 The check callback relies on `value` to be an object with the valid set of properties. So if any issues are detected in
 the input object the check won't be called:
 
 ```ts
-// Check isn't called since yearsOfExperience is missing
+// Check isn't called since yearsOfExperience isn't a number
 nameShape.parse({ age: 18 });
 ```
 

--- a/src/main/shapes/ArrayShape.ts
+++ b/src/main/shapes/ArrayShape.ts
@@ -3,6 +3,7 @@ import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import {
   addConstraint,
   concatIssues,
+  copyUnsafeChecks,
   createIssueFactory,
   isArray,
   isAsyncShapes,
@@ -114,7 +115,7 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
    * @template T The shape of rest elements.
    */
   rest<T extends AnyShape | null>(restShape: T): ArrayShape<U, T> {
-    return new ArrayShape(this.shapes, restShape, this._options);
+    return copyUnsafeChecks(this, new ArrayShape(this.shapes, restShape, this._options));
   }
 
   /**
@@ -167,7 +168,7 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
 
     const restShape = this.restShape !== null ? toDeepPartialShape(this.restShape).optional() : null;
 
-    return new ArrayShape<any, any>(shapes, restShape, this._options);
+    return copyUnsafeChecks(this, new ArrayShape<any, any>(shapes, restShape, this._options));
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/IntersectionShape.ts
+++ b/src/main/shapes/IntersectionShape.ts
@@ -1,5 +1,6 @@
 import { AnyShape, ApplyResult, DeepPartialProtocol, DeepPartialShape, Shape, ValueType } from './Shape';
 import {
+  copyUnsafeChecks,
   createIssueFactory,
   getValueType,
   isArray,
@@ -33,7 +34,7 @@ export class IntersectionShape<U extends readonly AnyShape[]>
   }
 
   deepPartial(): DeepPartialIntersectionShape<U> {
-    return new IntersectionShape<any>(this.shapes.map(toDeepPartialShape), this._options);
+    return copyUnsafeChecks(this, new IntersectionShape<any>(this.shapes.map(toDeepPartialShape), this._options));
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/IntersectionShape.ts
+++ b/src/main/shapes/IntersectionShape.ts
@@ -33,6 +33,29 @@ export class IntersectionShape<U extends readonly AnyShape[]>
     this._typeIssueFactory = createIssueFactory(CODE_INTERSECTION, MESSAGE_INTERSECTION, options, undefined);
   }
 
+  at(key: unknown): AnyShape | null {
+    const { shapes } = this;
+
+    if (shapes.length === 0) {
+      return null;
+    }
+    if (shapes.length === 1) {
+      return shapes[0].at(key);
+    }
+
+    const valueShapes = [];
+
+    for (const shape of shapes) {
+      const valueShape = shape.at(key);
+
+      if (valueShape === null) {
+        return null;
+      }
+      valueShapes.push(valueShape);
+    }
+    return new IntersectionShape(valueShapes);
+  }
+
   deepPartial(): DeepPartialIntersectionShape<U> {
     return copyUnsafeChecks(this, new IntersectionShape<any>(this.shapes.map(toDeepPartialShape), this._options));
   }

--- a/src/main/shapes/LazyShape.ts
+++ b/src/main/shapes/LazyShape.ts
@@ -1,6 +1,6 @@
 import { AnyShape, ApplyResult, DeepPartialProtocol, DeepPartialShape, Shape, ValueType } from './Shape';
 import { ParseOptions } from '../shared-types';
-import { isArray, returnArray, returnFalse, toDeepPartialShape } from '../utils';
+import { copyUnsafeChecks, isArray, returnArray, returnFalse, toDeepPartialShape } from '../utils';
 import { ERROR_SHAPE_EXPECTED } from '../constants';
 
 /**
@@ -44,7 +44,7 @@ export class LazyShape<S extends AnyShape>
   deepPartial(): LazyShape<DeepPartialShape<S>> {
     const { _shapeProvider } = this;
 
-    return new LazyShape(() => toDeepPartialShape(_shapeProvider()));
+    return copyUnsafeChecks(this, new LazyShape(() => toDeepPartialShape(_shapeProvider())));
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/MapShape.ts
+++ b/src/main/shapes/MapShape.ts
@@ -9,6 +9,7 @@ import {
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import {
   concatIssues,
+  copyUnsafeChecks,
   createIssueFactory,
   isArray,
   isEqual,
@@ -65,11 +66,10 @@ export class MapShape<K extends AnyShape, V extends AnyShape>
   }
 
   deepPartial(): MapShape<DeepPartialShape<K>, OptionalDeepPartialShape<V>> {
-    return new MapShape<any, any>(
-      toDeepPartialShape(this.keyShape),
-      toDeepPartialShape(this.valueShape).optional(),
-      this._options
-    );
+    const keyShape = toDeepPartialShape(this.keyShape);
+    const valueShape = toDeepPartialShape(this.valueShape).optional();
+
+    return copyUnsafeChecks(this, new MapShape<any, any>(keyShape, valueShape, this._options));
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -6,6 +6,7 @@ import {
   cloneObjectEnumerableKeys,
   cloneObjectKnownKeys,
   concatIssues,
+  copyUnsafeChecks,
   createIssueFactory,
   Dict,
   enableBitAt,
@@ -162,7 +163,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
   extend(shape: ObjectShape<any, any> | ReadonlyDict) {
     const shapes = Object.assign({}, this.shapes, shape instanceof ObjectShape ? shape.shapes : shape);
 
-    return new ObjectShape(shapes, this.restShape, this._options, this.keysMode);
+    return copyUnsafeChecks(this, new ObjectShape(shapes, this.restShape, this._options, this.keysMode));
   }
 
   /**
@@ -182,7 +183,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
         shapes[key] = this.shapes[key];
       }
     }
-    return new ObjectShape<any, any>(shapes, this.restShape, this._options, this.keysMode);
+    return copyUnsafeChecks(this, new ObjectShape<any, any>(shapes, this.restShape, this._options, this.keysMode));
   }
 
   /**
@@ -202,7 +203,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
         shapes[key] = this.shapes[key];
       }
     }
-    return new ObjectShape<any, any>(shapes, this.restShape, this._options, this.keysMode);
+    return copyUnsafeChecks(this, new ObjectShape<any, any>(shapes, this.restShape, this._options, this.keysMode));
   }
 
   /**
@@ -231,7 +232,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
     for (const key in this.shapes) {
       shapes[key] = keys === undefined || keys.includes(key) ? this.shapes[key].optional() : this.shapes[key];
     }
-    return new ObjectShape<any, any>(shapes, this.restShape, this._options, this.keysMode);
+    return copyUnsafeChecks(this, new ObjectShape<any, any>(shapes, this.restShape, this._options, this.keysMode));
   }
 
   deepPartial(): DeepPartialObjectShape<P, R> {
@@ -243,7 +244,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
 
     const restShape = this.restShape !== null ? toDeepPartialShape(this.restShape).optional() : null;
 
-    return new ObjectShape<any, any>(shapes, restShape, this._options, this.keysMode);
+    return copyUnsafeChecks(this, new ObjectShape<any, any>(shapes, restShape, this._options, this.keysMode));
   }
 
   /**
@@ -272,7 +273,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
     for (const key in this.shapes) {
       shapes[key] = keys === undefined || keys.includes(key) ? this.shapes[key].nonOptional() : this.shapes[key];
     }
-    return new ObjectShape<any, any>(shapes, this.restShape, this._options, this.keysMode);
+    return copyUnsafeChecks(this, new ObjectShape<any, any>(shapes, this.restShape, this._options, this.keysMode));
   }
 
   /**
@@ -288,7 +289,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
 
     shape._exactIssueFactory = createIssueFactory(CODE_UNKNOWN_KEYS, MESSAGE_UNKNOWN_KEYS, options);
 
-    return shape;
+    return copyUnsafeChecks(this, shape);
   }
 
   /**
@@ -299,7 +300,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
    * @returns The new object shape.
    */
   strip(): ObjectShape<P, null> {
-    return new ObjectShape(this.shapes, null, this._options, 'stripped');
+    return copyUnsafeChecks(this, new ObjectShape(this.shapes, null, this._options, 'stripped'));
   }
 
   /**
@@ -310,7 +311,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
    * @returns The new object shape.
    */
   preserve(): ObjectShape<P, null> {
-    return new ObjectShape(this.shapes, null, this._options);
+    return copyUnsafeChecks(this, new ObjectShape(this.shapes, null, this._options));
   }
 
   /**
@@ -323,7 +324,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
    * @template T The index signature shape.
    */
   rest<T extends AnyShape>(restShape: T): ObjectShape<P, T> {
-    return new ObjectShape(this.shapes, restShape, this._options);
+    return copyUnsafeChecks(this, new ObjectShape(this.shapes, restShape, this._options));
   }
 
   /**

--- a/src/main/shapes/PromiseShape.ts
+++ b/src/main/shapes/PromiseShape.ts
@@ -1,6 +1,6 @@
 import { AnyShape, ApplyResult, DeepPartialProtocol, OptionalDeepPartialShape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
-import { createIssueFactory, isArray, isEqual, ok, toDeepPartialShape } from '../utils';
+import { copyUnsafeChecks, createIssueFactory, isArray, isEqual, ok, toDeepPartialShape } from '../utils';
 import { CODE_TYPE, ERROR_REQUIRES_ASYNC, MESSAGE_PROMISE_TYPE, TYPE_OBJECT, TYPE_PROMISE } from '../constants';
 import { CoercibleShape } from './CoercibleShape';
 
@@ -31,7 +31,7 @@ export class PromiseShape<S extends AnyShape>
   }
 
   deepPartial(): PromiseShape<OptionalDeepPartialShape<S>> {
-    return new PromiseShape<any>(toDeepPartialShape(this.shape).optional(), this._options);
+    return copyUnsafeChecks(this, new PromiseShape<any>(toDeepPartialShape(this.shape).optional(), this._options));
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/RecordShape.ts
+++ b/src/main/shapes/RecordShape.ts
@@ -3,6 +3,7 @@ import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import {
   cloneObjectEnumerableKeys,
   concatIssues,
+  copyUnsafeChecks,
   createIssueFactory,
   isArray,
   isEqual,
@@ -64,7 +65,9 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
   }
 
   deepPartial(): RecordShape<K, OptionalDeepPartialShape<V>> {
-    return new RecordShape<any, any>(this.keyShape, toDeepPartialShape(this.valueShape).optional(), this._options);
+    const valueShape = toDeepPartialShape(this.valueShape).optional();
+
+    return copyUnsafeChecks(this, new RecordShape<any, any>(this.keyShape, valueShape, this._options));
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/SetShape.ts
+++ b/src/main/shapes/SetShape.ts
@@ -3,6 +3,7 @@ import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import {
   addConstraint,
   concatIssues,
+  copyUnsafeChecks,
   createIssueFactory,
   isArray,
   isEqual,
@@ -107,7 +108,7 @@ export class SetShape<S extends AnyShape>
   }
 
   deepPartial(): SetShape<OptionalDeepPartialShape<S>> {
-    return new SetShape<any>(toDeepPartialShape(this.shape).optional(), this._options);
+    return copyUnsafeChecks(this, new SetShape<any>(toDeepPartialShape(this.shape).optional(), this._options));
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/Shape.ts
+++ b/src/main/shapes/Shape.ts
@@ -187,9 +187,9 @@ export class Shape<I = any, O = I> {
    * @returns The clone of the shape.
    */
   check(cb: CheckCallback<O>, options: CheckOptions = {}): this {
-    const { key = cb, unsafe = false, param } = options;
+    const { key = cb, param, unsafe = false } = options;
 
-    const check: Check = { key, callback: cb, unsafe, param };
+    const check: Check = { key, callback: cb, param, unsafe };
 
     return this._replaceChecks(
       this._checks !== null ? this._checks.filter(check => check.key !== key).concat(check) : [check]
@@ -262,7 +262,7 @@ export class Shape<I = any, O = I> {
 
     const unsafe = options !== null && typeof options === 'object' && options.unsafe;
 
-    return this.check(cb, { key: predicate, unsafe, param: predicate });
+    return this.check(cb, { key: predicate, param: predicate, unsafe });
   }
 
   /**

--- a/src/main/shapes/Shape.ts
+++ b/src/main/shapes/Shape.ts
@@ -14,6 +14,7 @@ import {
 import {
   captureIssues,
   cloneObject,
+  copyUnsafeChecks,
   createApplyChecksCallback,
   createIssueFactory,
   getValueType,
@@ -919,7 +920,10 @@ export class PipeShape<I extends AnyShape, O extends Shape<I['output'], any>>
   }
 
   deepPartial(): PipeShape<DeepPartialShape<I>, DeepPartialShape<O>> {
-    return new PipeShape(toDeepPartialShape(this.inputShape), toDeepPartialShape(this.outputShape));
+    return copyUnsafeChecks(
+      this,
+      new PipeShape(toDeepPartialShape(this.inputShape), toDeepPartialShape(this.outputShape))
+    );
   }
 
   protected _requiresAsync(): boolean {
@@ -1045,7 +1049,7 @@ export class ReplaceShape<S extends AnyShape, A, B>
   }
 
   deepPartial(): ReplaceShape<DeepPartialShape<S>, A, B> {
-    return new ReplaceShape(toDeepPartialShape(this.shape), this.inputValue, this.outputValue);
+    return copyUnsafeChecks(this, new ReplaceShape(toDeepPartialShape(this.shape), this.inputValue, this.outputValue));
   }
 
   protected _requiresAsync(): boolean {
@@ -1155,7 +1159,7 @@ export class ExcludeShape<S extends AnyShape, T>
   }
 
   deepPartial(): ExcludeShape<DeepPartialShape<S>, T> {
-    return new ExcludeShape(toDeepPartialShape(this.shape), this.excludedValue, this._options);
+    return copyUnsafeChecks(this, new ExcludeShape(toDeepPartialShape(this.shape), this.excludedValue, this._options));
   }
 
   protected _requiresAsync(): boolean {
@@ -1268,7 +1272,7 @@ export class CatchShape<S extends AnyShape, T>
   }
 
   deepPartial(): CatchShape<DeepPartialShape<S>, T> {
-    return new CatchShape(toDeepPartialShape(this.shape), this.fallback);
+    return copyUnsafeChecks(this, new CatchShape(toDeepPartialShape(this.shape), this.fallback));
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/UnionShape.ts
+++ b/src/main/shapes/UnionShape.ts
@@ -2,6 +2,7 @@ import { AnyShape, ApplyResult, DeepPartialProtocol, DeepPartialShape, Shape, Va
 import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
 import {
   concatIssues,
+  copyUnsafeChecks,
   createIssueFactory,
   getValueType,
   isArray,
@@ -63,10 +64,6 @@ export class UnionShape<U extends readonly AnyShape[]>
     return cb;
   }
 
-  deepPartial(): DeepPartialUnionShape<U> {
-    return new UnionShape<any>(this.shapes.map(toDeepPartialShape), this._options);
-  }
-
   at(key: unknown): AnyShape | null {
     const valueShapes: AnyShape[] = [];
 
@@ -77,7 +74,6 @@ export class UnionShape<U extends readonly AnyShape[]>
         valueShapes.push(valueShape);
       }
     }
-
     if (valueShapes.length === 0) {
       return null;
     }
@@ -85,6 +81,10 @@ export class UnionShape<U extends readonly AnyShape[]>
       return valueShapes[0];
     }
     return new UnionShape(valueShapes);
+  }
+
+  deepPartial(): DeepPartialUnionShape<U> {
+    return copyUnsafeChecks(this, new UnionShape<any>(this.shapes.map(toDeepPartialShape), this._options));
   }
 
   protected _requiresAsync(): boolean {

--- a/src/main/shapes/UnionShape.ts
+++ b/src/main/shapes/UnionShape.ts
@@ -65,7 +65,7 @@ export class UnionShape<U extends readonly AnyShape[]>
   }
 
   at(key: unknown): AnyShape | null {
-    const valueShapes: AnyShape[] = [];
+    const valueShapes = [];
 
     for (const shape of this.shapes) {
       const valueShape = shape.at(key);

--- a/src/main/shared-types.ts
+++ b/src/main/shared-types.ts
@@ -42,14 +42,14 @@ export interface Check {
   readonly callback: CheckCallback;
 
   /**
-   * `true` if the {@linkcode callback} is invoked even if previous processors failed, or `false` otherwise.
-   */
-  readonly unsafe: boolean;
-
-  /**
    * The optional parameter used by the {@linkcode callback}.
    */
   readonly param: any;
+
+  /**
+   * `true` if the {@linkcode callback} is invoked even if previous processors failed, or `false` otherwise.
+   */
+  readonly unsafe: boolean;
 }
 
 /**
@@ -62,15 +62,15 @@ export interface CheckOptions {
   key?: unknown;
 
   /**
+   * An optional param associated with the check.
+   */
+  param?: any;
+
+  /**
    * If `true` then the check would be executed even if the preceding check failed, otherwise check is
    * ignored.
    */
   unsafe?: boolean;
-
-  /**
-   * An optional param associated with the check.
-   */
-  param?: any;
 }
 
 /**

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -119,6 +119,18 @@ export function addConstraint<S extends Shape>(
 }
 
 /**
+ * Replaces checks of the target shape with unsafe checks from the source shape.
+ */
+export function copyUnsafeChecks<S extends Shape>(sourceShape: AnyShape, targetShape: S): S {
+  const checks = sourceShape['_checks']?.filter(isUnsafeCheck);
+
+  if (checks === undefined || checks.length === 0) {
+    return targetShape;
+  }
+  return targetShape['_replaceChecks'](checks);
+}
+
+/**
  * Returns a function that creates a new array with a single issue.
  *
  * @param code The code of the issue.

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -86,11 +86,14 @@ export function isUnsafeCheck(check: Check): boolean {
 /**
  * Returns an array index, or -1 if key isn't an index.
  */
-export function toArrayIndex(key: any): number {
+export function toArrayIndex(key: unknown): number {
   if (typeof key === 'string' && '' + +key === key) {
     key = +key;
   }
-  return Number.isInteger(key) && key >= 0 && key < 0xffffffff ? key : -1;
+  if (typeof key === 'number' && key % 1 === 0 && key >= 0 && key < 0xffffffff) {
+    return key;
+  }
+  return -1;
 }
 
 /**

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -13,6 +13,9 @@ export interface Dict<T = any> {
 
 export type ToArray<T> = T extends readonly any[] ? T : never;
 
+/**
+ * Returns the extended value type.
+ */
 export function getValueType(value: unknown): Exclude<ValueType, 'any' | 'never'> {
   const type = typeof value;
 
@@ -39,6 +42,9 @@ export const isArray = Array.isArray;
 
 export const getPrototypeOf = Object.getPrototypeOf;
 
+/**
+ * [SameValueZero](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-samevaluezero) comparison.
+ */
 export function isEqual(a: unknown, b: unknown): boolean {
   return a === b || (a !== a && b !== b);
 }
@@ -106,7 +112,7 @@ export function addConstraint<S extends Shape>(
   param: unknown,
   cb: CheckCallback<S['output']>
 ): S {
-  return shape.check(cb, { key, unsafe: true, param });
+  return shape.check(cb, { key, param, unsafe: true });
 }
 
 /**

--- a/src/test/shapes/ArrayShape.test.ts
+++ b/src/test/shapes/ArrayShape.test.ts
@@ -245,47 +245,6 @@ describe('ArrayShape', () => {
     });
   });
 
-  test('returns the tuple element shape', () => {
-    const shape1 = new Shape();
-    const shape2 = new Shape();
-
-    const arrShape = new ArrayShape([shape1, shape2], null);
-
-    expect(arrShape.at('0')).toBe(shape1);
-    expect(arrShape.at('1')).toBe(shape2);
-    expect(arrShape.at('2')).toBe(null);
-
-    expect(arrShape.at(0)).toBe(shape1);
-    expect(arrShape.at(1)).toBe(shape2);
-    expect(arrShape.at(2)).toBe(null);
-
-    expect(arrShape.at('000')).toBe(null);
-    expect(arrShape.at('1e+49')).toBe(null);
-    expect(arrShape.at(-111)).toBe(null);
-    expect(arrShape.at(111.222)).toBe(null);
-    expect(arrShape.at('aaa')).toBe(null);
-  });
-
-  test('returns the rest element shape', () => {
-    const restShape = new Shape();
-
-    const arrShape = new ArrayShape(null, restShape);
-
-    expect(arrShape.at(0)).toBe(restShape);
-    expect(arrShape.at(1)).toBe(restShape);
-  });
-
-  test('returns the rest element shape when tuple element shapes are available', () => {
-    const shape1 = new Shape();
-    const restShape = new Shape();
-
-    const arrShape = new ArrayShape([shape1], restShape);
-
-    expect(arrShape.at(0)).toBe(shape1);
-    expect(arrShape.at(1)).toBe(restShape);
-    expect(arrShape.at(2)).toBe(restShape);
-  });
-
   test('allow any input types when coerced and unconstrained', () => {
     const arrShape = new ArrayShape(null, null).coerce();
 
@@ -380,6 +339,49 @@ describe('ArrayShape', () => {
     expect(arrShape.try('aaa')).toEqual({
       ok: false,
       issues: [{ code: CODE_TUPLE, input: 'aaa', message: 'Must be a tuple of length 2', param: 2, path: [] }],
+    });
+  });
+
+  describe('at', () => {
+    test('returns the tuple element shape', () => {
+      const shape1 = new Shape();
+      const shape2 = new Shape();
+
+      const arrShape = new ArrayShape([shape1, shape2], null);
+
+      expect(arrShape.at('0')).toBe(shape1);
+      expect(arrShape.at('1')).toBe(shape2);
+      expect(arrShape.at('2')).toBe(null);
+
+      expect(arrShape.at(0)).toBe(shape1);
+      expect(arrShape.at(1)).toBe(shape2);
+      expect(arrShape.at(2)).toBe(null);
+
+      expect(arrShape.at('000')).toBe(null);
+      expect(arrShape.at('1e+49')).toBe(null);
+      expect(arrShape.at(-111)).toBe(null);
+      expect(arrShape.at(111.222)).toBe(null);
+      expect(arrShape.at('aaa')).toBe(null);
+    });
+
+    test('returns the rest element shape', () => {
+      const restShape = new Shape();
+
+      const arrShape = new ArrayShape(null, restShape);
+
+      expect(arrShape.at(0)).toBe(restShape);
+      expect(arrShape.at(1)).toBe(restShape);
+    });
+
+    test('returns the rest element shape when tuple element shapes are available', () => {
+      const shape1 = new Shape();
+      const restShape = new Shape();
+
+      const arrShape = new ArrayShape([shape1], restShape);
+
+      expect(arrShape.at(0)).toBe(shape1);
+      expect(arrShape.at(1)).toBe(restShape);
+      expect(arrShape.at(2)).toBe(restShape);
     });
   });
 

--- a/src/test/shapes/ArrayShape.test.ts
+++ b/src/test/shapes/ArrayShape.test.ts
@@ -1,4 +1,4 @@
-import { ArrayShape, NumberShape, ObjectShape, Shape, StringShape } from '../../main';
+import { ArrayShape, NumberShape, ObjectShape, Ok, Shape, StringShape } from '../../main';
 import {
   CODE_ARRAY_MAX,
   CODE_ARRAY_MIN,
@@ -40,7 +40,7 @@ describe('ArrayShape', () => {
     const arrShape = new ArrayShape(null, null);
 
     const arr = [111, 222];
-    const result: any = arrShape.try(arr);
+    const result = arrShape.try(arr) as Ok<unknown>;
 
     expect(result).toEqual({ ok: true, value: arr });
     expect(result.value).toBe(arr);
@@ -56,7 +56,7 @@ describe('ArrayShape', () => {
     const arrShape = new ArrayShape([shape1, shape2], null);
 
     const arr = [111, 222];
-    const result: any = arrShape.try(arr);
+    const result = arrShape.try(arr) as Ok<unknown>;
 
     expect(result).toEqual({ ok: true, value: arr });
     expect(result.value).toBe(arr);
@@ -74,7 +74,7 @@ describe('ArrayShape', () => {
     const arrShape = new ArrayShape(null, restShape);
 
     const arr = [111, 222];
-    const result: any = arrShape.try(arr);
+    const result = arrShape.try(arr) as Ok<unknown>;
 
     expect(result).toEqual({ ok: true, value: arr });
     expect(result.value).toBe(arr);
@@ -95,7 +95,7 @@ describe('ArrayShape', () => {
     const arrShape = new ArrayShape([shape1, shape2], restShape);
 
     const arr = [111, 222, 333, 444];
-    const result: any = arrShape.try(arr);
+    const result = arrShape.try(arr) as Ok<unknown>;
 
     expect(result).toEqual({ ok: true, value: arr });
     expect(result.value).toBe(arr);
@@ -191,7 +191,7 @@ describe('ArrayShape', () => {
     const arrShape = new ArrayShape([shape1, shape2], null);
 
     const arr = [111, 222];
-    const result: any = arrShape.try(arr);
+    const result = arrShape.try(arr) as Ok<unknown>;
 
     expect(arr).toEqual([111, 222]);
     expect(result).toEqual({ ok: true, value: [111, 'aaa'] });
@@ -470,7 +470,7 @@ describe('ArrayShape', () => {
       const arrShape = new ArrayShape([shape1, shape2], null);
 
       const arr = [111, 222];
-      const result: any = await arrShape.tryAsync(arr);
+      const result = (await arrShape.tryAsync(arr)) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: arr });
       expect(result.value).toBe(arr);
@@ -488,7 +488,7 @@ describe('ArrayShape', () => {
       const arrShape = new ArrayShape(null, restShape);
 
       const arr = [111, 222];
-      const result: any = await arrShape.tryAsync(arr);
+      const result = (await arrShape.tryAsync(arr)) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: arr });
       expect(result.value).toBe(arr);
@@ -504,7 +504,7 @@ describe('ArrayShape', () => {
       const arrShape = new ArrayShape([shape1, shape2], null);
 
       const arr = [111, 222];
-      const result: any = await arrShape.tryAsync(arr);
+      const result = (await arrShape.tryAsync(arr)) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: [111, 'aaa'] });
       expect(result.value).not.toBe(arr);

--- a/src/test/shapes/IntersectionShape.test.ts
+++ b/src/test/shapes/IntersectionShape.test.ts
@@ -1,4 +1,13 @@
-import { ArrayShape, IntersectionShape, NumberShape, ObjectShape, Shape, StringShape, UnionShape } from '../../main';
+import {
+  AnyShape,
+  ArrayShape,
+  IntersectionShape,
+  NumberShape,
+  ObjectShape,
+  Shape,
+  StringShape,
+  UnionShape,
+} from '../../main';
 import {
   CODE_INTERSECTION,
   CODE_TYPE,
@@ -98,7 +107,7 @@ describe('IntersectionShape', () => {
 
       const andShape = new IntersectionShape([objShape, arrShape]);
 
-      const shape: any = andShape.at(1);
+      const shape = andShape.at(1) as IntersectionShape<AnyShape[]>;
 
       expect(shape instanceof IntersectionShape).toBe(true);
       expect(shape.shapes.length).toBe(2);

--- a/src/test/shapes/IntersectionShape.test.ts
+++ b/src/test/shapes/IntersectionShape.test.ts
@@ -88,6 +88,37 @@ describe('IntersectionShape', () => {
     });
   });
 
+  describe('at', () => {
+    test('returns an intersection of child shapes at key', () => {
+      const shape1 = new Shape();
+      const shape2 = new Shape();
+      const shape3 = new Shape();
+      const objShape = new ObjectShape({ 1: shape1, key1: shape2 }, null);
+      const arrShape = new ArrayShape(null, shape3);
+
+      const andShape = new IntersectionShape([objShape, arrShape]);
+
+      const shape: any = andShape.at(1);
+
+      expect(shape instanceof IntersectionShape).toBe(true);
+      expect(shape.shapes.length).toBe(2);
+      expect(shape.shapes[0]).toBe(shape1);
+      expect(shape.shapes[1]).toBe(shape3);
+    });
+
+    test('returns null if key does not exist in all children', () => {
+      const shape1 = new Shape();
+      const shape2 = new Shape();
+      const shape3 = new Shape();
+      const objShape = new ObjectShape({ 1: shape1, key1: shape2 }, null);
+      const arrShape = new ArrayShape(null, shape3);
+
+      const andShape = new IntersectionShape([objShape, arrShape]);
+
+      expect(andShape.at('key1')).toBe(null);
+    });
+  });
+
   describe('deepPartial', () => {
     test('parses intersected deep partial objects', () => {
       const andShape = new IntersectionShape([

--- a/src/test/shapes/MapShape.test.ts
+++ b/src/test/shapes/MapShape.test.ts
@@ -131,17 +131,6 @@ describe('MapShape', () => {
     });
   });
 
-  test('returns value shape for any key', () => {
-    const valueShape = new Shape();
-    const objShape = new MapShape(new StringShape(), valueShape);
-
-    expect(objShape.at('aaa')).toBe(valueShape);
-    expect(objShape.at(111)).toBe(valueShape);
-    expect(objShape.at(111.222)).toBe(valueShape);
-    expect(objShape.at(null)).toBe(valueShape);
-    expect(objShape.at(Symbol())).toBe(valueShape);
-  });
-
   test('coerces an object', () => {
     const mapShape = new MapShape(new Shape(), new Shape()).coerce();
 
@@ -183,6 +172,19 @@ describe('MapShape', () => {
           param: TYPE_MAP,
         },
       ],
+    });
+  });
+
+  describe('at', () => {
+    test('returns value shape for any key', () => {
+      const valueShape = new Shape();
+      const objShape = new MapShape(new StringShape(), valueShape);
+
+      expect(objShape.at('aaa')).toBe(valueShape);
+      expect(objShape.at(111)).toBe(valueShape);
+      expect(objShape.at(111.222)).toBe(valueShape);
+      expect(objShape.at(null)).toBe(valueShape);
+      expect(objShape.at(Symbol())).toBe(valueShape);
     });
   });
 

--- a/src/test/shapes/MapShape.test.ts
+++ b/src/test/shapes/MapShape.test.ts
@@ -1,4 +1,4 @@
-import { MapShape, ObjectShape, Shape, StringShape } from '../../main';
+import { MapShape, ObjectShape, Ok, Shape, StringShape } from '../../main';
 import {
   CODE_TYPE,
   MESSAGE_MAP_TYPE,
@@ -86,7 +86,7 @@ describe('MapShape', () => {
       ['key2', 'bbb'],
     ]);
 
-    const result: any = mapShape.try(map);
+    const result = mapShape.try(map) as Ok<unknown>;
 
     expect(result).toEqual({
       ok: true,
@@ -110,7 +110,7 @@ describe('MapShape', () => {
       ['key2', 'bbb'],
     ]);
 
-    const result: any = mapShape.try(map);
+    const result = mapShape.try(map) as Ok<unknown>;
 
     expect(result).toEqual({
       ok: true,
@@ -324,7 +324,7 @@ describe('MapShape', () => {
         ['key2', 'bbb'],
       ]);
 
-      const result: any = mapShape.tryAsync(map);
+      const result = mapShape.tryAsync(map) as Promise<Ok<unknown>>;
 
       await expect(result).resolves.toEqual({
         ok: true,
@@ -350,7 +350,7 @@ describe('MapShape', () => {
         ['key2', 'bbb'],
       ]);
 
-      const result: any = mapShape.tryAsync(map);
+      const result = mapShape.tryAsync(map) as Promise<Ok<unknown>>;
 
       await expect(result).resolves.toEqual({
         ok: true,

--- a/src/test/shapes/ObjectShape.test.ts
+++ b/src/test/shapes/ObjectShape.test.ts
@@ -1,4 +1,4 @@
-import { ObjectShape, Shape, StringShape } from '../../main';
+import { ObjectShape, Ok, Shape, StringShape } from '../../main';
 import {
   CODE_ENUM,
   CODE_EXCLUSION,
@@ -291,7 +291,7 @@ describe('ObjectShape', () => {
       const objShape = new ObjectShape({ key1: shape1 }, null);
 
       const obj = { key1: 'aaa' };
-      const result: any = objShape.try(obj);
+      const result = objShape.try(obj) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: obj });
       expect(result.value).toBe(obj);
@@ -305,7 +305,7 @@ describe('ObjectShape', () => {
 
       const objShape = new ObjectShape({ key1: shape1, key2: shape2 }, null);
 
-      const result: any = objShape.try({});
+      const result = objShape.try({}) as Ok<unknown>;
 
       expect(result).toEqual({
         ok: false,
@@ -319,7 +319,7 @@ describe('ObjectShape', () => {
 
       const objShape = new ObjectShape({ key1: shape1, key2: shape2 }, null);
 
-      const result: any = objShape.try({}, { verbose: true });
+      const result = objShape.try({}, { verbose: true }) as Ok<unknown>;
 
       expect(result).toEqual({
         ok: false,
@@ -337,7 +337,7 @@ describe('ObjectShape', () => {
       const objShape = new ObjectShape({ key1: shape1, key2: shape2 }, null);
 
       const obj = { key1: 'aaa', key2: 'bbb' };
-      const result: any = objShape.try(obj);
+      const result = objShape.try(obj) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: { key1: 'aaa', key2: 111 } });
       expect(result.value).not.toBe(obj);
@@ -351,7 +351,7 @@ describe('ObjectShape', () => {
       const objShape = new ObjectShape(shapes, null);
 
       const obj = {};
-      const result: any = objShape.try(obj);
+      const result = objShape.try(obj) as Ok<object>;
 
       expect(result).toEqual({
         ok: true,
@@ -384,7 +384,7 @@ describe('ObjectShape', () => {
       const objShape = new ObjectShape({ key1: shape1, key2: shape2 }, restShape);
 
       const obj = { key1: 'aaa', yay: 'bbb' };
-      const result: any = objShape.try(obj);
+      const result = objShape.try(obj) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: obj });
       expect(result.value).toBe(obj);
@@ -402,7 +402,7 @@ describe('ObjectShape', () => {
 
       const objShape = new ObjectShape({ key1: shape1 }, restShape);
 
-      const result: any = objShape.try({ key2: 'aaa' }, { verbose: true });
+      const result = objShape.try({ key2: 'aaa' }, { verbose: true }) as Ok<unknown>;
 
       expect(result).toEqual({
         ok: false,
@@ -420,7 +420,7 @@ describe('ObjectShape', () => {
       const objShape = new ObjectShape({ key1: shape1 }, restShape);
 
       const obj = { key1: 'aaa', yay: 'bbb' };
-      const result: any = objShape.try(obj);
+      const result = objShape.try(obj) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: { key1: 'aaa', yay: 111 } });
       expect(result.value).not.toBe(obj);
@@ -438,7 +438,7 @@ describe('ObjectShape', () => {
       const objShape = new ObjectShape({ key1: shape1 }, null).strip();
 
       const obj = { key1: 'aaa', yay: 'bbb' };
-      const result: any = objShape.try(obj);
+      const result = objShape.try(obj) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: { key1: 'aaa' } });
       expect(result.value).not.toBe(obj);
@@ -450,7 +450,7 @@ describe('ObjectShape', () => {
       const objShape = new ObjectShape({ key1: shape1 }, null).strip();
 
       const obj = { key1: 'aaa', yay: 'bbb' };
-      const result: any = objShape.try(obj);
+      const result = objShape.try(obj) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: { key1: 111 } });
       expect(result.value).not.toBe(obj);
@@ -538,7 +538,7 @@ describe('ObjectShape', () => {
       const objShape = new ObjectShape({ key1: shape1, key2: shape2 }, restShape);
 
       const obj = { key1: 'aaa', yay: 'bbb' };
-      const result: any = await objShape.tryAsync(obj);
+      const result = (await objShape.tryAsync(obj)) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: obj });
       expect(result.value).toBe(obj);
@@ -574,7 +574,7 @@ describe('ObjectShape', () => {
       const objShape = new ObjectShape({ key1: shape1 }, restShape);
 
       const obj = { key1: 'aaa', yay: 'bbb' };
-      const result: any = await objShape.tryAsync(obj);
+      const result = (await objShape.tryAsync(obj)) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: { key1: 'aaa', yay: 111 } });
       expect(result.value).not.toBe(obj);
@@ -586,7 +586,7 @@ describe('ObjectShape', () => {
       const objShape = new ObjectShape({ key1: shape1 }, null).strip();
 
       const obj = { key1: 'aaa', yay: 'bbb' };
-      const result: any = await objShape.tryAsync(obj);
+      const result = (await objShape.tryAsync(obj)) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: { key1: 'aaa' } });
       expect(result.value).not.toBe(obj);
@@ -598,7 +598,7 @@ describe('ObjectShape', () => {
       const objShape = new ObjectShape({ key1: shape1 }, null).strip();
 
       const obj = { key1: 'aaa', yay: 'bbb' };
-      const result: any = await objShape.tryAsync(obj);
+      const result = (await objShape.tryAsync(obj)) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: { key1: 111 } });
       expect(result.value).not.toBe(obj);

--- a/src/test/shapes/ObjectShape.test.ts
+++ b/src/test/shapes/ObjectShape.test.ts
@@ -166,17 +166,6 @@ describe('ObjectShape', () => {
     expect(objShape2.keys).toEqual(['key1']);
   });
 
-  test('returns property shape at key', () => {
-    const shape1 = new Shape();
-    const shape2 = new Shape();
-
-    const objShape = new ObjectShape({ key1: shape1, key2: shape2 }, null);
-
-    expect(objShape.at('key1')).toBe(shape1);
-    expect(objShape.at('key2')).toBe(shape2);
-    expect(objShape.at('xxx')).toBe(null);
-  });
-
   test('marks all properties optional', () => {
     const shape1 = new StringShape();
     const shape2 = new StringShape();
@@ -239,6 +228,19 @@ describe('ObjectShape', () => {
     expect(objShape.try(new Foo())).toEqual({
       ok: false,
       issues: [{ code: CODE_TYPE, input: {}, message: MESSAGE_OBJECT_TYPE, param: TYPE_OBJECT, path: [] }],
+    });
+  });
+
+  describe('at', () => {
+    test('returns property shape at key', () => {
+      const shape1 = new Shape();
+      const shape2 = new Shape();
+
+      const objShape = new ObjectShape({ key1: shape1, key2: shape2 }, null);
+
+      expect(objShape.at('key1')).toBe(shape1);
+      expect(objShape.at('key2')).toBe(shape2);
+      expect(objShape.at('xxx')).toBe(null);
     });
   });
 

--- a/src/test/shapes/RecordShape.test.ts
+++ b/src/test/shapes/RecordShape.test.ts
@@ -90,15 +90,17 @@ describe('RecordShape', () => {
     });
   });
 
-  test('returns value shape for string and number keys', () => {
-    const valueShape = new Shape();
-    const objShape = new RecordShape(null, valueShape);
+  describe('at', () => {
+    test('returns value shape for string and number keys', () => {
+      const valueShape = new Shape();
+      const objShape = new RecordShape(null, valueShape);
 
-    expect(objShape.at('aaa')).toBe(valueShape);
-    expect(objShape.at(111)).toBe(valueShape);
-    expect(objShape.at(111.222)).toBe(valueShape);
-    expect(objShape.at(null)).toBe(null);
-    expect(objShape.at(Symbol())).toBe(null);
+      expect(objShape.at('aaa')).toBe(valueShape);
+      expect(objShape.at(111)).toBe(valueShape);
+      expect(objShape.at(111.222)).toBe(valueShape);
+      expect(objShape.at(null)).toBe(null);
+      expect(objShape.at(Symbol())).toBe(null);
+    });
   });
 
   describe('deepPartial', () => {

--- a/src/test/shapes/RecordShape.test.ts
+++ b/src/test/shapes/RecordShape.test.ts
@@ -1,4 +1,4 @@
-import { ObjectShape, RecordShape, Shape, StringShape } from '../../main';
+import { ObjectShape, Ok, RecordShape, Shape, StringShape } from '../../main';
 import { CODE_TYPE, MESSAGE_OBJECT_TYPE, MESSAGE_STRING_TYPE, TYPE_OBJECT, TYPE_STRING } from '../../main/constants';
 
 describe('RecordShape', () => {
@@ -61,7 +61,7 @@ describe('RecordShape', () => {
 
     const obj = { key1: 'aaa', key2: 'bbb' };
 
-    const result: any = objShape.try(obj);
+    const result = objShape.try(obj) as Ok<unknown>;
 
     expect(result).toEqual({ ok: true, value: { KEY1: 'aaa', KEY2: 'bbb' } });
     expect(result.value).not.toBe(obj);
@@ -75,7 +75,7 @@ describe('RecordShape', () => {
 
     const obj = { key1: 'aaa', key2: 'bbb' };
 
-    const result: any = objShape.try(obj);
+    const result = objShape.try(obj) as Ok<unknown>;
 
     expect(result).toEqual({ ok: true, value: { key1: 'AAA', key2: 'BBB' } });
     expect(result.value).not.toBe(obj);
@@ -195,7 +195,7 @@ describe('RecordShape', () => {
 
       const obj = { key1: 'aaa', key2: 'bbb' };
 
-      const result: any = await objShape.tryAsync(obj);
+      const result = (await objShape.tryAsync(obj)) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: { KEY1: 'aaa', KEY2: 'bbb' } });
       expect(result.value).not.toBe(obj);
@@ -209,7 +209,7 @@ describe('RecordShape', () => {
 
       const obj = { key1: 'aaa', key2: 'bbb' };
 
-      const result: any = await objShape.tryAsync(obj);
+      const result = (await objShape.tryAsync(obj)) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: { key1: 'AAA', key2: 'BBB' } });
       expect(result.value).not.toBe(obj);

--- a/src/test/shapes/SetShape.test.ts
+++ b/src/test/shapes/SetShape.test.ts
@@ -138,21 +138,6 @@ describe('SetShape', () => {
     });
   });
 
-  test('returns the value shape', () => {
-    const shape = new Shape();
-
-    const setShape = new SetShape(shape);
-
-    expect(setShape.at('0')).toBe(shape);
-    expect(setShape.at(0)).toBe(shape);
-
-    expect(setShape.at('000')).toBe(null);
-    expect(setShape.at('1e+49')).toBe(null);
-    expect(setShape.at(-111)).toBe(null);
-    expect(setShape.at(111.222)).toBe(null);
-    expect(setShape.at('aaa')).toBe(null);
-  });
-
   test('updates input types when coerced', () => {
     const setShape = new SetShape(new StringShape()).coerce();
 
@@ -169,6 +154,23 @@ describe('SetShape', () => {
     const setShape = new SetShape(new Shape()).coerce();
 
     expect(setShape.parse(['aaa'])).toEqual(new Set(['aaa']));
+  });
+
+  describe('at', () => {
+    test('returns the value shape', () => {
+      const shape = new Shape();
+
+      const setShape = new SetShape(shape);
+
+      expect(setShape.at('0')).toBe(shape);
+      expect(setShape.at(0)).toBe(shape);
+
+      expect(setShape.at('000')).toBe(null);
+      expect(setShape.at('1e+49')).toBe(null);
+      expect(setShape.at(-111)).toBe(null);
+      expect(setShape.at(111.222)).toBe(null);
+      expect(setShape.at('aaa')).toBe(null);
+    });
   });
 
   describe('deepPartial', () => {

--- a/src/test/shapes/SetShape.test.ts
+++ b/src/test/shapes/SetShape.test.ts
@@ -1,4 +1,4 @@
-import { ObjectShape, SetShape, Shape, StringShape } from '../../main';
+import { ObjectShape, Ok, SetShape, Shape, StringShape } from '../../main';
 import {
   CODE_SET_MAX,
   CODE_SET_MIN,
@@ -40,7 +40,7 @@ describe('SetShape', () => {
     const setShape = new SetShape(shape);
 
     const set = new Set([111, 222]);
-    const result: any = setShape.try(set);
+    const result = setShape.try(set) as Ok<unknown>;
 
     expect(result).toEqual({ ok: true, value: set });
     expect(result.value).toBe(set);
@@ -84,7 +84,7 @@ describe('SetShape', () => {
     const setShape = new SetShape(shape);
 
     const set = new Set([111, 222]);
-    const result: any = setShape.try(set);
+    const result = setShape.try(set) as Ok<unknown>;
 
     expect(set).toEqual(new Set([111, 222]));
     expect(result).toEqual({ ok: true, value: new Set(['aaa', 'bbb']) });
@@ -226,7 +226,7 @@ describe('SetShape', () => {
       const setShape = new SetShape(shape);
 
       const set = new Set([111, 222]);
-      const result: any = await setShape.tryAsync(set);
+      const result = (await setShape.tryAsync(set)) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: set });
       expect(result.value).toBe(set);
@@ -245,7 +245,7 @@ describe('SetShape', () => {
       const setShape = new SetShape(shape);
 
       const set = new Set([111, 222]);
-      const result: any = await setShape.tryAsync(set);
+      const result = (await setShape.tryAsync(set)) as Ok<unknown>;
 
       expect(result).toEqual({ ok: true, value: new Set(['aaa', 'bbb']) });
       expect(result.value).not.toBe(set);

--- a/src/test/shapes/UnionShape.test.ts
+++ b/src/test/shapes/UnionShape.test.ts
@@ -101,35 +101,6 @@ describe('UnionShape', () => {
     });
   });
 
-  test('returns union of child shapes at key', () => {
-    const shape1 = new Shape();
-    const shape2 = new Shape();
-    const shape3 = new Shape();
-    const objShape = new ObjectShape({ 1: shape1, key1: shape2 }, null);
-    const arrShape = new ArrayShape(null, shape3);
-
-    const orShape = new UnionShape([objShape, arrShape]);
-
-    const shape: any = orShape.at(1);
-
-    expect(shape instanceof UnionShape).toBe(true);
-    expect(shape.shapes.length).toBe(2);
-    expect(shape.shapes[0]).toBe(shape1);
-    expect(shape.shapes[1]).toBe(shape3);
-  });
-
-  test('returns non-null child shapes at key', () => {
-    const shape1 = new Shape();
-    const shape2 = new Shape();
-    const shape3 = new Shape();
-    const objShape = new ObjectShape({ 1: shape1, key1: shape2 }, null);
-    const arrShape = new ArrayShape(null, shape3);
-
-    const orShape = new UnionShape([objShape, arrShape]);
-
-    expect(orShape.at('key1')).toBe(shape2);
-  });
-
   test('parses a discriminated union', () => {
     const shape = new UnionShape([
       new ObjectShape({ type: new ConstShape('aaa') }, null),
@@ -137,6 +108,37 @@ describe('UnionShape', () => {
     ]);
 
     expect(shape.parse({ type: 'bbb' })).toEqual({ type: 'bbb' });
+  });
+
+  describe('at', () => {
+    test('returns a union of child shapes at key', () => {
+      const shape1 = new Shape();
+      const shape2 = new Shape();
+      const shape3 = new Shape();
+      const objShape = new ObjectShape({ 1: shape1, key1: shape2 }, null);
+      const arrShape = new ArrayShape(null, shape3);
+
+      const orShape = new UnionShape([objShape, arrShape]);
+
+      const shape: any = orShape.at(1);
+
+      expect(shape instanceof UnionShape).toBe(true);
+      expect(shape.shapes.length).toBe(2);
+      expect(shape.shapes[0]).toBe(shape1);
+      expect(shape.shapes[1]).toBe(shape3);
+    });
+
+    test('returns non-null child shapes at key', () => {
+      const shape1 = new Shape();
+      const shape2 = new Shape();
+      const shape3 = new Shape();
+      const objShape = new ObjectShape({ 1: shape1, key1: shape2 }, null);
+      const arrShape = new ArrayShape(null, shape3);
+
+      const orShape = new UnionShape([objShape, arrShape]);
+
+      expect(orShape.at('key1')).toBe(shape2);
+    });
   });
 
   describe('deepPartial', () => {

--- a/src/test/shapes/UnionShape.test.ts
+++ b/src/test/shapes/UnionShape.test.ts
@@ -1,4 +1,5 @@
 import {
+  AnyShape,
   ArrayShape,
   BooleanShape,
   ConstShape,
@@ -120,7 +121,7 @@ describe('UnionShape', () => {
 
       const orShape = new UnionShape([objShape, arrShape]);
 
-      const shape: any = orShape.at(1);
+      const shape = orShape.at(1) as UnionShape<AnyShape[]>;
 
       expect(shape instanceof UnionShape).toBe(true);
       expect(shape.shapes.length).toBe(2);

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,6 +1,7 @@
 import {
   cloneObjectEnumerableKeys,
   cloneObjectKnownKeys,
+  copyUnsafeChecks,
   createApplyChecksCallback,
   createIssueFactory,
   enableBitAt,
@@ -9,7 +10,7 @@ import {
   toArrayIndex,
   unique,
 } from '../main/utils';
-import { Issue, ValidationError } from '../main';
+import { Issue, Shape, ValidationError } from '../main';
 
 describe('isEqual', () => {
   test('checks equality', () => {
@@ -46,6 +47,29 @@ describe('toArrayIndex', () => {
     expect(toArrayIndex(new Date())).toBe(-1);
     expect(toArrayIndex({ valueOf: () => 2 })).toBe(-1);
     expect(toArrayIndex({ toString: () => '2' })).toBe(-1);
+  });
+});
+
+describe('copyUnsafeChecks', () => {
+  test('returns target shape is there are no unsafe check on the source shape', () => {
+    const sourceShape = new Shape().check(() => undefined);
+    const targetShape = new Shape();
+
+    expect(copyUnsafeChecks(sourceShape, targetShape)).toBe(targetShape);
+  });
+
+  test('copies unsafe checks from source to a target clone', () => {
+    const safeCheck = () => undefined;
+    const unsafeCheck = () => undefined;
+
+    const sourceShape = new Shape().check(safeCheck).check(unsafeCheck, { unsafe: true });
+    const targetShape = new Shape();
+
+    const shape = copyUnsafeChecks(sourceShape, targetShape);
+
+    expect(shape).not.toBe(targetShape);
+    expect(shape['_checks']!.length).toBe(1);
+    expect(shape['_checks']![0].callback).toBe(unsafeCheck);
   });
 });
 

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -6,6 +6,7 @@ import {
   enableBitAt,
   isBitEnabledAt,
   isEqual,
+  toArrayIndex,
   unique,
 } from '../main/utils';
 import { Issue, ValidationError } from '../main';
@@ -18,6 +19,33 @@ describe('isEqual', () => {
 
     expect(isEqual(111, 222)).toBe(false);
     expect(isEqual({}, {})).toBe(false);
+  });
+});
+
+describe('toArrayIndex', () => {
+  test('returns an array index', () => {
+    expect(toArrayIndex('0')).toBe(0);
+    expect(toArrayIndex('1')).toBe(1);
+    expect(toArrayIndex('2')).toBe(2);
+
+    expect(toArrayIndex(0)).toBe(0);
+    expect(toArrayIndex(1)).toBe(1);
+    expect(toArrayIndex(2)).toBe(2);
+  });
+
+  test('returns -1 if value is not an array index', () => {
+    expect(toArrayIndex('-5')).toBe(-1);
+    expect(toArrayIndex('0xa')).toBe(-1);
+    expect(toArrayIndex('016')).toBe(-1);
+    expect(toArrayIndex('000')).toBe(-1);
+    expect(toArrayIndex('1e+49')).toBe(-1);
+    expect(toArrayIndex(-111)).toBe(-1);
+    expect(toArrayIndex(111.222)).toBe(-1);
+    expect(toArrayIndex('aaa')).toBe(-1);
+    expect(toArrayIndex(NaN)).toBe(-1);
+    expect(toArrayIndex(new Date())).toBe(-1);
+    expect(toArrayIndex({ valueOf: () => 2 })).toBe(-1);
+    expect(toArrayIndex({ toString: () => '2' })).toBe(-1);
   });
 });
 


### PR DESCRIPTION
Unsafe checks are preserved when a new shape is derived. For example, when a new partial object shape is created, unsafe checks are preserved.
