### PR TITLE
Simpler check method signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ const includesCheck: d.CheckCallback<string[], string> = (value, param) => {
   }
 };
 
-const shape = d.array(d.string()).check(includesCheck, 'Mars');
+const shape = d.array(d.string()).check(includesCheck, { param: 'Mars' });
 // ⮕ Shape<any[]>
 
 shape.parse(['Mars', 'Pluto']);
@@ -656,7 +656,7 @@ To force `noDigitsCheck` to be applied even if `helloCheck` has raised issues, p
 ```ts
 const shape = d.string()
   .check(helloCheck)
-  .check({ unsafe: true }, noDigitsCheck);
+  .check(noDigitsCheck, { unsafe: true });
 ```
 
 Safe and unsafe checks are applied only if the type of the input is valid.
@@ -747,7 +747,7 @@ Using a check callback identity as a key isn't always convenient. Pass the
 [`key`](https://smikhalevski.github.io/doubter/interfaces/CheckOptions.html#key) option to define a custom key:
 
 ```ts
-shape.check({ key: 'email' }, emailCheck);
+shape.check(emailCheck, { key: 'email' });
 // ⮕ Shape<string>
 ```
 

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -76,6 +76,11 @@ export interface CheckOptions {
   key?: unknown;
 
   /**
+   * The param passed to the {@linkcode CheckCallback} and stored in {@linkcode Check.param}.
+   */
+  param?: any;
+
+  /**
    * If `true` then the check would be executed even if the preceding check failed, otherwise check is
    * ignored.
    */

--- a/src/main/utils/shapes.ts
+++ b/src/main/utils/shapes.ts
@@ -73,7 +73,7 @@ export function replaceChecks<S extends Shape>(shape: S, checks: readonly Check[
  * The shortcut to add built-in checks to shapes.
  */
 export function addCheck<S extends Shape, P>(shape: S, key: string, param: P, cb: CheckCallback<S[OUTPUT], P>): S {
-  return shape.check({ key, unsafe: true }, cb, param);
+  return shape.check(cb, { key, param, unsafe: true });
 }
 
 /**

--- a/src/test/dsl/any.test.ts
+++ b/src/test/dsl/any.test.ts
@@ -18,6 +18,7 @@ describe('any', () => {
       key: cb,
       callback: expect.any(Function),
       isUnsafe: false,
+      param: cb,
     });
   });
 });

--- a/src/test/shapes/ArrayShape.test.ts
+++ b/src/test/shapes/ArrayShape.test.ts
@@ -230,7 +230,7 @@ describe('ArrayShape', () => {
   });
 
   test('applies unsafe checks if a tuple element raises an issue', () => {
-    const arrShape = new ArrayShape([new StringShape()], null).check({ unsafe: true }, () => [{ code: 'xxx' }]);
+    const arrShape = new ArrayShape([new StringShape()], null).check(() => [{ code: 'xxx' }], { unsafe: true });
 
     expect(arrShape.try([111], { verbose: true })).toEqual({
       ok: false,
@@ -295,7 +295,7 @@ describe('ArrayShape', () => {
       const cbMock1 = jest.fn();
       const cbMock2 = jest.fn();
 
-      const arrShape = new ArrayShape(null, null).check({ unsafe: true }, cbMock1).check(cbMock2);
+      const arrShape = new ArrayShape(null, null).check(cbMock1, { unsafe: true }).check(cbMock2);
 
       arrShape.rest(new Shape()).parse([]);
 

--- a/src/test/shapes/IntersectionShape.test.ts
+++ b/src/test/shapes/IntersectionShape.test.ts
@@ -141,7 +141,7 @@ describe('IntersectionShape', () => {
     const shape1 = new Shape();
     const shape2 = new Shape().check(() => [{ code: 'xxx' }]);
 
-    const orShape = new IntersectionShape([shape1, shape2]).check({ unsafe: true }, () => [{ code: 'yyy' }]);
+    const orShape = new IntersectionShape([shape1, shape2]).check(() => [{ code: 'yyy' }], { unsafe: true });
 
     expect(orShape.try({}, { verbose: true })).toEqual({
       ok: false,

--- a/src/test/shapes/LazyShape.test.ts
+++ b/src/test/shapes/LazyShape.test.ts
@@ -46,7 +46,7 @@ describe('LazyShape', () => {
 
   test('does not apply checks if an underlying shape raises an issue', () => {
     const shape = new Shape().check(() => [{ code: 'xxx' }]);
-    const lazyShape = new LazyShape(() => shape).check({ unsafe: true }, () => [{ code: 'yyy' }]);
+    const lazyShape = new LazyShape(() => shape).check(() => [{ code: 'yyy' }], { unsafe: true });
 
     expect(lazyShape.try('aaa', { verbose: true })).toEqual({
       ok: false,

--- a/src/test/shapes/PromiseShape.test.ts
+++ b/src/test/shapes/PromiseShape.test.ts
@@ -45,7 +45,7 @@ describe('PromiseShape', () => {
   test('applies unsafe checks if value shape raised issues', async () => {
     const shape = new Shape().check(() => [{ code: 'xxx' }]);
 
-    const promiseShape = new PromiseShape(shape).check({ unsafe: true }, () => [{ code: 'yyy' }]);
+    const promiseShape = new PromiseShape(shape).check(() => [{ code: 'yyy' }], { unsafe: true });
 
     await expect(promiseShape.tryAsync(Promise.resolve(111), { verbose: true })).resolves.toEqual({
       ok: false,

--- a/src/test/shapes/Shape.test.ts
+++ b/src/test/shapes/Shape.test.ts
@@ -83,7 +83,7 @@ describe('Shape', () => {
 
     test('adds an unsafe check', () => {
       const cb = () => null;
-      expect(new Shape().check({ unsafe: true }, cb).getCheck(cb)?.isUnsafe).toBe(true);
+      expect(new Shape().check(cb, { unsafe: true }).getCheck(cb)?.isUnsafe).toBe(true);
     });
 
     test('added check is applied', () => {
@@ -98,7 +98,7 @@ describe('Shape', () => {
 
     test('added parameterized check is applied', () => {
       const cbMock = jest.fn(() => null);
-      const shape = new Shape().check(cbMock, 111);
+      const shape = new Shape().check(cbMock, { param: 111 });
 
       shape.parse('aaa');
 
@@ -128,7 +128,7 @@ describe('Shape', () => {
 
     test('does not add the same check callback twice if keys are equal', () => {
       const cbMock = jest.fn();
-      const shape = new Shape().check({ key: 'aaa' }, cbMock).check({ key: 'aaa' }, cbMock);
+      const shape = new Shape().check(cbMock, { key: 'aaa' }).check(cbMock, { key: 'aaa' });
 
       shape.parse(111);
 
@@ -137,7 +137,7 @@ describe('Shape', () => {
 
     test('adds the same check callback twice if keys are different', () => {
       const cbMock = jest.fn();
-      const shape = new Shape().check({ key: 'aaa' }, cbMock).check(cbMock);
+      const shape = new Shape().check(cbMock, { key: 'aaa' }).check(cbMock);
 
       shape.parse(111);
 
@@ -147,7 +147,7 @@ describe('Shape', () => {
     test('replaces check callback with the same key', () => {
       const cbMock1 = jest.fn();
       const cbMock2 = jest.fn();
-      const shape = new Shape().check({ key: 'aaa' }, cbMock1).check({ key: 'aaa' }, cbMock2);
+      const shape = new Shape().check(cbMock1, { key: 'aaa' }).check(cbMock2, { key: 'aaa' });
 
       shape.parse(111);
 
@@ -170,7 +170,7 @@ describe('Shape', () => {
 
     test('returns the check with custom key', () => {
       const cb = () => null;
-      const shape = new Shape().check({ key: 'aaa' }, cb);
+      const shape = new Shape().check(cb, { key: 'aaa' });
 
       expect(shape.getCheck('aaa')).toEqual({ key: 'aaa', callback: cb, isUnsafe: false });
     });
@@ -696,7 +696,7 @@ describe('Shape', () => {
       const cbMock1 = jest.fn(() => [{ code: 'xxx' }]);
       const cbMock2 = jest.fn();
 
-      const shape = new Shape().check(cbMock1).check({ unsafe: true }, cbMock2);
+      const shape = new Shape().check(cbMock1).check(cbMock2, { unsafe: true });
 
       expect(shape.try('aaa', { verbose: true })).toEqual({
         ok: false,
@@ -712,7 +712,7 @@ describe('Shape', () => {
       const cbMock1 = jest.fn(() => [{ code: 'xxx' }]);
       const cbMock2 = jest.fn(() => [{ code: 'yyy' }]);
 
-      const shape = new Shape().check(cbMock1).check({ unsafe: true }, cbMock2);
+      const shape = new Shape().check(cbMock1).check(cbMock2, { unsafe: true });
 
       expect(shape.try('aaa', { verbose: true })).toEqual({
         ok: false,
@@ -1110,7 +1110,7 @@ describe('ReplaceLiteralShape', () => {
       new Shape().check(() => [{ code: 'xxx' }]),
       111,
       222
-    ).check({ unsafe: true }, () => [{ code: 'yyy' }]);
+    ).check(() => [{ code: 'yyy' }], { unsafe: true });
 
     expect(shape.try('aaa', { verbose: true })).toEqual({
       ok: false,
@@ -1164,7 +1164,7 @@ describe('ReplaceLiteralShape', () => {
         asyncShape.check(() => [{ code: 'xxx' }]),
         111,
         222
-      ).check({ unsafe: true }, () => [{ code: 'yyy' }]);
+      ).check(() => [{ code: 'yyy' }], { unsafe: true });
 
       await expect(shape.tryAsync('aaa', { verbose: true })).resolves.toEqual({
         ok: false,

--- a/src/test/shapes/UnionShape.test.ts
+++ b/src/test/shapes/UnionShape.test.ts
@@ -325,7 +325,7 @@ describe('UnionShape', () => {
           key1: asyncShape.check(() => [{ code: 'zzz' }]),
         },
         null
-      ).check({ unsafe: true }, () => [{ code: 'yyy' }]);
+      ).check(() => [{ code: 'yyy' }], { unsafe: true });
 
       const orShape = new UnionShape([shape1, shape2]);
 

--- a/src/test/utils/shapes.test.ts
+++ b/src/test/utils/shapes.test.ts
@@ -13,14 +13,14 @@ describe('copyUnsafeChecks', () => {
     const safeCheck = () => undefined;
     const unsafeCheck = () => undefined;
 
-    const sourceShape = new Shape().check(safeCheck).check({ unsafe: true }, unsafeCheck);
+    const sourceShape = new Shape().check(safeCheck).check(unsafeCheck, { unsafe: true });
     const targetShape = new Shape();
 
     const shape = copyUnsafeChecks(sourceShape, targetShape);
 
     expect(shape).not.toBe(targetShape);
-    expect(shape['_checks']!.length).toBe(1);
-    expect(shape['_checks']![0].callback).toBe(unsafeCheck);
+    expect(shape['_checks'].length).toBe(1);
+    expect(shape['_checks'][0].callback).toBe(unsafeCheck);
   });
 });
 


### PR DESCRIPTION
`Shape.check` signatures cause the ambiguity between `param` and `options`:

```ts
check(cb: CheckCallback<O, undefined>): this;

check<P>(cb: CheckCallback<O, P>, param: P): this;

check(options: CheckOptions, cb: CheckCallback<O, undefined>): this;

check<P>(options: CheckOptions, cb: CheckCallback<O, P>, param: P): this;
```

Now `param` is the part of `CheckOptions` interface:

```ts
check<P>(cb: CheckCallback<O, P>, options: CheckOptions & { param: P }): this;

check(cb: CheckCallback<O>, options?: CheckOptions): this;
```