### PR TITLE
Transformations applied through PipeShape

### DIFF
--- a/src/main/dsl/any.ts
+++ b/src/main/dsl/any.ts
@@ -6,7 +6,7 @@ import { ConstraintOptions, Message } from '../shared-types';
  *
  * You can specify compile-time type to enhance type inference.
  *
- * @template T The input and output.
+ * @template T The input and the output value.
  */
 export function any<T = any>(): Shape<T>;
 
@@ -17,18 +17,32 @@ export function any<T = any>(): Shape<T>;
  * @param cb The type predicate that returns `true` if value conforms the required type, or `false` otherwise.
  * @param options The constraint options or an issue message.
  * @returns The shape that has the narrowed output.
- * @template T The input and output.
+ * @template T The output value.
  */
-export function any<T>(cb: (value: any) => value is T, options?: ConstraintOptions | Message): Shape<T>;
+export function any<T>(
+  /**
+   * @param value The input value.
+   * @returns `true` if value conforms the predicate, or `false` otherwise.
+   */
+  cb: (value: any) => value is T,
+  options?: ConstraintOptions | Message
+): Shape<T>;
 
 /**
  * Creates a shape that is constrained with a predicate.
  *
  * @param cb The predicate that returns truthy result if value is valid, or returns falsy result otherwise.
  * @param options The constraint options or an issue message.
- * @template T The input and output.
+ * @template T The output value.
  */
