### PR TITLE
Naming overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,8 @@ greetingShape1.parse('Adiós, R2D2', { verbose: true });
 // ❌ ValidationError: type at /: Must start with "Hello"
 ```
 
-To force `noDigitsCheck` to be called even if the preceding check has failed, pass the `unsafe` option:
+To force `noDigitsCheck` to be called even if the preceding check has failed, pass the
+[`unsafe`](https://smikhalevski.github.io/doubter/interfaces/CheckOptions.html#unsafe) option:
 
 ```ts
 const greetingShape2 = d.string()
@@ -640,7 +641,7 @@ Retrieve a check:
 shape.check(emailCheck);
 
 shape.getCheck(emailCheck);
-// ⮕ { callback: emailCheck, unsafe: false, param: undefined }
+// ⮕ { key: emailCheck, callback: emailCheck, isUnsafe: false, param: undefined }
 ```
 
 Delete a check:
@@ -656,6 +657,9 @@ Using a check callback identity as a key isn't always convenient. Pass the
 ```ts
 shape.check(emailCheck, { key: 'email' });
 // ⮕ Shape<string>
+
+shape.getCheck(emailCheck);
+// ⮕ { key: 'email', callback: emailCheck, isUnsafe: false, param: undefined }
 ```
 
 Now you should use the key to get or delete the check:
@@ -1532,7 +1536,7 @@ emailShape.parse('Not an email');
 // ❌ ValidationError: predicate at /: Must be an email
 
 emailShape.getCheck(isEmail);
-// ⮕ { key: isEmail, unsafe: false, param: isEmail }
+// ⮕ { key: isEmail, callback: isEmail, isUnsafe: false, param: isEmail }
 ```
 
 Read more about [Refinements](#refinements) and how to [Add, get and delete checks](#add-get-and-delete-checks).

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ The optional metadata associated with the issue. Refer to [Metadata](#metadata) 
 | `arrayMaxLength` | [`d.array().max(n)`](#array) | The maximum array length `n` |
 | `const` | [`d.const(x)`](#const) | The expected constant value `x` |
 | `denied` | [`shape.deny(x)`](#deny-a-literal-value) | The denied value `x` |
-| `enum` | [`d.enum([x, y, z])`](#enum) | The list of unique expected values`[x, y, z]` |
+| `enum` | [`d.enum([x, y, z])`](#enum) | The array of unique values`[x, y, z]` |
 | `excluded` | [`shape.exclude(…)`](#exclude-a-shape) | The excluded shape |
 | `instance` | [`d.instanceOf(Class)`](#instanceof) | The class constructor `Class` |
 | `intersection` | [`d.and(…)`](#intersection) | — |

--- a/src/main/ValidationError.ts
+++ b/src/main/ValidationError.ts
@@ -6,14 +6,14 @@ import { Issue } from './shared-types';
  */
 export class ValidationError extends Error {
   /**
-   * The list of issues that caused the error.
+   * The array of issues that caused the error.
    */
   issues: Issue[];
 
   /**
    * Creates a new {@linkcode ValidationError} instance.
    *
-   * @param issues The mutable list of partially defined issues that have caused an error.
+   * @param issues The mutable array of partially defined issues that have caused an error.
    */
   constructor(issues: Partial<Issue>[]) {
     let message = '';

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -1,7 +1,7 @@
-export const ERROR_REQUIRES_ASYNC = 'Shape is async, use tryAsync, parseAsync, or parseOrDefaultAsync';
-export const ERROR_SHAPE_EXPECTED = 'Provider must return a shape';
-export const ERROR_FORBIDDEN_AT_RUNTIME = 'Must not be accessed at runtime';
-export const ERROR_ASYNC_DELEGATOR = 'The function signature is constrained by async shapes, use delegateAsync';
+export const ERROR_REQUIRES_ASYNC = 'Shape is async, use tryAsync, parseAsync, or parseOrDefaultAsync.';
+export const ERROR_SHAPE_EXPECTED = 'Provider must return a shape. Are you accessing a lazy shape prematurely?';
+export const ERROR_FORBIDDEN_AT_RUNTIME = 'Must not be accessed at runtime.';
+export const ERROR_ASYNC_DELEGATOR = 'The function signature is constrained by async shapes, use delegateAsync.';
 
 export const CODE_ARRAY_MIN = 'arrayMinLength';
 export const CODE_ARRAY_MAX = 'arrayMaxLength';

--- a/src/main/dsl/enum.ts
+++ b/src/main/dsl/enum.ts
@@ -3,12 +3,12 @@ import { EnumShape } from '../shapes';
 import { ReadonlyDict } from '../utils';
 
 /**
- * Creates the shape that constrains input with the list of values.
+ * Creates the shape that constrains input with the array of values.
  *
- * @param values The list of values allowed for the input.
+ * @param values The array of values allowed for the input.
  * @param options The constraint options or an issue message.
  * @template T Allowed values.
- * @template U The list of allowed values.
+ * @template U The array of allowed values.
  */
 function enum_<T extends Literal, U extends readonly [T, ...T[]]>(
   values: U,

--- a/src/main/dsl/intersection.ts
+++ b/src/main/dsl/intersection.ts
@@ -4,7 +4,7 @@ import { ConstraintOptions, Message } from '../shared-types';
 /**
  * Creates an intersection shape that tries to parse the input with all provided shapes.
  *
- * @param shapes The list of shapes.
+ * @param shapes The array of shapes.
  * @param options The constraint options or an issue message.
  * @template U The tuple of intersected shapes.
  */

--- a/src/main/dsl/tuple.ts
+++ b/src/main/dsl/tuple.ts
@@ -4,7 +4,7 @@ import { ConstraintOptions, Message } from '../shared-types';
 /**
  * Creates the tuple shape.
  *
- * @param shapes The list of tuple element shapes.
+ * @param shapes The array of tuple element shapes.
  * @param options The constraint options or an issue message.
  * @template U The tuple elements.
  */
@@ -16,7 +16,7 @@ export function tuple<U extends readonly [AnyShape, ...AnyShape[]]>(
 /**
  * Creates the tuple shape with rest elements.
  *
- * @param shapes The list of tuple element shapes.
+ * @param shapes The array of tuple element shapes.
  * @param restShape The shape of rest elements.
  * @param options The constraint options or an issue message.
  * @template U The head tuple elements.

--- a/src/main/dsl/union.ts
+++ b/src/main/dsl/union.ts
@@ -4,7 +4,7 @@ import { ConstraintOptions, Message } from '../shared-types';
 /**
  * Creates a union shape that tries to parse the input with one of the provided shapes.
  *
- * @param shapes The list of shapes to try.
+ * @param shapes The array of shapes to try.
  * @param options The constraint options or an issue message.
  * @template U The tuple of united shapes.
  */

--- a/src/main/shapes/ArrayShape.ts
+++ b/src/main/shapes/ArrayShape.ts
@@ -12,7 +12,7 @@ import {
   ok,
   toArrayIndex,
   toDeepPartialShape,
-  unshiftPath,
+  unshiftIssuesPath,
 } from '../utils';
 import {
   CODE_ARRAY_MAX,
@@ -223,7 +223,7 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
           continue;
         }
         if (isArray(result)) {
-          unshiftPath(result, i);
+          unshiftIssuesPath(result, i);
 
           if (!options.verbose) {
             return result;
@@ -276,7 +276,7 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
       const handleResult = (result: Result) => {
         if (result !== null) {
           if (isArray(result)) {
-            unshiftPath(result, index);
+            unshiftIssuesPath(result, index);
 
             if (!options.verbose) {
               return result;

--- a/src/main/shapes/ArrayShape.ts
+++ b/src/main/shapes/ArrayShape.ts
@@ -1,4 +1,4 @@
-import { AnyShape, ApplyResult, DeepPartialProtocol, OptionalDeepPartialShape, ValueType } from './Shape';
+import { AnyShape, DeepPartialProtocol, OptionalDeepPartialShape, Result, ValueType } from './Shape';
 import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
 import {
   addConstraint,
@@ -193,7 +193,7 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
     return shape.inputTypes.concat(TYPE_OBJECT, TYPE_ARRAY);
   }
 
-  protected _apply(input: any, options: ParseOptions): ApplyResult<InferArray<U, R, 'output'>> {
+  protected _apply(input: any, options: ParseOptions): Result<InferArray<U, R, 'output'>> {
     const { shapes, restShape, _applyChecks, _isUnsafe } = this;
 
     let output = input;
@@ -249,7 +249,7 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
     return issues;
   }
 
-  protected _applyAsync(input: any, options: ParseOptions): Promise<ApplyResult<InferArray<U, R, 'output'>>> {
+  protected _applyAsync(input: any, options: ParseOptions): Promise<Result<InferArray<U, R, 'output'>>> {
     return new Promise(resolve => {
       const { shapes, restShape, _applyChecks, _isUnsafe } = this;
 
@@ -273,7 +273,7 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
       let issues: Issue[] | null = null;
       let index = -1;
 
-      const applyResult = (result: ApplyResult) => {
+      const handleResult = (result: Result) => {
         if (result !== null) {
           if (isArray(result)) {
             unshiftPath(result, index);
@@ -292,13 +292,13 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
         return next();
       };
 
-      const next = (): ApplyResult | Promise<ApplyResult> => {
+      const next = (): Result | Promise<Result> => {
         index++;
 
         if (index !== outputLength && (shapes !== null || restShape !== null)) {
           const valueShape = index < shapesLength ? shapes![index] : restShape!;
 
-          return valueShape['_applyAsync'](output[index], options).then(applyResult);
+          return valueShape['_applyAsync'](output[index], options).then(handleResult);
         }
 
         if (_applyChecks !== null && (_isUnsafe || issues === null)) {

--- a/src/main/shapes/ArrayShape.ts
+++ b/src/main/shapes/ArrayShape.ts
@@ -51,7 +51,7 @@ export type DeepPartialArrayShape<U extends readonly AnyShape[] | null, R extend
 /**
  * The shape of an array or a tuple.
  *
- * @template U The list of positioned element shapes, or `null` if there are no positioned elements.
+ * @template U The array of positioned element shapes, or `null` if there are no positioned elements.
  * @template R The shape of rest elements, or `null` if there are no rest elements.
  */
 export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape | null>
@@ -64,15 +64,15 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
   /**
    * Creates a new {@linkcode ArrayShape} instance.
    *
-   * @param shapes The list of positioned element shapes or `null` if there are no positioned elements.
+   * @param shapes The array of positioned element shapes or `null` if there are no positioned elements.
    * @param restShape The shape of rest elements or `null` if there are no rest elements.
    * @param options The type constraint options or the type issue message.
-   * @template U The list of positioned element shapes, or `null` if there are no positioned elements.
+   * @template U The array of positioned element shapes, or `null` if there are no positioned elements.
    * @template R The shape of rest elements, or `null` if there are no rest elements.
    */
   constructor(
     /**
-     * The list of positioned element shapes or `null` if there are no positioned elements.
+     * The array of positioned element shapes or `null` if there are no positioned elements.
      */
     readonly shapes: U,
     /**

--- a/src/main/shapes/BigIntShape.ts
+++ b/src/main/shapes/BigIntShape.ts
@@ -1,4 +1,4 @@
-import { ApplyResult, ValueType } from './Shape';
+import { Result, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory, isArray, ok } from '../utils';
 import {
@@ -39,7 +39,7 @@ export class BigIntShape extends CoercibleShape<bigint> {
     }
   }
 
-  protected _apply(input: any, options: ParseOptions): ApplyResult<bigint> {
+  protected _apply(input: any, options: ParseOptions): Result<bigint> {
     const { _applyChecks } = this;
 
     let output = input;

--- a/src/main/shapes/BooleanShape.ts
+++ b/src/main/shapes/BooleanShape.ts
@@ -1,4 +1,4 @@
-import { ApplyResult, ValueType } from './Shape';
+import { Result, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory, isArray, ok } from '../utils';
 import {
@@ -38,7 +38,7 @@ export class BooleanShape extends CoercibleShape<boolean> {
     }
   }
 
-  protected _apply(input: any, options: ParseOptions): ApplyResult<boolean> {
+  protected _apply(input: any, options: ParseOptions): Result<boolean> {
     const { _applyChecks } = this;
 
     let output = input;

--- a/src/main/shapes/CoercibleShape.ts
+++ b/src/main/shapes/CoercibleShape.ts
@@ -1,5 +1,5 @@
 import { Shape } from './Shape';
-import { cloneObject } from '../utils';
+import { cloneInstance } from '../utils';
 
 /**
  * The shape which value can be coerced to a proper type during parsing.
@@ -19,7 +19,7 @@ export class CoercibleShape<I = any, O = I> extends Shape<I, O> {
    * @returns The clone of the shape.
    */
   coerce(): this {
-    const shape = cloneObject(this);
+    const shape = cloneInstance(this);
     shape.isCoerced = true;
     return shape;
   }

--- a/src/main/shapes/ConstShape.ts
+++ b/src/main/shapes/ConstShape.ts
@@ -1,4 +1,4 @@
-import { ApplyResult, Shape, ValueType } from './Shape';
+import { Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory, getValueType } from '../utils';
 import { CODE_CONST, MESSAGE_CONST } from '../constants';
@@ -40,7 +40,7 @@ export class ConstShape<T> extends Shape<T> {
     return [this.value];
   }
 
-  protected _apply(input: unknown, options: ParseOptions): ApplyResult<T> {
+  protected _apply(input: unknown, options: ParseOptions): Result<T> {
     const { _applyChecks } = this;
 
     if (!this._typePredicate(input)) {

--- a/src/main/shapes/DateShape.ts
+++ b/src/main/shapes/DateShape.ts
@@ -1,4 +1,4 @@
-import { ApplyResult, ValueType } from './Shape';
+import { Result, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory, isArray, isValidDate, ok } from '../utils';
 import { CODE_TYPE, MESSAGE_DATE_TYPE, TYPE_ARRAY, TYPE_DATE, TYPE_NUMBER, TYPE_STRING } from '../constants';
@@ -29,7 +29,7 @@ export class DateShape extends CoercibleShape<Date> {
     }
   }
 
-  protected _apply(input: any, options: ParseOptions): ApplyResult<Date> {
+  protected _apply(input: any, options: ParseOptions): Result<Date> {
     const { _applyChecks } = this;
 
     let output = input;

--- a/src/main/shapes/EnumShape.ts
+++ b/src/main/shapes/EnumShape.ts
@@ -1,4 +1,4 @@
-import { ApplyResult, ValueType } from './Shape';
+import { Result, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory, getValueType, isArray, NEVER, ok, ReadonlyDict, unique } from '../utils';
 import { CODE_ENUM, MESSAGE_ENUM, TYPE_ARRAY, TYPE_STRING } from '../constants';
@@ -74,7 +74,7 @@ export class EnumShape<T> extends CoercibleShape<T> {
     return this.values.slice(0);
   }
 
-  protected _apply(input: any, options: ParseOptions): ApplyResult<T> {
+  protected _apply(input: any, options: ParseOptions): Result<T> {
     const { _applyChecks } = this;
 
     let output = input;

--- a/src/main/shapes/EnumShape.ts
+++ b/src/main/shapes/EnumShape.ts
@@ -11,7 +11,7 @@ import { CoercibleShape } from './CoercibleShape';
  */
 export class EnumShape<T> extends CoercibleShape<T> {
   /**
-   * The list of unique values allowed as an input.
+   * The array of unique values allowed as an input.
    */
   readonly values: readonly T[];
 
@@ -25,13 +25,13 @@ export class EnumShape<T> extends CoercibleShape<T> {
   /**
    * Creates a new {@linkcode EnumShape} instance.
    *
-   * @param source The list of allowed values, a const key-value mapping, or an enum object.
+   * @param source The array of allowed values, a const key-value mapping, or an enum object.
    * @param options The type constraint options or an issue message.
    * @template T Allowed values.
    */
   constructor(
     /**
-     * The list of allowed values, a const key-value mapping, or an enum object.
+     * The array of allowed values, a const key-value mapping, or an enum object.
      */
     readonly source: readonly T[] | ReadonlyDict<T>,
     options?: ConstraintOptions | Message

--- a/src/main/shapes/FunctionShape.ts
+++ b/src/main/shapes/FunctionShape.ts
@@ -1,6 +1,6 @@
 import { AnyShape, defaultParseOptions, Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
-import { applyForResult, cloneObject, copyChecks, createIssueFactory, isArray, ok, unshiftPath } from '../utils';
+import { applyForResult, cloneInstance, copyChecks, createIssueFactory, isArray, ok, unshiftPath } from '../utils';
 import { CODE_TYPE, ERROR_ASYNC_DELEGATOR, MESSAGE_FUNCTION_TYPE, TYPE_FUNCTION } from '../constants';
 import { ValidationError } from '../ValidationError';
 
@@ -93,7 +93,7 @@ export class FunctionShape<A extends Shape, R extends AnyShape | null, T extends
    * @returns The new function shape.
    */
   bare(): this {
-    const shape = cloneObject(this);
+    const shape = cloneInstance(this);
     shape.isBare = true;
     return shape;
   }
@@ -105,7 +105,7 @@ export class FunctionShape<A extends Shape, R extends AnyShape | null, T extends
    * @returns The new function shape.
    */
   options(options: ParseOptions): this {
-    const shape = cloneObject(this);
+    const shape = cloneInstance(this);
     shape._parseOptions = options;
     return shape;
   }

--- a/src/main/shapes/FunctionShape.ts
+++ b/src/main/shapes/FunctionShape.ts
@@ -1,6 +1,6 @@
 import { AnyShape, defaultParseOptions, Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
-import { callApply, cloneObject, copyChecks, createIssueFactory, isArray, ok, unshiftPath } from '../utils';
+import { applyForResult, cloneObject, copyChecks, createIssueFactory, isArray, ok, unshiftPath } from '../utils';
 import { CODE_TYPE, ERROR_ASYNC_DELEGATOR, MESSAGE_FUNCTION_TYPE, TYPE_FUNCTION } from '../constants';
 import { ValidationError } from '../ValidationError';
 
@@ -157,22 +157,22 @@ export class FunctionShape<A extends Shape, R extends AnyShape | null, T extends
         let result;
 
         if (thisShape !== null) {
-          result = callApply(thisShape, this, options, thisResult => {
+          result = applyForResult(thisShape, this, options, thisResult => {
             const thisValue = getOrDie(thisResult, 'this', this);
 
-            return callApply(argsShape, args, options, argsResult =>
+            return applyForResult(argsShape, args, options, argsResult =>
               fn.apply(thisValue, getOrDie(argsResult, 'arguments', args))
             );
           });
         } else {
-          result = callApply(argsShape, args, options, argsResult =>
+          result = applyForResult(argsShape, args, options, argsResult =>
             fn.apply(this, getOrDie(argsResult, 'arguments', args))
           );
         }
 
         if (returnShape !== null) {
           result = Promise.resolve(result).then(result =>
-            callApply(returnShape, result, options, resultResult => getOrDie(resultResult, 'return', result))
+            applyForResult(returnShape, result, options, resultResult => getOrDie(resultResult, 'return', result))
           );
         }
 

--- a/src/main/shapes/FunctionShape.ts
+++ b/src/main/shapes/FunctionShape.ts
@@ -1,4 +1,4 @@
-import { AnyShape, ApplyResult, defaultParseOptions, Shape, ValueType } from './Shape';
+import { AnyShape, defaultParseOptions, Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { callApply, cloneObject, copyChecks, createIssueFactory, isArray, ok, unshiftPath } from '../utils';
 import { CODE_TYPE, ERROR_ASYNC_DELEGATOR, MESSAGE_FUNCTION_TYPE, TYPE_FUNCTION } from '../constants';
@@ -185,7 +185,7 @@ export class FunctionShape<A extends Shape, R extends AnyShape | null, T extends
     return [TYPE_FUNCTION];
   }
 
-  protected _apply(input: any, options: ParseOptions): ApplyResult<InferDelegator<A, R, T>> {
+  protected _apply(input: any, options: ParseOptions): Result<InferDelegator<A, R, T>> {
     const { _applyChecks } = this;
 
     let issues = null;
@@ -206,7 +206,7 @@ export class FunctionShape<A extends Shape, R extends AnyShape | null, T extends
   }
 }
 
-function getOrDie<T>(result: ApplyResult<T>, part: 'this' | 'arguments' | 'return', input: any): T {
+function getOrDie<T>(result: Result<T>, part: 'this' | 'arguments' | 'return', input: any): T {
   if (result === null) {
     return input;
   }

--- a/src/main/shapes/FunctionShape.ts
+++ b/src/main/shapes/FunctionShape.ts
@@ -58,8 +58,7 @@ export class FunctionShape<A extends Shape, R extends AnyShape | null, T extends
   }
 
   /**
-   * `true` if some shapes that describe the function signature are {@link Shape.isAsync async}, otherwise returns
-   * `false`.
+   * `true` if some shapes that describe the function signature are {@link Shape.isAsync async}, or `false` otherwise.
    */
   get isDelegatorAsync(): boolean {
     return this.returnShape?.isAsync || this.thisShape?.isAsync || this.argsShape.isAsync;

--- a/src/main/shapes/FunctionShape.ts
+++ b/src/main/shapes/FunctionShape.ts
@@ -1,6 +1,14 @@
 import { AnyShape, defaultParseOptions, Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
-import { applyForResult, cloneInstance, copyChecks, createIssueFactory, isArray, ok, unshiftPath } from '../utils';
+import {
+  applyForResult,
+  cloneInstance,
+  copyChecks,
+  createIssueFactory,
+  isArray,
+  ok,
+  unshiftIssuesPath,
+} from '../utils';
 import { CODE_TYPE, ERROR_ASYNC_DELEGATOR, MESSAGE_FUNCTION_TYPE, TYPE_FUNCTION } from '../constants';
 import { ValidationError } from '../ValidationError';
 
@@ -210,7 +218,7 @@ function getOrDie<T>(result: Result<T>, part: 'this' | 'arguments' | 'return', i
     return input;
   }
   if (isArray(result)) {
-    unshiftPath(result, part);
+    unshiftIssuesPath(result, part);
     throw new ValidationError(result);
   }
   return result.value;

--- a/src/main/shapes/InstanceShape.ts
+++ b/src/main/shapes/InstanceShape.ts
@@ -1,6 +1,6 @@
 import { Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
-import { createIssueFactory, isConstructorOf } from '../utils';
+import { createIssueFactory, isSubclass } from '../utils';
 import { CODE_INSTANCE, MESSAGE_INSTANCE, TYPE_ARRAY, TYPE_DATE, TYPE_OBJECT } from '../constants';
 
 /**
@@ -25,10 +25,10 @@ export class InstanceShape<C extends new (...args: any[]) => any> extends Shape<
   }
 
   protected _getInputTypes(): readonly ValueType[] {
-    if (isConstructorOf(this.ctor, Array)) {
+    if (isSubclass(this.ctor, Array)) {
       return [TYPE_ARRAY];
     }
-    if (isConstructorOf(this.ctor, Date)) {
+    if (isSubclass(this.ctor, Date)) {
       return [TYPE_DATE];
     }
     return [TYPE_OBJECT];

--- a/src/main/shapes/InstanceShape.ts
+++ b/src/main/shapes/InstanceShape.ts
@@ -1,7 +1,7 @@
-import { ApplyResult, Shape, ValueType } from './Shape';
+import { Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
-import { createIssueFactory } from '../utils';
-import { CODE_INSTANCE, MESSAGE_INSTANCE, TYPE_ARRAY, TYPE_OBJECT } from '../constants';
+import { createIssueFactory, isConstructorOf } from '../utils';
+import { CODE_INSTANCE, MESSAGE_INSTANCE, TYPE_ARRAY, TYPE_DATE, TYPE_OBJECT } from '../constants';
 
 /**
  * The shape of the class instance.
@@ -25,14 +25,16 @@ export class InstanceShape<C extends new (...args: any[]) => any> extends Shape<
   }
 
   protected _getInputTypes(): readonly ValueType[] {
-    if ((this.ctor as unknown) === Array || Array.prototype.isPrototypeOf(this.ctor.prototype)) {
+    if (isConstructorOf(this.ctor, Array)) {
       return [TYPE_ARRAY];
-    } else {
-      return [TYPE_OBJECT];
     }
+    if (isConstructorOf(this.ctor, Date)) {
+      return [TYPE_DATE];
+    }
+    return [TYPE_OBJECT];
   }
 
-  protected _apply(input: unknown, options: ParseOptions): ApplyResult<InstanceType<C>> {
+  protected _apply(input: unknown, options: ParseOptions): Result<InstanceType<C>> {
     const { _applyChecks } = this;
 
     if (!(input instanceof this.ctor)) {

--- a/src/main/shapes/IntersectionShape.ts
+++ b/src/main/shapes/IntersectionShape.ts
@@ -1,4 +1,4 @@
-import { AnyShape, ApplyResult, DeepPartialProtocol, DeepPartialShape, Shape, ValueType } from './Shape';
+import { AnyShape, DeepPartialProtocol, DeepPartialShape, Result, Shape, ValueType } from './Shape';
 import {
   callApply,
   concatIssues,
@@ -80,7 +80,7 @@ export class IntersectionShape<U extends readonly AnyShape[]>
     return intersectValueTypes(this.shapes.map(shape => shape.inputTypes));
   }
 
-  protected _apply(input: any, options: ParseOptions): ApplyResult<ToIntersection<U[number]>['output']> {
+  protected _apply(input: any, options: ParseOptions): Result<ToIntersection<U[number]>['output']> {
     const { shapes } = this;
     const shapesLength = shapes.length;
 
@@ -118,7 +118,7 @@ export class IntersectionShape<U extends readonly AnyShape[]>
     return issues;
   }
 
-  protected _applyAsync(input: any, options: ParseOptions): Promise<ApplyResult<ToIntersection<U[number]>['output']>> {
+  protected _applyAsync(input: any, options: ParseOptions): Promise<Result<ToIntersection<U[number]>['output']>> {
     return new Promise(resolve => {
       const { shapes } = this;
       const shapesLength = shapes.length;
@@ -127,7 +127,7 @@ export class IntersectionShape<U extends readonly AnyShape[]>
       let issues: Issue[] | null = null;
       let index = -1;
 
-      const applyResult = (result: ApplyResult) => {
+      const handleResult = (result: Result) => {
         if (result !== null) {
           if (isArray(result)) {
             if (!options.verbose) {
@@ -147,11 +147,11 @@ export class IntersectionShape<U extends readonly AnyShape[]>
         return next();
       };
 
-      const next = (): ApplyResult | Promise<ApplyResult> => {
+      const next = (): Result | Promise<Result> => {
         index++;
 
         if (index !== shapesLength) {
-          return callApply(shapes[index], input, options, applyResult);
+          return callApply(shapes[index], input, options, handleResult);
         }
         if (issues === null) {
           return this._applyIntersection(input, outputs, options);
@@ -170,7 +170,7 @@ export class IntersectionShape<U extends readonly AnyShape[]>
     input: any,
     outputs: any[] | null,
     options: ParseOptions
-  ): ApplyResult<ToIntersection<U[number]>['output']> {
+  ): Result<ToIntersection<U[number]>['output']> {
     const { shapes, _applyChecks } = this;
 
     let result = null;

--- a/src/main/shapes/IntersectionShape.ts
+++ b/src/main/shapes/IntersectionShape.ts
@@ -191,9 +191,8 @@ export class IntersectionShape<U extends readonly AnyShape[]>
   ): Result<ToIntersection<U[number]>['output']> {
     const { shapes, _applyChecks } = this;
 
-    let result = null;
     let output = input;
-    let issues;
+    let issues = null;
 
     if (outputs !== null) {
       let outputsLength = outputs.length;
@@ -210,13 +209,14 @@ export class IntersectionShape<U extends readonly AnyShape[]>
       if (output === NEVER) {
         return this._typeIssueFactory(input, options);
       }
-      if (!isEqual(output, input)) {
-        result = ok(output);
-      }
     }
 
-    if (_applyChecks === null || (issues = _applyChecks(output, null, options)) === null) {
-      return result;
+    if (
+      (_applyChecks === null || (issues = _applyChecks(output, null, options)) === null) &&
+      outputs !== null &&
+      !isEqual(output, input)
+    ) {
+      return ok(output);
     }
     return issues;
   }

--- a/src/main/shapes/IntersectionShape.ts
+++ b/src/main/shapes/IntersectionShape.ts
@@ -31,6 +31,11 @@ export type DeepPartialIntersectionShape<U extends readonly AnyShape[]> = Inters
   [K in keyof U]: U[K] extends AnyShape ? DeepPartialShape<U[K]> : never;
 }>;
 
+/**
+ * The shape that requires an input to conform all given shapes.
+ *
+ * @template U The array of shapes that comprise an intersection.
+ */
 export class IntersectionShape<U extends readonly AnyShape[]>
   extends Shape<ToIntersection<U[number]>['input'], ToIntersection<U[number]>['output']>
   implements DeepPartialProtocol<DeepPartialIntersectionShape<U>>
@@ -38,7 +43,20 @@ export class IntersectionShape<U extends readonly AnyShape[]>
   protected _options;
   protected _typeIssueFactory;
 
-  constructor(readonly shapes: U, options?: ConstraintOptions | Message) {
+  /**
+   * Creates a new {@linkcode IntersectionShape} instance.
+   *
+   * @param shapes The array of shapes that comprise an intersection.
+   * @param options The union constraint options or an issue message.
+   * @template U The array of shapes that comprise an intersection.
+   */
+  constructor(
+    /**
+     * The array of shapes that comprise an intersection.
+     */
+    readonly shapes: U,
+    options?: ConstraintOptions | Message
+  ) {
     super();
 
     this._options = options;

--- a/src/main/shapes/IntersectionShape.ts
+++ b/src/main/shapes/IntersectionShape.ts
@@ -1,6 +1,6 @@
 import { AnyShape, DeepPartialProtocol, DeepPartialShape, Result, Shape, ValueType } from './Shape';
 import {
-  callApply,
+  applyForResult,
   concatIssues,
   copyUnsafeChecks,
   createIssueFactory,
@@ -151,7 +151,7 @@ export class IntersectionShape<U extends readonly AnyShape[]>
         index++;
 
         if (index !== shapesLength) {
-          return callApply(shapes[index], input, options, handleResult);
+          return applyForResult(shapes[index], input, options, handleResult);
         }
         if (issues === null) {
           return this._applyIntersection(input, outputs, options);

--- a/src/main/shapes/JSONShape.ts
+++ b/src/main/shapes/JSONShape.ts
@@ -1,4 +1,4 @@
-import { ApplyResult, Shape, ValueType } from './Shape';
+import { Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { cloneObject, createIssueFactory, ok } from '../utils';
 import { CODE_JSON, CODE_TYPE, MESSAGE_JSON, MESSAGE_STRING_TYPE, TYPE_STRING } from '../constants';
@@ -48,7 +48,7 @@ export class JSONShape extends Shape<string, any> {
     return [TYPE_STRING];
   }
 
-  protected _apply(input: unknown, options: ParseOptions): ApplyResult {
+  protected _apply(input: unknown, options: ParseOptions): Result {
     const { _applyChecks } = this;
 
     let output;

--- a/src/main/shapes/JSONShape.ts
+++ b/src/main/shapes/JSONShape.ts
@@ -1,6 +1,6 @@
 import { Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
-import { cloneObject, createIssueFactory, ok } from '../utils';
+import { cloneInstance, createIssueFactory, ok } from '../utils';
 import { CODE_JSON, CODE_TYPE, MESSAGE_JSON, MESSAGE_STRING_TYPE, TYPE_STRING } from '../constants';
 
 /**
@@ -39,7 +39,7 @@ export class JSONShape extends Shape<string, any> {
      */
     reviver: (this: any, key: string, value: any) => any
   ): this {
-    const shape = cloneObject(this);
+    const shape = cloneInstance(this);
     shape._reviver = reviver;
     return shape;
   }

--- a/src/main/shapes/LazyShape.ts
+++ b/src/main/shapes/LazyShape.ts
@@ -1,10 +1,10 @@
-import { AnyShape, ApplyResult, DeepPartialProtocol, DeepPartialShape, Shape, ValueType } from './Shape';
+import { AnyShape, DeepPartialProtocol, DeepPartialShape, Result, Shape, ValueType } from './Shape';
 import { ParseOptions } from '../shared-types';
 import { copyUnsafeChecks, isArray, returnArray, returnFalse, toDeepPartialShape } from '../utils';
 import { ERROR_SHAPE_EXPECTED } from '../constants';
 
 /**
- * Lazily resolves a shape using the provider.
+ * Lazily resolves a shape using the provider callback.
  *
  * @template S The resolved shape.
  */
@@ -17,7 +17,7 @@ export class LazyShape<S extends AnyShape>
   /**
    * Creates a new {@linkcode LazyShape} instance.
    *
-   * @param shapeProvider The provider that returns the resolved shape.
+   * @param shapeProvider The provider callback that returns the shape.
    * @template S The resolved shape.
    */
   constructor(shapeProvider: () => S) {
@@ -27,7 +27,7 @@ export class LazyShape<S extends AnyShape>
   }
 
   /**
-   * The resolved shape.
+   * The lazy-loaded shape.
    */
   get shape(): S {
     const shape = this._shapeProvider();
@@ -83,15 +83,15 @@ export class LazyShape<S extends AnyShape>
     }
   }
 
-  protected _apply(input: unknown, options: ParseOptions): ApplyResult<S['output']> {
-    return this._applyResult(this.shape['_apply'](input, options), input, options);
+  protected _apply(input: unknown, options: ParseOptions): Result<S['output']> {
+    return this._handleResult(this.shape['_apply'](input, options), input, options);
   }
 
-  protected _applyAsync(input: unknown, options: ParseOptions): Promise<ApplyResult<S['output']>> {
-    return this.shape['_applyAsync'](input, options).then(result => this._applyResult(result, input, options));
+  protected _applyAsync(input: unknown, options: ParseOptions): Promise<Result<S['output']>> {
+    return this.shape['_applyAsync'](input, options).then(result => this._handleResult(result, input, options));
   }
 
-  private _applyResult(result: ApplyResult, input: unknown, options: ParseOptions): ApplyResult<S['output']> {
+  private _handleResult(result: Result, input: unknown, options: ParseOptions): Result<S['output']> {
     const { _applyChecks } = this;
 
     let output = input;

--- a/src/main/shapes/LazyShape.ts
+++ b/src/main/shapes/LazyShape.ts
@@ -1,6 +1,6 @@
 import { AnyShape, DeepPartialProtocol, DeepPartialShape, Result, Shape, ValueType } from './Shape';
 import { ParseOptions } from '../shared-types';
-import { copyUnsafeChecks, isArray, returnArray, returnFalse, toDeepPartialShape } from '../utils';
+import { copyUnsafeChecks, isArray, toDeepPartialShape } from '../utils';
 import { ERROR_SHAPE_EXPECTED } from '../constants';
 
 /**
@@ -108,4 +108,12 @@ export class LazyShape<S extends AnyShape>
     }
     return issues;
   }
+}
+
+function returnFalse(): boolean {
+  return false;
+}
+
+function returnArray(): any[] {
+  return [];
 }

--- a/src/main/shapes/MapShape.ts
+++ b/src/main/shapes/MapShape.ts
@@ -1,7 +1,7 @@
 import { AnyShape, DeepPartialProtocol, DeepPartialShape, OptionalDeepPartialShape, Result, ValueType } from './Shape';
 import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
 import {
-  callApply,
+  applyForResult,
   concatIssues,
   copyUnsafeChecks,
   createIssueFactory,
@@ -191,7 +191,7 @@ export class MapShape<K extends AnyShape, V extends AnyShape>
             outputKey = keyResult.value;
           }
         }
-        return callApply(valueShape, value, options, handleValueResult);
+        return applyForResult(valueShape, value, options, handleValueResult);
       };
 
       const handleValueResult = (valueResult: Result) => {
@@ -224,7 +224,7 @@ export class MapShape<K extends AnyShape, V extends AnyShape>
           key = outputKey = entry[0];
           value = outputValue = entry[1];
 
-          return callApply(keyShape, key, options, handleKeyResult);
+          return applyForResult(keyShape, key, options, handleKeyResult);
         }
 
         const output = changed ? new Map(entries) : input;

--- a/src/main/shapes/MapShape.ts
+++ b/src/main/shapes/MapShape.ts
@@ -243,7 +243,7 @@ export class MapShape<K extends AnyShape, V extends AnyShape>
   }
 
   /**
-   * Coerces value to a list of `Map` entries, or returns `null` if coercion isn't possible.
+   * Coerces value to a array of `Map` entries, or returns `null` if coercion isn't possible.
    *
    * @param value The non-`Map` value to coerce.
    */

--- a/src/main/shapes/MapShape.ts
+++ b/src/main/shapes/MapShape.ts
@@ -11,7 +11,7 @@ import {
   isObjectLike,
   ok,
   toDeepPartialShape,
-  unshiftPath,
+  unshiftIssuesPath,
 } from '../utils';
 import { CODE_TYPE, MESSAGE_MAP_TYPE, TYPE_ARRAY, TYPE_MAP, TYPE_OBJECT } from '../constants';
 import { CoercibleShape } from './CoercibleShape';
@@ -107,7 +107,7 @@ export class MapShape<K extends AnyShape, V extends AnyShape>
 
       if (keyResult !== null) {
         if (isArray(keyResult)) {
-          unshiftPath(keyResult, key);
+          unshiftIssuesPath(keyResult, key);
 
           if (!options.verbose) {
             return keyResult;
@@ -122,7 +122,7 @@ export class MapShape<K extends AnyShape, V extends AnyShape>
 
       if (valueResult !== null) {
         if (isArray(valueResult)) {
-          unshiftPath(valueResult, key);
+          unshiftIssuesPath(valueResult, key);
 
           if (!options.verbose) {
             return valueResult;
@@ -181,7 +181,7 @@ export class MapShape<K extends AnyShape, V extends AnyShape>
       const handleKeyResult = (keyResult: Result) => {
         if (keyResult !== null) {
           if (isArray(keyResult)) {
-            unshiftPath(keyResult, key);
+            unshiftIssuesPath(keyResult, key);
 
             if (!options.verbose) {
               return keyResult;
@@ -197,7 +197,7 @@ export class MapShape<K extends AnyShape, V extends AnyShape>
       const handleValueResult = (valueResult: Result) => {
         if (valueResult !== null) {
           if (isArray(valueResult)) {
-            unshiftPath(valueResult, key);
+            unshiftIssuesPath(valueResult, key);
 
             if (!options.verbose) {
               return valueResult;

--- a/src/main/shapes/NeverShape.ts
+++ b/src/main/shapes/NeverShape.ts
@@ -1,4 +1,4 @@
-import { ApplyResult, Shape, ValueType } from './Shape';
+import { Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory } from '../utils';
 import { CODE_TYPE, MESSAGE_NEVER_TYPE, TYPE_NEVER } from '../constants';
@@ -24,7 +24,7 @@ export class NeverShape extends Shape<never> {
     return [TYPE_NEVER];
   }
 
-  protected _apply(input: unknown, options: ParseOptions): ApplyResult<never> {
+  protected _apply(input: unknown, options: ParseOptions): Result<never> {
     return this._typeIssueFactory(input, options);
   }
 }

--- a/src/main/shapes/NumberShape.ts
+++ b/src/main/shapes/NumberShape.ts
@@ -1,4 +1,4 @@
-import { ApplyResult, Shape, ValueType } from './Shape';
+import { Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { addConstraint, cloneObject, createIssueFactory, isArray, isNumber, ok } from '../utils';
 import {
@@ -44,6 +44,20 @@ export class NumberShape extends CoercibleShape<number> {
     super();
 
     this._typeIssueFactory = createIssueFactory(CODE_TYPE, MESSAGE_NUMBER_TYPE, options, TYPE_NUMBER);
+  }
+
+  /**
+   * `true` if the shape constrains a finite number, or `false` otherwise.
+   */
+  get isFinite(): boolean {
+    return this._typePredicate === Number.isFinite || this.isInteger;
+  }
+
+  /**
+   * `true` if the shape constrains an integer number, or `false` otherwise.
+   */
+  get isInteger(): boolean {
+    return this._typePredicate === Number.isInteger;
   }
 
   /**
@@ -202,20 +216,6 @@ export class NumberShape extends CoercibleShape<number> {
   }
 
   /**
-   * `true` if the shape constrains a finite number, or `false` otherwise.
-   */
-  get isFinite(): boolean {
-    return this._typePredicate === Number.isFinite || this.isInteger;
-  }
-
-  /**
-   * `true` if the shape constrains an integer number, or `false` otherwise.
-   */
-  get isInteger(): boolean {
-    return this._typePredicate === Number.isInteger;
-  }
-
-  /**
    * Allows `NaN` as an input and output value, or replaces an input `NaN` value with a default output value.
    *
    * @param [defaultValue = NaN] The value that is used instead of `NaN` in the output.
@@ -232,7 +232,7 @@ export class NumberShape extends CoercibleShape<number> {
     }
   }
 
-  protected _apply(input: any, options: ParseOptions): ApplyResult<number> {
+  protected _apply(input: any, options: ParseOptions): Result<number> {
     const { _applyChecks } = this;
 
     let output = input;

--- a/src/main/shapes/NumberShape.ts
+++ b/src/main/shapes/NumberShape.ts
@@ -1,6 +1,6 @@
 import { Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
-import { addConstraint, cloneObject, createIssueFactory, isArray, isNumber, ok } from '../utils';
+import { addConstraint, cloneInstance, createIssueFactory, isArray, isNumber, ok } from '../utils';
 import {
   CODE_NUMBER_FINITE,
   CODE_NUMBER_GT,
@@ -192,7 +192,7 @@ export class NumberShape extends CoercibleShape<number> {
    * @returns The clone of the shape.
    */
   finite(options?: ConstraintOptions | Message): this {
-    const shape = cloneObject(this);
+    const shape = cloneInstance(this);
 
     shape._typeIssueFactory = createIssueFactory(CODE_NUMBER_FINITE, MESSAGE_NUMBER_FINITE, options, undefined);
     shape._typePredicate = Number.isFinite;
@@ -207,7 +207,7 @@ export class NumberShape extends CoercibleShape<number> {
    * @returns The clone of the shape.
    */
   integer(options?: ConstraintOptions | Message): this {
-    const shape = cloneObject(this);
+    const shape = cloneInstance(this);
 
     shape._typeIssueFactory = createIssueFactory(CODE_NUMBER_INTEGER, MESSAGE_NUMBER_INTEGER, options, undefined);
     shape._typePredicate = Number.isInteger;

--- a/src/main/shapes/NumberShape.ts
+++ b/src/main/shapes/NumberShape.ts
@@ -1,6 +1,6 @@
 import { Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
-import { addConstraint, cloneInstance, createIssueFactory, isArray, isNumber, ok } from '../utils';
+import { abs, addConstraint, cloneInstance, createIssueFactory, floor, isArray, isNumber, max, ok } from '../utils';
 import {
   CODE_NUMBER_FINITE,
   CODE_NUMBER_GT,
@@ -300,8 +300,6 @@ export interface NumberShape {
 NumberShape.prototype.min = NumberShape.prototype.gte;
 
 NumberShape.prototype.max = NumberShape.prototype.lte;
-
-const { abs, floor, max } = Math;
 
 /**
  * Checks that `a` is divisible without a remainder by `b`.

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -1,8 +1,8 @@
 import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
 import { CODE_TYPE, CODE_UNKNOWN_KEYS, MESSAGE_OBJECT_TYPE, MESSAGE_UNKNOWN_KEYS, TYPE_OBJECT } from '../constants';
 import {
+  applyForResult,
   Bits,
-  callApply,
   cloneObject,
   cloneObjectEnumerableKeys,
   cloneObjectKnownKeys,
@@ -458,7 +458,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
         if (index !== entriesLength) {
           const entry = entries[index];
           key = entry[0];
-          return callApply(entry[2], entry[1], options, handleValueResult);
+          return applyForResult(entry[2], entry[1], options, handleValueResult);
         }
 
         if (_applyChecks !== null && (_isUnsafe || issues === null)) {

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -174,7 +174,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
   /**
    * Returns an object shape that only has properties with listed keys.
    *
-   * @param keys The list of property keys to pick.
+   * @param keys The array of property keys to pick.
    * @returns The new object shape.
    * @template K The tuple of keys to pick.
    */
@@ -192,7 +192,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
   /**
    * Returns an object shape that doesn't have the listed keys.
    *
-   * @param keys The list of property keys to omit.
+   * @param keys The array of property keys to omit.
    * @returns The new object shape.
    * @template K The tuple of keys to omit.
    */
@@ -217,9 +217,9 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
   /**
    * Returns an object shape with keys marked as optional.
    *
-   * @param keys The list of property keys to make optional.
+   * @param keys The array of property keys to make optional.
    * @returns The new object shape.
-   * @template K The list of string keys.
+   * @template K The array of string keys.
    */
   partial<K extends StringKeyof<P>[]>(keys: K): ObjectShape<Omit<P, K[number]> & OptionalProps<Pick<P, K[number]>>, R>;
 
@@ -254,9 +254,9 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
   /**
    * Returns an object shape with keys marked as required.
    *
-   * @param keys The list of property keys to make required.
+   * @param keys The array of property keys to make required.
    * @returns The new object shape.
-   * @template K The list of string keys.
+   * @template K The array of string keys.
    */
   required<K extends StringKeyof<P>[]>(keys: K): ObjectShape<Omit<P, K[number]> & RequiredProps<Pick<P, K[number]>>, R>;
 

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -2,7 +2,6 @@ import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types
 import { CODE_TYPE, CODE_UNKNOWN_KEYS, MESSAGE_OBJECT_TYPE, MESSAGE_UNKNOWN_KEYS, TYPE_OBJECT } from '../constants';
 import {
   applyForResult,
-  Bits,
   cloneObject,
   cloneObjectEnumerableKeys,
   cloneObjectKnownKeys,
@@ -10,13 +9,14 @@ import {
   copyUnsafeChecks,
   createIssueFactory,
   Dict,
-  enableBitAt,
+  enableMask,
   isArray,
   isAsyncShape,
-  isBitEnabledAt,
   isEqual,
+  isMaskEnabled,
   isObjectLike,
   isPlainObject,
+  Mask,
   ok,
   ReadonlyDict,
   setObjectProperty,
@@ -364,7 +364,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
       let output = input;
 
       let seenCount = 0;
-      let seenBits: Bits = 0;
+      let seenMask: Mask = 0;
 
       let unknownKeys: string[] | null = null;
 
@@ -378,7 +378,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
 
         if (index !== -1) {
           seenCount++;
-          seenBits = enableBitAt(seenBits, index);
+          seenMask = enableMask(seenMask, index);
 
           valueShape = _valueShapes[index];
         }
@@ -419,7 +419,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
 
       if (seenCount !== keysLength) {
         for (let i = 0; i < keysLength; ++i) {
-          if (isBitEnabledAt(seenBits, i)) {
+          if (isMaskEnabled(seenMask, i)) {
             continue;
           }
 
@@ -531,7 +531,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
     let output = input;
 
     let seenCount = 0;
-    let seenBits: Bits = 0;
+    let seenMask: Mask = 0;
 
     let unknownKeys = null;
 
@@ -544,7 +544,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
       // The key is known
       if (index !== -1) {
         seenCount++;
-        seenBits = enableBitAt(seenBits, index);
+        seenMask = enableMask(seenMask, index);
 
         valueShape = _valueShapes[index];
       }
@@ -608,7 +608,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
     // Parse absent known keys
     if (seenCount !== keysLength) {
       for (let i = 0; i < keysLength; ++i) {
-        if (isBitEnabledAt(seenBits, i)) {
+        if (isMaskEnabled(seenMask, i)) {
           continue;
         }
 

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -2,7 +2,7 @@ import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types
 import { CODE_TYPE, CODE_UNKNOWN_KEYS, MESSAGE_OBJECT_TYPE, MESSAGE_UNKNOWN_KEYS, TYPE_OBJECT } from '../constants';
 import {
   applyForResult,
-  cloneObject,
+  cloneInstance,
   cloneObjectEnumerableKeys,
   cloneObjectKnownKeys,
   concatIssues,
@@ -325,7 +325,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
    * Constrains an object to be an `Object` instance or to have a `null` prototype.
    */
   plain(): this {
-    const shape = cloneObject(this);
+    const shape = cloneInstance(this);
     shape._typePredicate = isPlainObject;
     return shape;
   }
@@ -419,12 +419,10 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
 
       if (seenCount !== keysLength) {
         for (let i = 0; i < keysLength; ++i) {
-          if (isMaskEnabled(seenMask, i)) {
-            continue;
+          if (!isMaskEnabled(seenMask, i)) {
+            const key = keys[i];
+            entries.push([key, input[key], _valueShapes[i]]);
           }
-
-          const key = keys[i];
-          entries.push([key, input[key], _valueShapes[i]]);
         }
       }
 

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -2,9 +2,9 @@ import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types
 import { CODE_TYPE, CODE_UNKNOWN_KEYS, MESSAGE_OBJECT_TYPE, MESSAGE_UNKNOWN_KEYS, TYPE_OBJECT } from '../constants';
 import {
   applyForResult,
+  cloneDict,
+  cloneDictKeys,
   cloneInstance,
-  cloneObjectEnumerableKeys,
-  cloneObjectKnownKeys,
   concatIssues,
   copyUnsafeChecks,
   createIssueFactory,
@@ -21,7 +21,7 @@ import {
   ReadonlyDict,
   setObjectProperty,
   toDeepPartialShape,
-  unshiftPath,
+  unshiftIssuesPath,
 } from '../utils';
 import {
   AllowLiteralShape,
@@ -403,7 +403,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
         }
 
         if (input === output && keysMode === 'stripped') {
-          output = cloneObjectKnownKeys(input, keys);
+          output = cloneDictKeys(input, keys);
         }
       }
 
@@ -434,7 +434,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
       const handleValueResult = (result: Result) => {
         if (result !== null) {
           if (isArray(result)) {
-            unshiftPath(result, key);
+            unshiftIssuesPath(result, key);
 
             if (!options.verbose) {
               return result;
@@ -442,7 +442,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
             issues = concatIssues(issues, result);
           } else if ((_isUnsafe || issues === null) && !isEqual(input[key], result.value)) {
             if (input === output) {
-              output = cloneObjectEnumerableKeys(input);
+              output = cloneDict(input);
             }
             setObjectProperty(output, key, result.value);
           }
@@ -492,7 +492,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
         continue;
       }
       if (isArray(result)) {
-        unshiftPath(result, key);
+        unshiftIssuesPath(result, key);
 
         if (!options.verbose) {
           return result;
@@ -502,7 +502,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
       }
       if ((_isUnsafe || issues === null) && !isEqual(value, result.value)) {
         if (input === output) {
-          output = cloneObjectEnumerableKeys(input);
+          output = cloneDict(input);
         }
         setObjectProperty(output, key, result.value);
       }
@@ -555,7 +555,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
           continue;
         }
         if (isArray(result)) {
-          unshiftPath(result, key);
+          unshiftIssuesPath(result, key);
 
           if (!options.verbose) {
             return result;
@@ -565,7 +565,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
         }
         if ((_isUnsafe || issues === null) && !isEqual(value, result.value)) {
           if (input === output) {
-            output = restShape === null ? cloneObjectKnownKeys(input, keys) : cloneObjectEnumerableKeys(input);
+            output = restShape === null ? cloneDictKeys(input, keys) : cloneDict(input);
           }
           setObjectProperty(output, key, result.value);
         }
@@ -589,7 +589,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
 
       // Unknown keys are stripped
       if (input === output && (_isUnsafe || issues === null)) {
-        output = cloneObjectKnownKeys(input, keys);
+        output = cloneDictKeys(input, keys);
       }
     }
 
@@ -618,7 +618,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
           continue;
         }
         if (isArray(result)) {
-          unshiftPath(result, key);
+          unshiftIssuesPath(result, key);
 
           if (!options.verbose) {
             return result;
@@ -628,7 +628,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
         }
         if ((_isUnsafe || issues === null) && !isEqual(value, result.value)) {
           if (input === output) {
-            output = cloneObjectEnumerableKeys(input);
+            output = cloneDict(input);
           }
           setObjectProperty(output, key, result.value);
         }

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -19,7 +19,7 @@ import {
   isPlainObject,
   ok,
   ReadonlyDict,
-  setKeyValue,
+  setObjectProperty,
   toDeepPartialShape,
   unshiftPath,
 } from '../utils';
@@ -446,7 +446,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
             if (input === output) {
               output = cloneObjectEnumerableKeys(input);
             }
-            setKeyValue(output, key, result.value);
+            setObjectProperty(output, key, result.value);
           }
         }
         return next();
@@ -506,7 +506,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
         if (input === output) {
           output = cloneObjectEnumerableKeys(input);
         }
-        setKeyValue(output, key, result.value);
+        setObjectProperty(output, key, result.value);
       }
     }
 
@@ -569,7 +569,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
           if (input === output) {
             output = restShape === null ? cloneObjectKnownKeys(input, keys) : cloneObjectEnumerableKeys(input);
           }
-          setKeyValue(output, key, result.value);
+          setObjectProperty(output, key, result.value);
         }
         continue;
       }
@@ -632,7 +632,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
           if (input === output) {
             output = cloneObjectEnumerableKeys(input);
           }
-          setKeyValue(output, key, result.value);
+          setObjectProperty(output, key, result.value);
         }
       }
     }

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -37,7 +37,7 @@ import { EnumShape } from './EnumShape';
 
 // prettier-ignore
 export type InferObject<P extends ReadonlyDict<AnyShape>, R extends AnyShape | null, C extends 'input' | 'output'> =
-  Prettify<UndefinedAsOptional<{ [K in keyof P]: P[K][C] }> & InferIndexer<R, C>>;
+  Prettify<UndefinedAsOptionalProps<{ [K in keyof P]: P[K][C] }> & InferIndexer<R, C>>;
 
 // prettier-ignore
 export type InferIndexer<R extends AnyShape | null, C extends 'input' | 'output'> =
@@ -47,15 +47,15 @@ export type StringKeyof<T extends object> = Extract<keyof T, string>;
 
 export type Prettify<T> = { [K in keyof T]: T[K] } & {};
 
-export type UndefinedAsOptional<T> = OmitBy<T, undefined> & Partial<PickBy<T, undefined>>;
+export type UndefinedAsOptionalProps<T> = OmitBy<T, undefined> & Partial<PickBy<T, undefined>>;
 
 export type OmitBy<T, V> = Omit<T, { [K in keyof T]: V extends Extract<T[K], V> ? K : never }[keyof T]>;
 
 export type PickBy<T, V> = Pick<T, { [K in keyof T]: V extends Extract<T[K], V> ? K : never }[keyof T]>;
 
-export type Optional<P extends ReadonlyDict<AnyShape>> = { [K in keyof P]: AllowLiteralShape<P[K], undefined> };
+export type OptionalProps<P extends ReadonlyDict<AnyShape>> = { [K in keyof P]: AllowLiteralShape<P[K], undefined> };
 
-export type Required<P extends ReadonlyDict<AnyShape>> = { [K in keyof P]: DenyLiteralShape<P[K], undefined> };
+export type RequiredProps<P extends ReadonlyDict<AnyShape>> = { [K in keyof P]: DenyLiteralShape<P[K], undefined> };
 
 export type KeysMode = 'preserved' | 'stripped' | 'exact';
 
@@ -212,7 +212,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
    *
    * @returns The new object shape.
    */
-  partial(): ObjectShape<Optional<P>, R>;
+  partial(): ObjectShape<OptionalProps<P>, R>;
 
   /**
    * Returns an object shape with keys marked as optional.
@@ -221,7 +221,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
    * @returns The new object shape.
    * @template K The list of string keys.
    */
-  partial<K extends StringKeyof<P>[]>(keys: K): ObjectShape<Omit<P, K[number]> & Optional<Pick<P, K[number]>>, R>;
+  partial<K extends StringKeyof<P>[]>(keys: K): ObjectShape<Omit<P, K[number]> & OptionalProps<Pick<P, K[number]>>, R>;
 
   partial(keys?: string[]) {
     const shapes: Dict<AnyShape> = {};
@@ -249,7 +249,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
    *
    * @returns The new object shape.
    */
-  required(): ObjectShape<Required<P>, R>;
+  required(): ObjectShape<RequiredProps<P>, R>;
 
   /**
    * Returns an object shape with keys marked as required.
@@ -258,7 +258,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
    * @returns The new object shape.
    * @template K The list of string keys.
    */
-  required<K extends StringKeyof<P>[]>(keys: K): ObjectShape<Omit<P, K[number]> & Required<Pick<P, K[number]>>, R>;
+  required<K extends StringKeyof<P>[]>(keys: K): ObjectShape<Omit<P, K[number]> & RequiredProps<Pick<P, K[number]>>, R>;
 
   required(keys?: string[]) {
     const shapes: Dict<AnyShape> = {};
@@ -465,7 +465,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
           issues = _applyChecks(output, issues, options);
         }
         if (issues === null && input !== output) {
-          return ok(output as InferObject<P, R, 'output'>);
+          return ok(output);
         }
         return issues;
       };

--- a/src/main/shapes/PromiseShape.ts
+++ b/src/main/shapes/PromiseShape.ts
@@ -1,6 +1,14 @@
 import { AnyShape, DeepPartialProtocol, OptionalDeepPartialShape, Result, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
-import { callApply, copyUnsafeChecks, createIssueFactory, isArray, isEqual, ok, toDeepPartialShape } from '../utils';
+import {
+  applyForResult,
+  copyUnsafeChecks,
+  createIssueFactory,
+  isArray,
+  isEqual,
+  ok,
+  toDeepPartialShape,
+} from '../utils';
 import { CODE_TYPE, ERROR_REQUIRES_ASYNC, MESSAGE_PROMISE_TYPE, TYPE_OBJECT, TYPE_PROMISE } from '../constants';
 import { CoercibleShape } from './CoercibleShape';
 
@@ -59,7 +67,7 @@ export class PromiseShape<S extends AnyShape>
     const { _applyChecks } = this;
 
     return output.then((value: unknown) =>
-      callApply(this.shape, value, options, result => {
+      applyForResult(this.shape, value, options, result => {
         let issues = null;
 
         if (result !== null) {

--- a/src/main/shapes/RecordShape.ts
+++ b/src/main/shapes/RecordShape.ts
@@ -10,7 +10,7 @@ import {
   isEqual,
   isObjectLike,
   ok,
-  setKeyValue,
+  setObjectProperty,
   toDeepPartialShape,
   unshiftPath,
 } from '../utils';
@@ -132,7 +132,7 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
         if (input === output) {
           output = cloneObjectEnumerableKeys(input, index);
         }
-        setKeyValue(output, outputKey, outputValue);
+        setObjectProperty(output, outputKey, outputValue);
       }
     }
 
@@ -200,7 +200,7 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
           if (input === output) {
             output = cloneObjectEnumerableKeys(input, index);
           }
-          setKeyValue(output, outputKey, outputValue);
+          setObjectProperty(output, outputKey, outputValue);
         }
 
         return next();

--- a/src/main/shapes/RecordShape.ts
+++ b/src/main/shapes/RecordShape.ts
@@ -2,7 +2,7 @@ import { AnyShape, DeepPartialProtocol, OptionalDeepPartialShape, Result, Shape,
 import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
 import {
   applyForResult,
-  cloneObjectEnumerableKeys,
+  cloneDictHead,
   concatIssues,
   copyUnsafeChecks,
   createIssueFactory,
@@ -12,7 +12,7 @@ import {
   ok,
   setObjectProperty,
   toDeepPartialShape,
-  unshiftPath,
+  unshiftIssuesPath,
 } from '../utils';
 import { CODE_TYPE, MESSAGE_OBJECT_TYPE, TYPE_OBJECT } from '../constants';
 
@@ -101,7 +101,7 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
 
         if (keyResult !== null) {
           if (isArray(keyResult)) {
-            unshiftPath(keyResult, key);
+            unshiftIssuesPath(keyResult, key);
 
             if (!options.verbose) {
               return keyResult;
@@ -117,7 +117,7 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
 
       if (valueResult !== null) {
         if (isArray(valueResult)) {
-          unshiftPath(valueResult, key);
+          unshiftIssuesPath(valueResult, key);
 
           if (!options.verbose) {
             return valueResult;
@@ -130,7 +130,7 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
 
       if ((_isUnsafe || issues === null) && (key !== outputKey || !isEqual(value, outputValue))) {
         if (input === output) {
-          output = cloneObjectEnumerableKeys(input, index);
+          output = cloneDictHead(input, index);
         }
         setObjectProperty(output, outputKey, outputValue);
       }
@@ -169,7 +169,7 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
       const handleKeyResult = (keyResult: Result) => {
         if (keyResult !== null) {
           if (isArray(keyResult)) {
-            unshiftPath(keyResult, key);
+            unshiftIssuesPath(keyResult, key);
 
             if (!options.verbose) {
               return keyResult;
@@ -185,7 +185,7 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
       const handleValueResult = (valueResult: Result) => {
         if (valueResult !== null) {
           if (isArray(valueResult)) {
-            unshiftPath(valueResult, key);
+            unshiftIssuesPath(valueResult, key);
 
             if (!options.verbose) {
               return valueResult;
@@ -198,7 +198,7 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
 
         if ((_isUnsafe || issues === null) && (key !== outputKey || !isEqual(value, outputValue))) {
           if (input === output) {
-            output = cloneObjectEnumerableKeys(input, index);
+            output = cloneDictHead(input, index);
           }
           setObjectProperty(output, outputKey, outputValue);
         }

--- a/src/main/shapes/RecordShape.ts
+++ b/src/main/shapes/RecordShape.ts
@@ -18,9 +18,7 @@ import { CODE_TYPE, MESSAGE_OBJECT_TYPE, TYPE_OBJECT } from '../constants';
 
 // prettier-ignore
 export type InferRecord<K extends Shape<string, PropertyKey> | null, V extends AnyShape, C extends 'input' | 'output'> =
-  undefined extends V[C]
-    ? Partial<Record<K extends Shape ? K[C] : string, V[C]>>
-    : Record<K extends Shape ? K[C] : string, V[C]>;
+  Record<K extends Shape ? K[C] : string, V[C]>;
 
 /**
  * The shape that describes an object with string keys and values that conform the given shape.

--- a/src/main/shapes/RecordShape.ts
+++ b/src/main/shapes/RecordShape.ts
@@ -1,7 +1,7 @@
 import { AnyShape, DeepPartialProtocol, OptionalDeepPartialShape, Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
 import {
-  callApply,
+  applyForResult,
   cloneObjectEnumerableKeys,
   concatIssues,
   copyUnsafeChecks,
@@ -179,7 +179,7 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
             outputKey = keyResult.value;
           }
         }
-        return callApply(valueShape, value, options, handleValueResult);
+        return applyForResult(valueShape, value, options, handleValueResult);
       };
 
       const handleValueResult = (valueResult: Result) => {
@@ -214,7 +214,7 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
           value = outputValue = input[key];
 
           if (keyShape !== null) {
-            return callApply(keyShape, key, options, handleKeyResult);
+            return applyForResult(keyShape, key, options, handleKeyResult);
           } else {
             return valueShape['_applyAsync'](value, options).then(handleValueResult);
           }

--- a/src/main/shapes/SetShape.ts
+++ b/src/main/shapes/SetShape.ts
@@ -11,7 +11,7 @@ import {
   ok,
   toArrayIndex,
   toDeepPartialShape,
-  unshiftPath,
+  unshiftIssuesPath,
 } from '../utils';
 import {
   CODE_SET_MAX,
@@ -148,7 +148,7 @@ export class SetShape<S extends AnyShape>
         continue;
       }
       if (isArray(result)) {
-        unshiftPath(result, i);
+        unshiftIssuesPath(result, i);
 
         if (!options.verbose) {
           return result;
@@ -197,7 +197,7 @@ export class SetShape<S extends AnyShape>
       const handleResult = (result: Result) => {
         if (result !== null) {
           if (isArray(result)) {
-            unshiftPath(result, index);
+            unshiftIssuesPath(result, index);
 
             if (!options.verbose) {
               return result;

--- a/src/main/shapes/SetShape.ts
+++ b/src/main/shapes/SetShape.ts
@@ -233,7 +233,7 @@ export class SetShape<S extends AnyShape>
   }
 
   /**
-   * Coerces value to a list of `Set` values, or returns `null` if coercion isn't possible.
+   * Coerces value to a array of `Set` values, or returns `null` if coercion isn't possible.
    *
    * @param value The non-`Set` value to coerce.
    */

--- a/src/main/shapes/SetShape.ts
+++ b/src/main/shapes/SetShape.ts
@@ -1,4 +1,4 @@
-import { AnyShape, ApplyResult, DeepPartialProtocol, OptionalDeepPartialShape, ValueType } from './Shape';
+import { AnyShape, DeepPartialProtocol, OptionalDeepPartialShape, Result, ValueType } from './Shape';
 import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
 import {
   addConstraint,
@@ -123,7 +123,7 @@ export class SetShape<S extends AnyShape>
     }
   }
 
-  protected _apply(input: any, options: ParseOptions): ApplyResult<Set<S['output']>> {
+  protected _apply(input: any, options: ParseOptions): Result<Set<S['output']>> {
     let changed = false;
     let values;
     let issues = null;
@@ -166,13 +166,13 @@ export class SetShape<S extends AnyShape>
     if (_applyChecks !== null && (_isUnsafe || issues === null)) {
       issues = _applyChecks(output, issues, options);
     }
-    if (issues === null && changed) {
+    if (changed && issues === null) {
       return ok(output);
     }
     return issues;
   }
 
-  protected _applyAsync(input: any, options: ParseOptions): Promise<ApplyResult<Set<S['output']>>> {
+  protected _applyAsync(input: any, options: ParseOptions): Promise<Result<Set<S['output']>>> {
     return new Promise(resolve => {
       let changed = false;
       let values: unknown[];
@@ -194,7 +194,7 @@ export class SetShape<S extends AnyShape>
       let index = -1;
       let value: unknown;
 
-      const applyResult = (result: ApplyResult) => {
+      const handleResult = (result: Result) => {
         if (result !== null) {
           if (isArray(result)) {
             unshiftPath(result, index);
@@ -210,11 +210,11 @@ export class SetShape<S extends AnyShape>
         return next();
       };
 
-      const next = (): ApplyResult | Promise<ApplyResult> => {
+      const next = (): Result | Promise<Result> => {
         index++;
 
         if (index !== valuesLength) {
-          return shape['_applyAsync']((value = values[index]), options).then(applyResult);
+          return shape['_applyAsync']((value = values[index]), options).then(handleResult);
         }
 
         const output = changed ? new Set(values) : input;
@@ -222,7 +222,7 @@ export class SetShape<S extends AnyShape>
         if (_applyChecks !== null && (_isUnsafe || issues === null)) {
           issues = _applyChecks(output, issues, options);
         }
-        if (issues === null && changed) {
+        if (changed && issues === null) {
           return ok(output);
         }
         return issues;

--- a/src/main/shapes/Shape.ts
+++ b/src/main/shapes/Shape.ts
@@ -14,7 +14,7 @@ import {
 import {
   applyForResult,
   captureIssues,
-  cloneObject,
+  cloneInstance,
   copyUnsafeChecks,
   createApplyChecksCallback,
   createIssueFactory,
@@ -212,7 +212,7 @@ export class Shape<I = any, O = I> {
    * @returns The clone of the shape with the description added.
    */
   describe(text: string): this {
-    const shape = cloneObject(this);
+    const shape = cloneInstance(this);
     shape.description = text;
     return shape;
   }
@@ -520,7 +520,7 @@ export class Shape<I = any, O = I> {
    * @returns The clone of the shape.
    */
   protected _replaceChecks(checks: readonly Check[]): this {
-    const shape = cloneObject(this);
+    const shape = cloneInstance(this);
 
     shape._checks = checks.length !== 0 ? checks : null;
     shape._applyChecks = createApplyChecksCallback(checks);

--- a/src/main/shapes/Shape.ts
+++ b/src/main/shapes/Shape.ts
@@ -538,7 +538,7 @@ export class Shape<I = any, O = I> {
   }
 
   /**
-   * Returns the list of runtime value types that can be processed by the shape.
+   * Returns the array of runtime value types that can be processed by the shape.
    *
    * Used for various optimizations. Elements of the returned array don't have to be unique.
    */
@@ -547,7 +547,7 @@ export class Shape<I = any, O = I> {
   }
 
   /**
-   * Returns the list of all input values that are known beforehand.
+   * Returns the array of all input values that are known beforehand.
    */
   protected _getInputValues(): unknown[] {
     return [];

--- a/src/main/shapes/Shape.ts
+++ b/src/main/shapes/Shape.ts
@@ -21,6 +21,7 @@ import {
   getValueType,
   isArray,
   isEqual,
+  isFunction,
   isUnsafeCheck,
   ok,
   toDeepPartialShape,
@@ -1349,8 +1350,8 @@ export class CatchShape<S extends AnyShape, T>
   ) {
     super();
 
-    if (typeof fallback === 'function') {
-      this._resultProvider = () => ok((fallback as Function)());
+    if (isFunction(fallback)) {
+      this._resultProvider = () => ok(fallback());
     } else {
       const result = ok(fallback);
       this._resultProvider = () => result;

--- a/src/main/shapes/Shape.ts
+++ b/src/main/shapes/Shape.ts
@@ -233,7 +233,7 @@ export class Shape<I = any, O = I> {
   check(cb: CheckCallback<O>, options: CheckOptions = {}): this {
     const { key = cb, param, unsafe = false } = options;
 
-    const check: Check = { key, callback: cb, param, unsafe };
+    const check: Check = { key, callback: cb, param, isUnsafe: unsafe };
 
     return this._replaceChecks(
       this._checks !== null ? this._checks.filter(check => check.key !== key).concat(check) : [check]

--- a/src/main/shapes/StringShape.ts
+++ b/src/main/shapes/StringShape.ts
@@ -1,4 +1,4 @@
-import { ApplyResult, ValueType } from './Shape';
+import { Result, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { addConstraint, createIssueFactory, isArray, isValidDate, ok } from '../utils';
 import {
@@ -109,7 +109,7 @@ export class StringShape extends CoercibleShape<string> {
     }
   }
 
-  protected _apply(input: any, options: ParseOptions): ApplyResult<string> {
+  protected _apply(input: any, options: ParseOptions): Result<string> {
     const { _applyChecks } = this;
 
     let output = input;

--- a/src/main/shapes/SymbolShape.ts
+++ b/src/main/shapes/SymbolShape.ts
@@ -1,4 +1,4 @@
-import { ApplyResult, Shape, ValueType } from './Shape';
+import { Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Message, ParseOptions } from '../shared-types';
 import { createIssueFactory } from '../utils';
 import { CODE_TYPE, MESSAGE_SYMBOL_TYPE, TYPE_SYMBOL } from '../constants';
@@ -24,7 +24,7 @@ export class SymbolShape extends Shape<symbol> {
     return [TYPE_SYMBOL];
   }
 
-  protected _apply(input: unknown, options: ParseOptions): ApplyResult<symbol> {
+  protected _apply(input: unknown, options: ParseOptions): Result<symbol> {
     const { _applyChecks } = this;
 
     if (typeof input !== 'symbol') {

--- a/src/main/shapes/UnionShape.ts
+++ b/src/main/shapes/UnionShape.ts
@@ -134,10 +134,10 @@ export class UnionShape<U extends readonly AnyShape[]>
         output = result.value;
         break;
       }
-      if (issueGroups !== null) {
-        issueGroups.push(result);
-      } else {
+      if (issueGroups === null) {
         issueGroups = [result];
+      } else {
+        issueGroups.push(result);
       }
       issues = result;
       index++;
@@ -173,10 +173,10 @@ export class UnionShape<U extends readonly AnyShape[]>
 
         if (result !== null) {
           if (isArray(result)) {
-            if (issueGroups !== null) {
-              issueGroups.push(result);
-            } else {
+            if (issueGroups === null) {
               issueGroups = [result];
+            } else {
+              issueGroups.push(result);
             }
             issues = result;
 

--- a/src/main/shapes/UnionShape.ts
+++ b/src/main/shapes/UnionShape.ts
@@ -1,7 +1,7 @@
 import { AnyShape, DeepPartialProtocol, DeepPartialShape, Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
 import {
-  callApply,
+  applyForResult,
   copyUnsafeChecks,
   createIssueFactory,
   getValueType,
@@ -196,7 +196,7 @@ export class UnionShape<U extends readonly AnyShape[]>
         index++;
 
         if (index !== shapesLength) {
-          return callApply(shapes[index], input, options, handleResult);
+          return applyForResult(shapes[index], input, options, handleResult);
         }
         if (shapesLength === 1) {
           return issues;

--- a/src/main/shapes/UnionShape.ts
+++ b/src/main/shapes/UnionShape.ts
@@ -1,4 +1,4 @@
-import { AnyShape, ApplyResult, DeepPartialProtocol, DeepPartialShape, Shape, ValueType } from './Shape';
+import { AnyShape, DeepPartialProtocol, DeepPartialShape, Result, Shape, ValueType } from './Shape';
 import { ConstraintOptions, Issue, Message, ParseOptions } from '../shared-types';
 import {
   callApply,
@@ -112,7 +112,7 @@ export class UnionShape<U extends readonly AnyShape[]>
     return inputValues;
   }
 
-  protected _apply(input: unknown, options: ParseOptions): ApplyResult<U[number]['output']> {
+  protected _apply(input: unknown, options: ParseOptions): Result<U[number]['output']> {
     const { _applyChecks } = this;
 
     let result = null;
@@ -134,7 +134,11 @@ export class UnionShape<U extends readonly AnyShape[]>
         output = result.value;
         break;
       }
-      (issueGroups ||= []).push(result);
+      if (issueGroups !== null) {
+        issueGroups.push(result);
+      } else {
+        issueGroups = [result];
+      }
       issues = result;
       index++;
     }
@@ -152,7 +156,7 @@ export class UnionShape<U extends readonly AnyShape[]>
     return issues;
   }
 
-  protected _applyAsync(input: unknown, options: ParseOptions): Promise<ApplyResult<U[number]['output']>> {
+  protected _applyAsync(input: unknown, options: ParseOptions): Promise<Result<U[number]['output']>> {
     return new Promise(resolve => {
       const { _applyChecks } = this;
 
@@ -164,13 +168,18 @@ export class UnionShape<U extends readonly AnyShape[]>
 
       let index = -1;
 
-      const applyResult = (result: ApplyResult) => {
+      const handleResult = (result: Result) => {
         let output = input;
 
         if (result !== null) {
           if (isArray(result)) {
-            (issueGroups ||= []).push(result);
+            if (issueGroups !== null) {
+              issueGroups.push(result);
+            } else {
+              issueGroups = [result];
+            }
             issues = result;
+
             return next();
           } else {
             output = result.value;
@@ -183,11 +192,11 @@ export class UnionShape<U extends readonly AnyShape[]>
         return issues;
       };
 
-      const next = (): ApplyResult | Promise<ApplyResult> => {
+      const next = (): Result | Promise<Result> => {
         index++;
 
         if (index !== shapesLength) {
-          return callApply(shapes[index], input, options, applyResult);
+          return callApply(shapes[index], input, options, handleResult);
         }
         if (shapesLength === 1) {
           return issues;

--- a/src/main/shapes/UnionShape.ts
+++ b/src/main/shapes/UnionShape.ts
@@ -15,7 +15,7 @@ import { CODE_UNION, MESSAGE_UNION, TYPE_ANY, TYPE_NEVER } from '../constants';
 import { ObjectShape } from './ObjectShape';
 
 /**
- * Returns the list of shapes that are applicable to the input.
+ * Returns the array of shapes that are applicable to the input.
  */
 export type LookupCallback = (input: any) => readonly AnyShape[];
 
@@ -26,7 +26,7 @@ export type DeepPartialUnionShape<U extends readonly AnyShape[]> = UnionShape<{
 /**
  * The shape that requires an input to conform at least one of shapes.
  *
- * @template U The list of shapes that comprise a union.
+ * @template U The array of shapes that comprise a union.
  */
 export class UnionShape<U extends readonly AnyShape[]>
   extends Shape<U[number]['input'], U[number]['output']>
@@ -38,13 +38,13 @@ export class UnionShape<U extends readonly AnyShape[]>
   /**
    * Creates a new {@linkcode UnionShape} instance.
    *
-   * @param shapes The list of shapes that comprise a union.
+   * @param shapes The array of shapes that comprise a union.
    * @param options The union constraint options or an issue message.
-   * @template U The list of shapes that comprise a union.
+   * @template U The array of shapes that comprise a union.
    */
   constructor(
     /**
-     * The list of shapes that comprise a union.
+     * The array of shapes that comprise a union.
      */
     readonly shapes: U,
     options?: ConstraintOptions | Message

--- a/src/main/shapes/index.ts
+++ b/src/main/shapes/index.ts
@@ -29,6 +29,7 @@ export {
   NotShape,
   PipeShape,
   ReplaceLiteralShape,
+  Result,
   Shape,
   TransformShape,
   ValueType,

--- a/src/main/shared-types.ts
+++ b/src/main/shared-types.ts
@@ -11,7 +11,7 @@ export interface Err {
   ok: false;
 
   /**
-   * The list of issues encountered during parsing.
+   * The array of issues encountered during parsing.
    */
   issues: Issue[];
 }
@@ -37,7 +37,8 @@ export interface Check {
   readonly key: any;
 
   /**
-   * The callback that validates the shape output and returns the list of issues or throws a {@linkcode Validation} error.
+   * The callback that validates the shape output and returns the array of issues or throws a {@linkcode Validation}
+   * error.
    */
   readonly callback: CheckCallback;
 

--- a/src/main/shared-types.ts
+++ b/src/main/shared-types.ts
@@ -50,7 +50,7 @@ export interface Check {
   /**
    * `true` if the {@linkcode callback} is invoked even if previous processors failed, or `false` otherwise.
    */
-  readonly unsafe: boolean;
+  readonly isUnsafe: boolean;
 }
 
 /**

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -261,34 +261,50 @@ export function captureIssues(error: unknown): Issue[] {
   throw error;
 }
 
-export type Bits = number[] | number;
+/**
+ * A bitmask that can hold an arbitrary number of bits.
+ */
+export type Mask = number[] | number;
 
-export function enableBitAt(bits: Bits, index: number): Bits {
-  if (typeof bits === 'number') {
+/**
+ * Sets bit to 1 at index in mask.
+ *
+ * @param mask The mutable mask to update.
+ * @param index The index at which the bit must be set to 1.
+ * @returns The updated mask.
+ */
+export function enableMask(mask: Mask, index: number): Mask {
+  if (typeof mask === 'number') {
     if (index < 32) {
-      return bits | (1 << index);
+      return mask | (1 << index);
     }
-    bits = [bits, 0, 0];
+    mask = [mask, 0, 0];
   }
 
-  bits[index >> 5] |= 1 << index % 32;
+  mask[index >> 5] |= 1 << index % 32;
 
-  return bits;
+  return mask;
 }
 
-export function isBitEnabledAt(bits: Bits, index: number): boolean {
-  if (typeof bits === 'number') {
-    return bits >>> index !== 0;
+/**
+ * Returns `true` if the bit at index in the bitmask is set to 1.
+ */
+export function isMaskEnabled(mask: Mask, index: number): boolean {
+  if (typeof mask === 'number') {
+    return mask >>> index !== 0;
   } else {
-    return bits[index >> 5] >>> index % 32 !== 0;
+    return mask[index >> 5] >>> index % 32 !== 0;
   }
 }
 
-export function setObjectProperty(obj: Record<any, any>, key: PropertyKey, value: unknown): void {
+/**
+ * Updates object property value, prevents prototype pollution.
+ */
+export function setObjectProperty(obj: Record<any, any>, key: any, value: unknown): void {
   if (key === '__proto__') {
     Object.defineProperty(obj, key, { value, writable: true, enumerable: true, configurable: true });
   } else {
-    obj[key as string] = value;
+    obj[key] = value;
   }
 }
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -2,9 +2,9 @@ import { Check, CheckCallback, ConstraintOptions, Issue, Message, Ok, ParseOptio
 import {
   AnyShape,
   ApplyChecksCallback,
-  ApplyResult,
   DeepPartialProtocol,
   DeepPartialShape,
+  Result,
   Shape,
   ValueType,
 } from './shapes/Shape';
@@ -68,6 +68,10 @@ export function isPlainObject(value: unknown): boolean {
 
 export function isIterableObject(value: any): value is Iterable<any> {
   return isObjectLike(value) && (Symbol.iterator in value || !isNaN(value.length));
+}
+
+export function isConstructorOf(ctor: Function, superCtor: Function): boolean {
+  return ctor === superCtor || superCtor.prototype.isPrototypeOf(ctor.prototype);
 }
 
 export function isNumber(value: unknown): boolean {
@@ -147,7 +151,7 @@ export function callApply<T>(
   shape: AnyShape,
   input: unknown,
   options: ParseOptions,
-  cb: (result: ApplyResult) => T
+  cb: (result: Result) => T
 ): T | Promise<Awaited<T>> {
   if (shape.isAsync) {
     return shape['_applyAsync'](input, options).then(cb) as Promise<Awaited<T>>;

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -243,7 +243,7 @@ export function isAsyncShape(shape: AnyShape): boolean {
 }
 
 export function isUnsafeCheck(check: Check): boolean {
-  return check.unsafe;
+  return check.isUnsafe;
 }
 
 /**
@@ -421,10 +421,10 @@ export function createApplyChecksCallback(checks: readonly Check[]): ApplyChecks
   }
 
   if (checksLength === 1) {
-    const [{ unsafe: unsafe0, callback: cb0 }] = checks;
+    const [{ isUnsafe: isUnsafe0, callback: cb0 }] = checks;
 
     return (output, issues, options) => {
-      if (issues === null || unsafe0) {
+      if (issues === null || isUnsafe0) {
         let result;
 
         try {
@@ -441,10 +441,10 @@ export function createApplyChecksCallback(checks: readonly Check[]): ApplyChecks
   }
 
   if (checksLength === 2) {
-    const [{ unsafe: unsafe0, callback: cb0 }, { unsafe: unsafe1, callback: cb1 }] = checks;
+    const [{ isUnsafe: isUnsafe0, callback: cb0 }, { isUnsafe: isUnsafe1, callback: cb1 }] = checks;
 
     return (output, issues, options) => {
-      if (issues === null || unsafe0) {
+      if (issues === null || isUnsafe0) {
         let result;
 
         try {
@@ -465,7 +465,7 @@ export function createApplyChecksCallback(checks: readonly Check[]): ApplyChecks
         }
       }
 
-      if (issues === null || unsafe1) {
+      if (issues === null || isUnsafe1) {
         let result;
 
         try {
@@ -484,11 +484,11 @@ export function createApplyChecksCallback(checks: readonly Check[]): ApplyChecks
 
   return (output, issues, options) => {
     for (let i = 0; i < checksLength; ++i) {
-      const { unsafe, callback } = checks[i];
+      const { isUnsafe, callback } = checks[i];
 
       let result;
 
-      if (issues !== null && !unsafe) {
+      if (issues !== null && !isUnsafe) {
         continue;
       }
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -147,7 +147,7 @@ export function copyChecks<S extends Shape>(
   );
 }
 
-export function callApply<T>(
+export function applyForResult<T>(
   shape: AnyShape,
   input: unknown,
   options: ParseOptions,

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -48,8 +48,6 @@ export function ok<T>(value: T): Ok<T> {
 
 export const isArray = Array.isArray;
 
-export const getPrototypeOf = Object.getPrototypeOf;
-
 /**
  * [SameValueZero](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-samevaluezero) comparison.
  */
@@ -61,9 +59,25 @@ export function isObjectLike(value: unknown): boolean {
   return value !== null && typeof value === 'object';
 }
 
-export function isPlainObject(value: unknown): boolean {
-  let prototype;
-  return isObjectLike(value) && ((prototype = getPrototypeOf(value)) === null || prototype.constructor === Object);
+const objectCtorString = Object.prototype.constructor.toString();
+
+export function isPlainObject(value: any): boolean {
+  let proto;
+  let ctor;
+
+  if (!isObjectLike(value)) {
+    return false;
+  }
+  if ((proto = Object.getPrototypeOf(value)) === null) {
+    return true;
+  }
+  if (!Object.hasOwnProperty.call(proto, 'constructor')) {
+    return false;
+  }
+  if ((ctor = proto.constructor) === Object) {
+    return true;
+  }
+  return typeof ctor == 'function' && Function.toString.call(ctor) === objectCtorString;
 }
 
 export function isIterableObject(value: any): value is Iterable<any> {
@@ -311,8 +325,8 @@ export function setObjectProperty(obj: Record<any, any>, key: any, value: unknow
 /**
  * Returns the shallow clone of the instance object.
  */
-export function cloneObject<T extends object>(instance: T): T {
-  return Object.assign(Object.create(getPrototypeOf(instance)), instance);
+export function cloneInstance<T extends object>(obj: T): T {
+  return Object.assign(Object.create(Object.getPrototypeOf(obj)), obj);
 }
 
 /**

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -284,7 +284,7 @@ export function isBitEnabledAt(bits: Bits, index: number): boolean {
   }
 }
 
-export function setKeyValue(obj: Record<any, any>, key: PropertyKey, value: unknown): void {
+export function setObjectProperty(obj: Record<any, any>, key: PropertyKey, value: unknown): void {
   if (key === '__proto__') {
     Object.defineProperty(obj, key, { value, writable: true, enumerable: true, configurable: true });
   } else {
@@ -307,7 +307,7 @@ export function cloneObjectEnumerableKeys(input: ReadonlyDict, keyCount = -1): R
 
   if (keyCount < 0) {
     for (const key in input) {
-      setKeyValue(output, key, input[key]);
+      setObjectProperty(output, key, input[key]);
     }
   }
   if (keyCount > 0) {
@@ -317,7 +317,7 @@ export function cloneObjectEnumerableKeys(input: ReadonlyDict, keyCount = -1): R
       if (index === keyCount) {
         break;
       }
-      setKeyValue(output, key, input[key]);
+      setObjectProperty(output, key, input[key]);
       ++index;
     }
   }
@@ -335,7 +335,7 @@ export function cloneObjectKnownKeys(input: ReadonlyDict, keys: readonly string[
     const key = keys[i];
 
     if (key in input) {
-      setKeyValue(output, key, input[key]);
+      setObjectProperty(output, key, input[key]);
     }
   }
   return output;

--- a/src/test/dsl/any.test.ts
+++ b/src/test/dsl/any.test.ts
@@ -8,6 +8,6 @@ describe('any', () => {
   test('returns a shape with a refinement', () => {
     const cb = () => true;
 
-    expect(d.any(cb).getCheck(cb)).toEqual({ key: cb, callback: expect.any(Function), unsafe: false, param: cb });
+    expect(d.any(cb).getCheck(cb)).toEqual({ key: cb, callback: expect.any(Function), isUnsafe: false, param: cb });
   });
 });

--- a/src/test/dsl/record.test-d.ts
+++ b/src/test/dsl/record.test-d.ts
@@ -9,3 +9,5 @@ expectType<{ bbb: number }>(
     d.number()
   ).output
 );
+
+expectType<Record<string, boolean | undefined>>(d.record(d.string(), d.boolean().optional()).output);

--- a/src/test/shapes/ArrayShape.test.ts
+++ b/src/test/shapes/ArrayShape.test.ts
@@ -509,8 +509,8 @@ describe('ArrayShape', () => {
       shape1.isAsync;
       shape2.isAsync;
 
-      const applyAsyncSpy1 = jest.spyOn<Shape, any>(shape1, '_applyAsync');
-      const applyAsyncSpy2 = jest.spyOn<Shape, any>(shape2, '_applyAsync');
+      const applySpy1 = jest.spyOn<Shape, any>(shape1, '_applyAsync');
+      const applySpy2 = jest.spyOn<Shape, any>(shape2, '_applyAsync');
 
       const arrShape = new ArrayShape([shape1, shape2], null);
 
@@ -519,10 +519,10 @@ describe('ArrayShape', () => {
 
       expect(result).toEqual({ ok: true, value: arr });
       expect(result.value).toBe(arr);
-      expect(applyAsyncSpy1).toHaveBeenCalledTimes(1);
-      expect(applyAsyncSpy1).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false });
-      expect(applyAsyncSpy2).toHaveBeenCalledTimes(1);
-      expect(applyAsyncSpy2).toHaveBeenNthCalledWith(1, 222, { verbose: false, coerced: false });
+      expect(applySpy1).toHaveBeenCalledTimes(1);
+      expect(applySpy1).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false });
+      expect(applySpy2).toHaveBeenCalledTimes(1);
+      expect(applySpy2).toHaveBeenNthCalledWith(1, 222, { verbose: false, coerced: false });
     });
 
     test('does not apply tuple element shape if previous shape raised an issue', async () => {
@@ -532,8 +532,8 @@ describe('ArrayShape', () => {
       shape1.isAsync;
       shape2.isAsync;
 
-      const applyAsyncSpy1 = jest.spyOn<Shape, any>(shape1, '_applyAsync');
-      const applyAsyncSpy2 = jest.spyOn<Shape, any>(shape2, '_applyAsync');
+      const applySpy1 = jest.spyOn<Shape, any>(shape1, '_applyAsync');
+      const applySpy2 = jest.spyOn<Shape, any>(shape2, '_applyAsync');
 
       const arrShape = new ArrayShape([shape1, shape2], null);
 
@@ -541,9 +541,9 @@ describe('ArrayShape', () => {
       const result = (await arrShape.tryAsync(arr)) as Err;
 
       expect(result).toEqual({ ok: false, issues: [{ code: 'xxx', path: [0] }] });
-      expect(applyAsyncSpy1).toHaveBeenCalledTimes(1);
-      expect(applyAsyncSpy1).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false });
-      expect(applyAsyncSpy2).not.toHaveBeenCalled();
+      expect(applySpy1).toHaveBeenCalledTimes(1);
+      expect(applySpy1).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false });
+      expect(applySpy2).not.toHaveBeenCalled();
     });
 
     test('parses rest elements', async () => {

--- a/src/test/shapes/ArrayShape.test.ts
+++ b/src/test/shapes/ArrayShape.test.ts
@@ -1,4 +1,15 @@
-import { AnyShape, ArrayShape, Err, NumberShape, ObjectShape, Ok, Shape, StringShape } from '../../main';
+import {
+  AnyShape,
+  ArrayShape,
+  Err,
+  NumberShape,
+  ObjectShape,
+  Ok,
+  ParseOptions,
+  Result,
+  Shape,
+  StringShape,
+} from '../../main';
 import {
   CODE_ARRAY_MAX,
   CODE_ARRAY_MIN,
@@ -18,7 +29,15 @@ describe('ArrayShape', () => {
   let asyncShape: AnyShape;
 
   beforeEach(() => {
-    asyncShape = new Shape().transformAsync(value => Promise.resolve(value));
+    asyncShape = new (class extends Shape {
+      protected _isAsync(): boolean {
+        return true;
+      }
+
+      protected _applyAsync(input: unknown, options: ParseOptions) {
+        return new Promise<Result>(resolve => resolve(Shape.prototype['_apply'].call(this, input, options)));
+      }
+    })();
   });
 
   test('creates an array shape', () => {

--- a/src/test/shapes/FunctionShape.test.ts
+++ b/src/test/shapes/FunctionShape.test.ts
@@ -4,6 +4,8 @@ import {
   FunctionShape,
   NumberShape,
   ObjectShape,
+  ParseOptions,
+  Result,
   Shape,
   StringShape,
   ValidationError,
@@ -23,7 +25,16 @@ describe('FunctionShape', () => {
 
   beforeEach(() => {
     noArgsShape = new ArrayShape(null, null);
-    asyncShape = new Shape().transformAsync(value => Promise.resolve(value));
+
+    asyncShape = new (class extends Shape {
+      protected _isAsync(): boolean {
+        return true;
+      }
+
+      protected _applyAsync(input: unknown, options: ParseOptions) {
+        return new Promise<Result>(resolve => resolve(Shape.prototype['_apply'].call(this, input, options)));
+      }
+    })();
   });
 
   test('creates a string shape', () => {

--- a/src/test/shapes/InstanceShape.test.ts
+++ b/src/test/shapes/InstanceShape.test.ts
@@ -16,6 +16,11 @@ describe('InstanceShape', () => {
     expect(new InstanceShape(class extends Array {}).inputTypes).toEqual(['array']);
   });
 
+  test('uses date input type for an Date and its subclasses', () => {
+    expect(new InstanceShape(Date).inputTypes).toEqual(['date']);
+    expect(new InstanceShape(class extends Date {}).inputTypes).toEqual(['date']);
+  });
+
   test('parses an instance of a class', () => {
     const value = new Foo();
 

--- a/src/test/shapes/LazyShape.test.ts
+++ b/src/test/shapes/LazyShape.test.ts
@@ -75,12 +75,12 @@ describe('LazyShape', () => {
     test('parses values with a shape', async () => {
       const lazyShape = new LazyShape(() => asyncShape);
 
-      const applyAsyncSpy = jest.spyOn<Shape, any>(asyncShape, '_applyAsync');
+      const applySpy = jest.spyOn<Shape, any>(asyncShape, '_applyAsync');
 
       expect(lazyShape.isAsync).toBe(true);
       await expect(lazyShape.parseAsync('aaa')).resolves.toBe('aaa');
-      expect(applyAsyncSpy).toHaveBeenCalledTimes(1);
-      expect(applyAsyncSpy).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false });
+      expect(applySpy).toHaveBeenCalledTimes(1);
+      expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false });
     });
   });
 });

--- a/src/test/shapes/LazyShape.test.ts
+++ b/src/test/shapes/LazyShape.test.ts
@@ -1,10 +1,18 @@
-import { AnyShape, DeepPartialProtocol, LazyShape, Shape, StringShape } from '../../main';
+import { AnyShape, DeepPartialProtocol, LazyShape, ParseOptions, Result, Shape, StringShape } from '../../main';
 
 describe('LazyShape', () => {
   let asyncShape: AnyShape;
 
   beforeEach(() => {
-    asyncShape = new Shape().transformAsync(value => Promise.resolve(value));
+    asyncShape = new (class extends Shape {
+      protected _isAsync(): boolean {
+        return true;
+      }
+
+      protected _applyAsync(input: unknown, options: ParseOptions) {
+        return new Promise<Result>(resolve => resolve(Shape.prototype['_apply'].call(this, input, options)));
+      }
+    })();
   });
 
   test('parses values with a shape', () => {

--- a/src/test/shapes/MapShape.test.ts
+++ b/src/test/shapes/MapShape.test.ts
@@ -1,4 +1,4 @@
-import { AnyShape, MapShape, ObjectShape, Ok, Shape, StringShape } from '../../main';
+import { AnyShape, MapShape, ObjectShape, Ok, ParseOptions, Result, Shape, StringShape } from '../../main';
 import {
   CODE_TYPE,
   MESSAGE_MAP_TYPE,
@@ -12,7 +12,15 @@ describe('MapShape', () => {
   let asyncShape: AnyShape;
 
   beforeEach(() => {
-    asyncShape = new Shape().transformAsync(value => Promise.resolve(value));
+    asyncShape = new (class extends Shape {
+      protected _isAsync(): boolean {
+        return true;
+      }
+
+      protected _applyAsync(input: unknown, options: ParseOptions) {
+        return new Promise<Result>(resolve => resolve(Shape.prototype['_apply'].call(this, input, options)));
+      }
+    })();
   });
 
   test('creates a Map shape', () => {

--- a/src/test/shapes/ObjectShape.test.ts
+++ b/src/test/shapes/ObjectShape.test.ts
@@ -1,4 +1,4 @@
-import { AnyShape, ObjectShape, Ok, Shape, StringShape } from '../../main';
+import { AnyShape, ObjectShape, Ok, ParseOptions, Result, Shape, StringShape } from '../../main';
 import {
   CODE_DENIED,
   CODE_ENUM,
@@ -14,7 +14,15 @@ describe('ObjectShape', () => {
   let asyncShape: AnyShape;
 
   beforeEach(() => {
-    asyncShape = new Shape().transformAsync(value => Promise.resolve(value));
+    asyncShape = new (class extends Shape {
+      protected _isAsync(): boolean {
+        return true;
+      }
+
+      protected _applyAsync(input: unknown, options: ParseOptions) {
+        return new Promise<Result>(resolve => resolve(Shape.prototype['_apply'].call(this, input, options)));
+      }
+    })();
   });
 
   test('raises non object values', () => {

--- a/src/test/shapes/ObjectShape.test.ts
+++ b/src/test/shapes/ObjectShape.test.ts
@@ -235,6 +235,7 @@ describe('ObjectShape', () => {
   test('raises if object is not plain', () => {
     const objShape = new ObjectShape({}, null).plain();
 
+    expect(objShape.isPlain).toBe(true);
     expect(objShape.parse({})).toEqual({});
 
     class Foo {}

--- a/src/test/shapes/RecordShape.test.ts
+++ b/src/test/shapes/RecordShape.test.ts
@@ -1,11 +1,19 @@
-import { AnyShape, ObjectShape, Ok, RecordShape, Shape, StringShape } from '../../main';
+import { AnyShape, ObjectShape, Ok, ParseOptions, RecordShape, Result, Shape, StringShape } from '../../main';
 import { CODE_TYPE, MESSAGE_OBJECT_TYPE, MESSAGE_STRING_TYPE, TYPE_OBJECT, TYPE_STRING } from '../../main/constants';
 
 describe('RecordShape', () => {
   let asyncShape: AnyShape;
 
   beforeEach(() => {
-    asyncShape = new Shape().transformAsync(value => Promise.resolve(value));
+    asyncShape = new (class extends Shape {
+      protected _isAsync(): boolean {
+        return true;
+      }
+
+      protected _applyAsync(input: unknown, options: ParseOptions) {
+        return new Promise<Result>(resolve => resolve(Shape.prototype['_apply'].call(this, input, options)));
+      }
+    })();
   });
 
   test('raises non object values', () => {

--- a/src/test/shapes/SetShape.test.ts
+++ b/src/test/shapes/SetShape.test.ts
@@ -1,4 +1,4 @@
-import { AnyShape, ObjectShape, Ok, SetShape, Shape, StringShape } from '../../main';
+import { AnyShape, ObjectShape, Ok, ParseOptions, Result, SetShape, Shape, StringShape } from '../../main';
 import {
   CODE_SET_MAX,
   CODE_SET_MIN,
@@ -15,7 +15,15 @@ describe('SetShape', () => {
   let asyncShape: AnyShape;
 
   beforeEach(() => {
-    asyncShape = new Shape().transformAsync(value => Promise.resolve(value));
+    asyncShape = new (class extends Shape {
+      protected _isAsync(): boolean {
+        return true;
+      }
+
+      protected _applyAsync(input: unknown, options: ParseOptions) {
+        return new Promise<Result>(resolve => resolve(Shape.prototype['_apply'].call(this, input, options)));
+      }
+    })();
   });
 
   test('creates a Set shape', () => {

--- a/src/test/shapes/SetShape.test.ts
+++ b/src/test/shapes/SetShape.test.ts
@@ -231,7 +231,7 @@ describe('SetShape', () => {
     });
 
     test('parses values in a Set', async () => {
-      const applyAsyncSpy = jest.spyOn<Shape, any>(asyncShape, '_applyAsync');
+      const applySpy = jest.spyOn<Shape, any>(asyncShape, '_applyAsync');
 
       const setShape = new SetShape(asyncShape);
 
@@ -240,9 +240,9 @@ describe('SetShape', () => {
 
       expect(result).toEqual({ ok: true, value: set });
       expect(result.value).toBe(set);
-      expect(applyAsyncSpy).toHaveBeenCalledTimes(2);
-      expect(applyAsyncSpy).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false });
-      expect(applyAsyncSpy).toHaveBeenNthCalledWith(2, 222, { verbose: false, coerced: false });
+      expect(applySpy).toHaveBeenCalledTimes(2);
+      expect(applySpy).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false });
+      expect(applySpy).toHaveBeenNthCalledWith(2, 222, { verbose: false, coerced: false });
     });
 
     test('does not apply value shape if the previous value raised an issue', async () => {
@@ -255,16 +255,16 @@ describe('SetShape', () => {
 
       shape.isAsync;
 
-      const applyAsyncSpy = jest.spyOn<Shape, any>(shape, '_applyAsync');
+      const applySpy = jest.spyOn<Shape, any>(shape, '_applyAsync');
 
       const setShape = new SetShape(shape);
 
       const set = new Set([111, 222, 333]);
       await setShape.tryAsync(set);
 
-      expect(applyAsyncSpy).toHaveBeenCalledTimes(2);
-      expect(applyAsyncSpy).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false });
-      expect(applyAsyncSpy).toHaveBeenNthCalledWith(2, 222, { verbose: false, coerced: false });
+      expect(applySpy).toHaveBeenCalledTimes(2);
+      expect(applySpy).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false });
+      expect(applySpy).toHaveBeenNthCalledWith(2, 222, { verbose: false, coerced: false });
     });
 
     test('returns a new set if some values were transformed', async () => {

--- a/src/test/shapes/Shape.test.ts
+++ b/src/test/shapes/Shape.test.ts
@@ -608,18 +608,18 @@ describe('PipeShape', () => {
       const shape1 = asyncShape;
       const shape2 = new Shape();
 
-      const applyAsyncSpy1 = jest.spyOn<Shape, any>(shape1, '_applyAsync');
-      const applyAsyncSpy2 = jest.spyOn<Shape, any>(shape2, '_apply');
+      const applySpy1 = jest.spyOn<Shape, any>(shape1, '_applyAsync');
+      const applySpy2 = jest.spyOn<Shape, any>(shape2, '_apply');
 
       const pipeShape = new PipeShape(shape1, shape2);
 
       await expect(pipeShape.parseAsync('aaa')).resolves.toBe('aaa');
 
-      expect(applyAsyncSpy1).toHaveBeenCalledTimes(1);
-      expect(applyAsyncSpy1).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false });
+      expect(applySpy1).toHaveBeenCalledTimes(1);
+      expect(applySpy1).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false });
 
-      expect(applyAsyncSpy2).toHaveBeenCalledTimes(1);
-      expect(applyAsyncSpy2).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false });
+      expect(applySpy2).toHaveBeenCalledTimes(1);
+      expect(applySpy2).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false });
     });
 
     test('does not apply the output shape if the input shape parsing failed', async () => {

--- a/src/test/shapes/Shape.test.ts
+++ b/src/test/shapes/Shape.test.ts
@@ -55,7 +55,7 @@ describe('Shape', () => {
 
     expect(shape1).not.toBe(shape2);
     expect(shape1.getCheck(cb)).toBe(undefined);
-    expect(shape2.getCheck(cb)).toEqual({ key: cb, callback: cb, unsafe: false });
+    expect(shape2.getCheck(cb)).toEqual({ key: cb, callback: cb, isUnsafe: false });
   });
 
   test('deletes a check', () => {

--- a/src/test/shapes/Shape.test.ts
+++ b/src/test/shapes/Shape.test.ts
@@ -585,7 +585,7 @@ describe('PipeShape', () => {
       const shape2 = new Shape();
 
       const applyAsyncSpy1 = jest.spyOn<Shape, any>(shape1, '_applyAsync');
-      const applyAsyncSpy2 = jest.spyOn<Shape, any>(shape2, '_applyAsync');
+      const applyAsyncSpy2 = jest.spyOn<Shape, any>(shape2, '_apply');
 
       const pipeShape = new PipeShape(shape1, shape2);
 

--- a/src/test/shapes/UnionShape.test.ts
+++ b/src/test/shapes/UnionShape.test.ts
@@ -212,18 +212,18 @@ describe('UnionShape', () => {
       const shape2 = new StringShape().transformAsync(value => Promise.resolve(value));
       const shape3 = new BooleanShape();
 
-      const applyAsyncSpy1 = jest.spyOn<Shape, any>(shape1, '_applyAsync');
-      const applyAsyncSpy2 = jest.spyOn<Shape, any>(shape2, '_applyAsync');
-      const applyAsyncSpy3 = jest.spyOn<Shape, any>(shape3, '_applyAsync');
+      const applySpy1 = jest.spyOn<Shape, any>(shape1, '_applyAsync');
+      const applySpy2 = jest.spyOn<Shape, any>(shape2, '_applyAsync');
+      const applySpy3 = jest.spyOn<Shape, any>(shape3, '_applyAsync');
 
       const orShape = new UnionShape([shape1, shape2, shape3]);
 
       expect(orShape.isAsync).toBe(true);
 
       await expect(orShape.parseAsync('aaa')).resolves.toBe('aaa');
-      expect(applyAsyncSpy1).not.toHaveBeenCalled();
-      expect(applyAsyncSpy2).toHaveBeenCalledTimes(1);
-      expect(applyAsyncSpy3).not.toHaveBeenCalled();
+      expect(applySpy1).not.toHaveBeenCalled();
+      expect(applySpy2).toHaveBeenCalledTimes(1);
+      expect(applySpy3).not.toHaveBeenCalled();
     });
 
     test('does not unwrap union shapes that have checks', async () => {
@@ -232,9 +232,9 @@ describe('UnionShape', () => {
       const shape3 = new BooleanShape();
       const orShape1 = new UnionShape([shape2, shape3]).refine(() => true);
 
-      const applyAsyncSpy1 = jest.spyOn<Shape, any>(shape1, '_applyAsync');
-      const applyAsyncSpy2 = jest.spyOn<Shape, any>(shape2, '_applyAsync');
-      const applyAsyncSpy3 = jest.spyOn<Shape, any>(shape3, '_applyAsync');
+      const applySpy1 = jest.spyOn<Shape, any>(shape1, '_applyAsync');
+      const applySpy2 = jest.spyOn<Shape, any>(shape2, '_applyAsync');
+      const applySpy3 = jest.spyOn<Shape, any>(shape3, '_applyAsync');
       const unionApplyAsyncSpy = jest.spyOn<Shape, any>(orShape1, '_applyAsync');
 
       const orShape2 = new UnionShape([shape1, orShape1]);
@@ -242,9 +242,9 @@ describe('UnionShape', () => {
       expect(orShape2.isAsync).toBe(true);
 
       await expect(orShape2.parseAsync('aaa')).resolves.toBe('aaa');
-      expect(applyAsyncSpy1).not.toHaveBeenCalled();
-      expect(applyAsyncSpy2).toHaveBeenCalledTimes(1);
-      expect(applyAsyncSpy3).not.toHaveBeenCalled();
+      expect(applySpy1).not.toHaveBeenCalled();
+      expect(applySpy2).toHaveBeenCalledTimes(1);
+      expect(applySpy3).not.toHaveBeenCalled();
       expect(unionApplyAsyncSpy).toHaveBeenCalledTimes(1);
     });
 

--- a/src/test/shapes/UnionShape.test.ts
+++ b/src/test/shapes/UnionShape.test.ts
@@ -7,6 +7,8 @@ import {
   NeverShape,
   NumberShape,
   ObjectShape,
+  ParseOptions,
+  Result,
   Shape,
   StringShape,
   UnionShape,
@@ -18,7 +20,15 @@ describe('UnionShape', () => {
   let asyncShape: AnyShape;
 
   beforeEach(() => {
-    asyncShape = new Shape().transformAsync(value => Promise.resolve(value));
+    asyncShape = new (class extends Shape {
+      protected _isAsync(): boolean {
+        return true;
+      }
+
+      protected _applyAsync(input: unknown, options: ParseOptions) {
+        return new Promise<Result>(resolve => resolve(Shape.prototype['_apply'].call(this, input, options)));
+      }
+    })();
   });
 
   test('distributes buckets', () => {

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -362,7 +362,7 @@ describe('createApplyChecksCallback', () => {
       const cbMock = jest.fn(() => [{ code: 'xxx' }]);
 
       const applyChecks = createApplyChecksCallback([
-        { key: cbMock, callback: cbMock, param: undefined, unsafe: false },
+        { key: cbMock, callback: cbMock, param: undefined, isUnsafe: false },
       ]);
 
       expect(applyChecks!(111, null, { verbose: false, coerced: false })).toEqual([{ code: 'xxx', path: [] }]);
@@ -374,7 +374,7 @@ describe('createApplyChecksCallback', () => {
       const cbMock = jest.fn(() => [{ code: 'xxx' }]);
 
       const applyChecks = createApplyChecksCallback([
-        { key: cbMock, callback: cbMock, param: undefined, unsafe: true },
+        { key: cbMock, callback: cbMock, param: undefined, isUnsafe: true },
       ]);
 
       const issues: Issue[] = [];
@@ -389,7 +389,7 @@ describe('createApplyChecksCallback', () => {
       const cbMock = jest.fn(() => [{ code: 'xxx' }]);
 
       const applyChecks = createApplyChecksCallback([
-        { key: cbMock, callback: cbMock, param: undefined, unsafe: false },
+        { key: cbMock, callback: cbMock, param: undefined, isUnsafe: false },
       ]);
 
       const issues: Issue[] = [];
@@ -405,7 +405,7 @@ describe('createApplyChecksCallback', () => {
       });
 
       const applyChecks = createApplyChecksCallback([
-        { key: cbMock, callback: cbMock, param: undefined, unsafe: false },
+        { key: cbMock, callback: cbMock, param: undefined, isUnsafe: false },
       ]);
 
       expect(() => applyChecks!(111, null, {})).toThrow(new Error('expected'));
@@ -417,7 +417,7 @@ describe('createApplyChecksCallback', () => {
       });
 
       const applyChecks = createApplyChecksCallback([
-        { key: cbMock, callback: cbMock, param: undefined, unsafe: false },
+        { key: cbMock, callback: cbMock, param: undefined, isUnsafe: false },
       ]);
 
       expect(applyChecks!(111, null, { verbose: false, coerced: false })).toEqual([{ code: 'xxx', path: [] }]);
@@ -432,10 +432,10 @@ describe('createApplyChecksCallback', () => {
       const cbMock4 = jest.fn(() => [{ code: 'DDD' }]);
 
       const applyChecks = createApplyChecksCallback([
-        { key: cbMock1, callback: cbMock1, param: undefined, unsafe: true },
-        { key: cbMock2, callback: cbMock2, param: undefined, unsafe: true },
-        { key: cbMock3, callback: cbMock3, param: undefined, unsafe: true },
-        { key: cbMock4, callback: cbMock4, param: undefined, unsafe: true },
+        { key: cbMock1, callback: cbMock1, param: undefined, isUnsafe: true },
+        { key: cbMock2, callback: cbMock2, param: undefined, isUnsafe: true },
+        { key: cbMock3, callback: cbMock3, param: undefined, isUnsafe: true },
+        { key: cbMock4, callback: cbMock4, param: undefined, isUnsafe: true },
       ]);
 
       expect(applyChecks!(111, null, { verbose: false, coerced: false })).toEqual([{ code: 'BBB', path: [] }]);
@@ -454,10 +454,10 @@ describe('createApplyChecksCallback', () => {
       const cbMock4 = jest.fn(() => [{ code: 'DDD' }]);
 
       const applyChecks = createApplyChecksCallback([
-        { key: cbMock1, callback: cbMock1, param: undefined, unsafe: true },
-        { key: cbMock2, callback: cbMock2, param: undefined, unsafe: true },
-        { key: cbMock3, callback: cbMock3, param: undefined, unsafe: true },
-        { key: cbMock4, callback: cbMock4, param: undefined, unsafe: true },
+        { key: cbMock1, callback: cbMock1, param: undefined, isUnsafe: true },
+        { key: cbMock2, callback: cbMock2, param: undefined, isUnsafe: true },
+        { key: cbMock3, callback: cbMock3, param: undefined, isUnsafe: true },
+        { key: cbMock4, callback: cbMock4, param: undefined, isUnsafe: true },
       ]);
 
       expect(applyChecks!(111, null, { verbose: true })).toEqual([
@@ -482,10 +482,10 @@ describe('createApplyChecksCallback', () => {
       const cbMock4 = jest.fn(() => [{ code: 'DDD' }]);
 
       const applyChecks = createApplyChecksCallback([
-        { key: cbMock1, callback: cbMock1, param: undefined, unsafe: false },
-        { key: cbMock2, callback: cbMock2, param: undefined, unsafe: true },
-        { key: cbMock3, callback: cbMock3, param: undefined, unsafe: false },
-        { key: cbMock4, callback: cbMock4, param: undefined, unsafe: true },
+        { key: cbMock1, callback: cbMock1, param: undefined, isUnsafe: false },
+        { key: cbMock2, callback: cbMock2, param: undefined, isUnsafe: true },
+        { key: cbMock3, callback: cbMock3, param: undefined, isUnsafe: false },
+        { key: cbMock4, callback: cbMock4, param: undefined, isUnsafe: true },
       ]);
 
       expect(applyChecks!(111, null, { verbose: true })).toEqual([

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,6 +1,7 @@
 import {
-  cloneObjectEnumerableKeys,
-  cloneObjectKnownKeys,
+  cloneDict,
+  cloneDictHead,
+  cloneDictKeys,
   copyUnsafeChecks,
   createApplyChecksCallback,
   createIssueFactory,
@@ -317,18 +318,20 @@ describe('isMaskEnabled', () => {
   });
 });
 
-describe('cloneObjectEnumerableKeys', () => {
+describe('cloneDict', () => {
   test('clones all keys', () => {
     const obj1 = { aaa: 111, bbb: 222 };
-    const obj2 = cloneObjectEnumerableKeys(obj1);
+    const obj2 = cloneDict(obj1);
 
     expect(obj1).not.toBe(obj2);
     expect(obj2).toEqual({ aaa: 111, bbb: 222 });
   });
+});
 
+describe('cloneDictHead', () => {
   test('clones limited number of leading keys', () => {
     const obj1 = { aaa: 111, bbb: 222 };
-    const obj2 = cloneObjectEnumerableKeys(obj1, 1);
+    const obj2 = cloneDictHead(obj1, 1);
 
     expect(obj1).not.toBe(obj2);
     expect(obj2).toEqual({ aaa: 111 });
@@ -336,17 +339,17 @@ describe('cloneObjectEnumerableKeys', () => {
 
   test('clones no keys', () => {
     const obj1 = { aaa: 111, bbb: 222 };
-    const obj2 = cloneObjectEnumerableKeys(obj1, 0);
+    const obj2 = cloneDictHead(obj1, 0);
 
     expect(obj1).not.toBe(obj2);
     expect(obj2).toEqual({});
   });
 });
 
-describe('cloneObjectKnownKeys', () => {
+describe('cloneDictKeys', () => {
   test('clones known keys', () => {
     const obj1 = { aaa: 111, bbb: 222 };
-    const obj2 = cloneObjectKnownKeys(obj1, ['bbb']);
+    const obj2 = cloneDictKeys(obj1, ['bbb']);
 
     expect(obj1).not.toBe(obj2);
     expect(obj2).toEqual({ bbb: 222 });

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -6,13 +6,37 @@ import {
   createIssueFactory,
   enableMask,
   getValueType,
-  isMaskEnabled,
   isEqual,
   isIterableObject,
+  isMaskEnabled,
+  isPlainObject,
   toArrayIndex,
   unique,
 } from '../main/utils';
 import { Issue, Shape, ValidationError } from '../main';
+
+describe('isPlainObject', () => {
+  test('detects plain objects', () => {
+    expect(isPlainObject({})).toBe(true);
+    expect(isPlainObject({ a: 1 })).toBe(true);
+    expect(isPlainObject({ constructor: () => undefined })).toBe(true);
+    expect(isPlainObject([1, 2, 3])).toBe(false);
+    expect(isPlainObject(new (class {})())).toBe(false);
+  });
+
+  test('returns true for objects with a [[Prototype]] of null', () => {
+    expect(isPlainObject(Object.create(null))).toBe(true);
+  });
+
+  test('returns false for non-Object objects', () => {
+    expect(isPlainObject(Error)).toBe(false);
+  });
+
+  test('returns false for non-objects', () => {
+    expect(isPlainObject(111)).toBe(false);
+    expect(isPlainObject('aaa')).toBe(false);
+  });
+});
 
 describe('getValueType', () => {
   test('returns value type', () => {

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -4,9 +4,9 @@ import {
   copyUnsafeChecks,
   createApplyChecksCallback,
   createIssueFactory,
-  enableBitAt,
+  enableMask,
   getValueType,
-  isBitEnabledAt,
+  isMaskEnabled,
   isEqual,
   isIterableObject,
   toArrayIndex,
@@ -273,23 +273,23 @@ describe('createIssueFactory', () => {
   });
 });
 
-describe('enableBitAt', () => {
+describe('enableMask', () => {
   test('sets bit', () => {
-    expect(enableBitAt(0b0, 5)).toBe(0b100000);
-    expect(enableBitAt(0b1, 5)).toBe(0b100001);
-    expect(enableBitAt(0b100, 5)).toBe(0b100100);
-    expect(enableBitAt(0b1, 31)).toBe(-2147483647);
-    expect(enableBitAt(0b1, 35)).toEqual([1, 0b1000, 0]);
+    expect(enableMask(0b0, 5)).toBe(0b100000);
+    expect(enableMask(0b1, 5)).toBe(0b100001);
+    expect(enableMask(0b100, 5)).toBe(0b100100);
+    expect(enableMask(0b1, 31)).toBe(-2147483647);
+    expect(enableMask(0b1, 35)).toEqual([1, 0b1000, 0]);
   });
 });
 
-describe('isBitEnabledAt', () => {
+describe('isMaskEnabled', () => {
   test('reads bit', () => {
-    expect(isBitEnabledAt(enableBitAt(0b0, 5), 5)).toBe(true);
-    expect(isBitEnabledAt(enableBitAt(0b1, 5), 5)).toBe(true);
-    expect(isBitEnabledAt(enableBitAt(0b100, 5), 5)).toBe(true);
-    expect(isBitEnabledAt(enableBitAt(0b1, 31), 31)).toBe(true);
-    expect(isBitEnabledAt(enableBitAt(0b1, 35), 35)).toEqual(true);
+    expect(isMaskEnabled(enableMask(0b0, 5), 5)).toBe(true);
+    expect(isMaskEnabled(enableMask(0b1, 5), 5)).toBe(true);
+    expect(isMaskEnabled(enableMask(0b100, 5), 5)).toBe(true);
+    expect(isMaskEnabled(enableMask(0b1, 31), 31)).toBe(true);
+    expect(isMaskEnabled(enableMask(0b1, 35), 35)).toEqual(true);
   });
 });
 


### PR DESCRIPTION
- Better and shorter names for utility functions and types;
- Minor `IntersectionShape` optimization;
- Fixed `TransformShape` for sync callbacks that return promises.