### PR TITLE
Support readonly arrays of keys in pick, omit, partial, and required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1859,7 +1859,7 @@ class NumberLikeShape extends d.Shape<string, number> {
 
   protected _apply(input: unknown, options: d.ApplyOptions): d.Result<number> {
 
-    // 1️⃣ Validate the input and retun issues if it is invalid
+    // 1️⃣ Validate the input and return issues if it is invalid
     if (typeof input !== 'string' || isNaN(parseFloat(input))) {
       return [{
         code: 'kaputs',

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -179,7 +179,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
    * @returns The new object shape.
    * @template K The tuple of keys to pick.
    */
-  pick<K extends StringKeyof<P>[]>(keys: K): ObjectShape<Pick<P, K[number]>, R> {
+  pick<K extends readonly StringKeyof<P>[]>(keys: K): ObjectShape<Pick<P, K[number]>, R> {
     const shapes: Dict<AnyShape> = {};
 
     for (const key in this.shapes) {
@@ -197,7 +197,7 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
    * @returns The new object shape.
    * @template K The tuple of keys to omit.
    */
-  omit<K extends StringKeyof<P>[]>(keys: K): ObjectShape<Omit<P, K[number]>, R> {
+  omit<K extends readonly StringKeyof<P>[]>(keys: K): ObjectShape<Omit<P, K[number]>, R> {
     const shapes: Dict<AnyShape> = {};
 
     for (const key in this.shapes) {
@@ -222,7 +222,9 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
    * @returns The new object shape.
    * @template K The array of string keys.
    */
-  partial<K extends StringKeyof<P>[]>(keys: K): ObjectShape<Omit<P, K[number]> & OptionalProps<Pick<P, K[number]>>, R>;
+  partial<K extends readonly StringKeyof<P>[]>(
+    keys: K
+  ): ObjectShape<Omit<P, K[number]> & OptionalProps<Pick<P, K[number]>>, R>;
 
   partial(keys?: string[]) {
     const shapes: Dict<AnyShape> = {};
@@ -259,7 +261,9 @@ export class ObjectShape<P extends ReadonlyDict<AnyShape>, R extends AnyShape | 
    * @returns The new object shape.
    * @template K The array of string keys.
    */
-  required<K extends StringKeyof<P>[]>(keys: K): ObjectShape<Omit<P, K[number]> & RequiredProps<Pick<P, K[number]>>, R>;
+  required<K extends readonly StringKeyof<P>[]>(
+    keys: K
+  ): ObjectShape<Omit<P, K[number]> & RequiredProps<Pick<P, K[number]>>, R>;
 
   required(keys?: string[]) {
     const shapes: Dict<AnyShape> = {};

--- a/src/test/README.test.ts
+++ b/src/test/README.test.ts
@@ -77,7 +77,7 @@ describe('Advanced shapes', () => {
   test('NumberLikeShape', () => {
     class NumberLikeShape extends d.Shape<string, number> {
       protected _apply(input: unknown, options: d.ApplyOptions): d.Result<number> {
-        // 1️⃣ Validate the input and retun issues if it is invalid
+        // 1️⃣ Validate the input and return issues if it is invalid
         if (typeof input !== 'string' || isNaN(parseFloat(input))) {
           return [
             {

--- a/src/test/dsl/object.test-d.ts
+++ b/src/test/dsl/object.test-d.ts
@@ -77,3 +77,27 @@ expectType<{ aaa?: string; bbb?: Array<number | undefined> }>(
     })
     .deepPartial().__output
 );
+
+const keys = ['aaa'] as const;
+
+expectType<{ aaa: string }>(d.object({ aaa: d.string(), bbb: d.number() }).pick(keys).__output);
+
+expectType<{ bbb: number }>(d.object({ aaa: d.string(), bbb: d.number() }).omit(keys).__output);
+
+expectType<{ aaa?: string | undefined; bbb: number }>(
+  d
+    .object({
+      aaa: d.string(),
+      bbb: d.number(),
+    })
+    .partial(keys).__output
+);
+
+expectType<{ aaa: string; bbb: number }>(
+  d
+    .object({
+      aaa: d.string().optional(),
+      bbb: d.number(),
+    })
+    .required(keys).__output
+);


### PR DESCRIPTION
```ts
const keys = ['aaa'] as const;

d
  .object({
    aaa: d.string(),
    bbb: d.number()
  })
  //    👇 No typing errors here anymore
  .pick(keys)
// ⮕ Shape<{ aaa: string }>
```