-export function any<T = any>(cb: (value: any) => boolean, options?: ConstraintOptions | Message): Shape<T>;
+export function any<T = any>(
+  /**
+   * @param value The input value.
+   * @returns `true` if value conforms the predicate, or `false` otherwise.
+   */
+  cb: (value: any) => boolean,
+  options?: ConstraintOptions | Message
+): Shape<T>;
 
 export function any(cb?: (value: any) => boolean, options?: ConstraintOptions | Message): AnyShape {
   const shape = new Shape();

--- a/src/main/dsl/transform.ts
+++ b/src/main/dsl/transform.ts
@@ -1,26 +1,42 @@
 import { ParseOptions } from '../shared-types';
-import { Shape } from '../shapes';
+import { TransformShape } from '../shapes';
 
 /**
  * Creates the shape that synchronously transforms the input value.
  *
- * @param cb The callback that processes the input value.
- * @template I The input value.
- * @template O The output value.
+ * @param cb The callback that transforms the input value.
+ * @template T The output value.
  */
-export function transform<I = any, O = any>(cb: (input: I, options: Readonly<ParseOptions>) => O): Shape<I, O> {
-  return new Shape().transform(cb);
+export function transform<T>(
+  /**
+   * The callback that transforms the input value.
+   *
+   * @param value The input value.
+   * @param options Parsing options.
+   * @return The transformation result.
+   * @throws {@linkcode ValidationError} to notify that the transformation cannot be successfully completed.
+   */
+  cb: (value: any, options: Readonly<ParseOptions>) => T
+): TransformShape<T> {
+  return new TransformShape(cb);
 }
 
 /**
  * Creates the shape that asynchronously transforms the input value.
  *
- * @param cb The callback that processes the input value.
- * @template I The input value.
- * @template O The output value.
+ * @param cb The callback that transforms the input value.
+ * @template T The output value.
  */
-export function transformAsync<I = any, O = any>(
-  cb: (input: I, options: Readonly<ParseOptions>) => Promise<O>
-): Shape<I, O> {
-  return new Shape().transformAsync(cb);
+export function transformAsync<T>(
+  /**
+   * The callback that transforms the input value.
+   *
+   * @param value The input value.
+   * @param options Parsing options.
+   * @return The transformation result.
+   * @throws {@linkcode ValidationError} to notify that the transformation cannot be successfully completed.
+   */
+  cb: (value: any, options: Readonly<ParseOptions>) => Promise<T>
+): TransformShape<T> {
+  return new TransformShape(cb, true);
 }

--- a/src/main/shapes/ArrayShape.ts
+++ b/src/main/shapes/ArrayShape.ts
@@ -7,7 +7,6 @@ import {
   createIssueFactory,
   isArray,
   isAsyncShape,
-  isEqual,
   isIterableObject,
   ok,
   toArrayIndex,
@@ -231,7 +230,7 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
           issues = concatIssues(issues, result);
           continue;
         }
-        if ((_isUnsafe || issues === null) && !isEqual(value, result.value)) {
+        if (_isUnsafe || issues === null) {
           if (input === output) {
             output = input.slice(0);
           }
@@ -282,7 +281,7 @@ export class ArrayShape<U extends readonly AnyShape[] | null, R extends AnyShape
               return result;
             }
             issues = concatIssues(issues, result);
-          } else if ((_isUnsafe || issues === null) && !isEqual(input[index], result.value)) {
+          } else if (_isUnsafe || issues === null) {
             if (input === output) {
               output = input.slice(0);
             }

--- a/src/main/shapes/LazyShape.ts
+++ b/src/main/shapes/LazyShape.ts
@@ -1,6 +1,6 @@
 import { AnyShape, DeepPartialProtocol, DeepPartialShape, Result, Shape, ValueType } from './Shape';
 import { ParseOptions } from '../shared-types';
-import { copyUnsafeChecks, isArray, toDeepPartialShape } from '../utils';
+import { copyUnsafeChecks, isArray, returnArray, returnFalse, toDeepPartialShape } from '../utils';
 import { ERROR_SHAPE_EXPECTED } from '../constants';
 
 /**
@@ -108,12 +108,4 @@ export class LazyShape<S extends AnyShape>
     }
     return issues;
   }
-}
-
-function returnFalse(): boolean {
-  return false;
-}
-
-function returnArray(): any[] {
-  return [];
 }

--- a/src/main/shapes/NumberShape.ts
+++ b/src/main/shapes/NumberShape.ts
@@ -229,7 +229,7 @@ export class NumberShape extends CoercibleShape<number> {
   /**
    * Allows `NaN` as an input and output value, or replaces an input `NaN` value with a default output value.
    *
-   * @param [defaultValue = NaN] The value that is used instead of `NaN` in the output.
+   * @param defaultValue The value that is used instead of `NaN` in the output.
    */
   nan(defaultValue = NaN): Shape<number> {
     return this.replace(NaN, defaultValue);

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -12,7 +12,6 @@ import {
   enableMask,
   isArray,
   isAsyncShape,
-  isEqual,
   isMaskEnabled,
   isObjectLike,
   isPlainObject,
@@ -440,7 +439,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
               return result;
             }
             issues = concatIssues(issues, result);
-          } else if ((_isUnsafe || issues === null) && !isEqual(input[key], result.value)) {
+          } else if (_isUnsafe || issues === null) {
             if (input === output) {
               output = cloneDict(input);
             }
@@ -500,7 +499,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
         issues = concatIssues(issues, result);
         continue;
       }
-      if ((_isUnsafe || issues === null) && !isEqual(value, result.value)) {
+      if (_isUnsafe || issues === null) {
         if (input === output) {
           output = cloneDict(input);
         }
@@ -563,7 +562,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
           issues = concatIssues(issues, result);
           continue;
         }
-        if ((_isUnsafe || issues === null) && !isEqual(value, result.value)) {
+        if (_isUnsafe || issues === null) {
           if (input === output) {
             output = restShape === null ? cloneDictKeys(input, keys) : cloneDict(input);
           }
@@ -626,7 +625,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
           issues = concatIssues(issues, result);
           continue;
         }
-        if ((_isUnsafe || issues === null) && !isEqual(value, result.value)) {
+        if (_isUnsafe || issues === null) {
           if (input === output) {
             output = cloneDict(input);
           }

--- a/src/main/shapes/RecordShape.ts
+++ b/src/main/shapes/RecordShape.ts
@@ -86,9 +86,8 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
     let output = input;
     let issues = null;
     let index = -1;
-    let key: PropertyKey;
 
-    for (key in input) {
+    for (let key in input) {
       let value = input[key];
       let keyResult = null;
 
@@ -107,7 +106,7 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
             issues = concatIssues(issues, keyResult);
             keyResult = null;
           } else {
-            key = keyResult.value;
+            key = keyResult.value as string;
           }
         }
       }

--- a/src/main/shapes/RecordShape.ts
+++ b/src/main/shapes/RecordShape.ts
@@ -7,7 +7,6 @@ import {
   copyUnsafeChecks,
   createIssueFactory,
   isArray,
-  isEqual,
   isObjectLike,
   ok,
   setObjectProperty,
@@ -87,17 +86,16 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
     let output = input;
     let issues = null;
     let index = -1;
+    let key: PropertyKey;
 
-    for (const key in input) {
-      const value = input[key];
-
-      let outputKey: PropertyKey = key;
-      let outputValue = value;
+    for (key in input) {
+      let value = input[key];
+      let keyResult = null;
 
       index++;
 
       if (keyShape !== null) {
-        const keyResult = keyShape['_apply'](key, options);
+        keyResult = keyShape['_apply'](key, options);
 
         if (keyResult !== null) {
           if (isArray(keyResult)) {
@@ -107,13 +105,14 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
               return keyResult;
             }
             issues = concatIssues(issues, keyResult);
+            keyResult = null;
           } else {
-            outputKey = keyResult.value;
+            key = keyResult.value;
           }
         }
       }
 
-      const valueResult = valueShape['_apply'](value, options);
+      let valueResult = valueShape['_apply'](value, options);
 
       if (valueResult !== null) {
         if (isArray(valueResult)) {
@@ -123,16 +122,17 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
             return valueResult;
           }
           issues = concatIssues(issues, valueResult);
+          valueResult = null;
         } else {
-          outputValue = valueResult.value;
+          value = valueResult.value;
         }
       }
 
-      if ((_isUnsafe || issues === null) && (key !== outputKey || !isEqual(value, outputValue))) {
+      if ((_isUnsafe || issues === null) && (keyResult !== null || valueResult !== null)) {
         if (input === output) {
           output = cloneDictHead(input, index);
         }
-        setObjectProperty(output, outputKey, outputValue);
+        setObjectProperty(output, key, value);
       }
     }
 
@@ -161,12 +161,13 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
       let issues: Issue[] | null = null;
       let index = -1;
 
-      let key: string;
+      let key: PropertyKey;
       let value: unknown;
-      let outputKey: string;
-      let outputValue: unknown;
+      let keyChanged = false;
 
       const handleKeyResult = (keyResult: Result) => {
+        keyChanged = false;
+
         if (keyResult !== null) {
           if (isArray(keyResult)) {
             unshiftIssuesPath(keyResult, key);
@@ -176,7 +177,8 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
             }
             issues = concatIssues(issues, keyResult);
           } else {
-            outputKey = keyResult.value;
+            key = keyResult.value;
+            keyChanged = true;
           }
         }
         return applyForResult(valueShape, value, options, handleValueResult);
@@ -191,16 +193,17 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
               return valueResult;
             }
             issues = concatIssues(issues, valueResult);
+            valueResult = null;
           } else {
-            outputValue = valueResult.value;
+            value = valueResult.value;
           }
         }
 
-        if ((_isUnsafe || issues === null) && (key !== outputKey || !isEqual(value, outputValue))) {
+        if ((_isUnsafe || issues === null) && (keyChanged || valueResult !== null)) {
           if (input === output) {
             output = cloneDictHead(input, index);
           }
-          setObjectProperty(output, outputKey, outputValue);
+          setObjectProperty(output, key, value);
         }
 
         return next();
@@ -210,8 +213,8 @@ export class RecordShape<K extends Shape<string, PropertyKey> | null, V extends 
         index++;
 
         if (index !== keysLength) {
-          key = outputKey = keys[index];
-          value = outputValue = input[key];
+          key = keys[index];
+          value = input[key];
 
           if (keyShape !== null) {
             return applyForResult(keyShape, key, options, handleKeyResult);

--- a/src/main/shapes/SetShape.ts
+++ b/src/main/shapes/SetShape.ts
@@ -6,7 +6,6 @@ import {
   copyUnsafeChecks,
   createIssueFactory,
   isArray,
-  isEqual,
   isIterableObject,
   ok,
   toArrayIndex,
@@ -156,9 +155,8 @@ export class SetShape<S extends AnyShape>
         issues = concatIssues(issues, result);
         continue;
       }
-      if ((changed = !isEqual(value, result.value))) {
-        values[i] = result.value;
-      }
+      changed = true;
+      values[i] = result.value;
     }
 
     const output = changed ? new Set(values) : input;
@@ -192,7 +190,6 @@ export class SetShape<S extends AnyShape>
 
       let issues: Issue[] | null = null;
       let index = -1;
-      let value: unknown;
 
       const handleResult = (result: Result) => {
         if (result !== null) {
@@ -203,7 +200,8 @@ export class SetShape<S extends AnyShape>
               return result;
             }
             issues = concatIssues(issues, result);
-          } else if ((changed = !isEqual(value, result.value))) {
+          } else {
+            changed = true;
             values[index] = result.value;
           }
         }
@@ -214,7 +212,7 @@ export class SetShape<S extends AnyShape>
         index++;
 
         if (index !== valuesLength) {
-          return shape['_applyAsync']((value = values[index]), options).then(handleResult);
+          return shape['_applyAsync'](values[index], options).then(handleResult);
         }
 
         const output = changed ? new Set(values) : input;

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -59,6 +59,18 @@ export function isValidDate(value: unknown): value is Date {
   return value instanceof Date && (value = value.getTime()) === value;
 }
 
+export function returnTrue(): boolean {
+  return true;
+}
+
+export function returnFalse(): boolean {
+  return false;
+}
+
+export function returnArray(): any[] {
+  return [];
+}
+
 export function unique<T>(arr: T[]): T[];
 
 export function unique<T>(arr: readonly T[]): readonly T[];


### PR DESCRIPTION
- `TransformShape` doesn't require a base shape anymore;
- Removed multiple excessive `isEqual` checks.