### PR TITLE
Infer function signature types from the implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2293,7 +2293,7 @@ Finite numbers follow [number type coercion rules](#coerce-to-a-number).
 [`function`](https://smikhalevski.github.io/doubter/functions/function.html) returns a
 [`FunctionShape`](https://smikhalevski.github.io/doubter/classes/FunctionShape.html) instance.
 
-Constrain a value to be a function that has an insured signature at runtime.
+Constrain a value to be a function that has an ensured signature at runtime.
 
 A function that has no arguments and returns `any`:
 
@@ -2362,12 +2362,12 @@ shape1.parse('Mars');
 ```
 
 By default, the input function is returned as is during parsing. Tell the function shape to wrap the input function with
-a signature insurance wrapper during parsing by calling `insure` method.
+a signature ensurance wrapper during parsing by calling `strict` method.
 
 ```ts
 const greetShape = d.fn([d.string()])
   .return(d.string())
-  .insure();
+  .strict();
 
 const greet = greetShape.parse(name => `Hello, $name!`);
 ```
@@ -2377,7 +2377,7 @@ respective shapes.
 
 ## Implementing a function
 
-You can wrap an input function with a signature insurance wrapper that guarantees that the function signature is
+You can wrap an input function with a signature ensurance wrapper that guarantees that the function signature is
 type-safe at runtime.
 
 Let's declare a function shape that takes two integers arguments and returns an integer as well:
@@ -2390,7 +2390,7 @@ const sumShape = d.fn([d.int(), d.int()]).return(d.int());
 Now let's provide a concrete implementation:
 
 ```ts
-const sum = sumShape.insureFunction(
+const sum = sumShape.ensureSignature(
   (arg1, arg2) => arg1 + arg2
 );
 // ⮕ (arg1: number, arg2: number) => number
@@ -2420,7 +2420,7 @@ const atShape = d.fn([d.int()])
   .return(d.number());
 // ⮕ Shape<(this: string[]) => number>
 
-const at = atShape.insureFunction(function (index) {
+const at = atShape.ensureSignature(function (index) {
   // 🟡 May be undefined if index is out of bounds
   return this[index];
 });
@@ -2456,7 +2456,7 @@ Function shapes go well with [type coercion](#type-coercion):
 const plus2Shape = d.fn([d.int().coerce()]).return(d.int());
 // ⮕ Shape<(arg: number) => number>
 
-const plus2 = plus2Shape.insureFunction(
+const plus2 = plus2Shape.ensureSignature(
   arg => arg + 2
 );
 // ⮕ (arg: number) => number
@@ -2487,7 +2487,7 @@ function inputFunction(arg: number): any {
   return arg + 2;
 }
 
-const outputFunction = shape.insureFunction(inputFunction);
+const outputFunction = shape.ensureSignature(inputFunction);
 // ⮕ (arg: string) => any
 ```
 

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -1,6 +1,6 @@
 export const ERROR_REQUIRES_ASYNC = 'Shape is async, use tryAsync, parseAsync, or parseOrDefaultAsync.';
 export const ERROR_SHAPE_EXPECTED = 'Provider must return a shape. Are you accessing a lazy shape prematurely?';
-export const ERROR_ASYNC_FUNCTION = 'The function signature is constrained by async shapes, use insureAsyncFunction.';
+export const ERROR_ASYNC_FUNCTION = 'The function signature is constrained by async shapes, use ensureAsyncSignature.';
 
 export const CODE_ARRAY_MIN = 'arrayMinLength';
 export const CODE_ARRAY_MAX = 'arrayMaxLength';

--- a/src/main/dsl/any.ts
+++ b/src/main/dsl/any.ts
@@ -4,11 +4,11 @@ import { ApplyOptions, Message, RefineOptions } from '../types';
 /**
  * Creates the unconstrained shape.
  *
- * You can specify compile-time type to enhance type inference.
+ * You can specify compile-time type to enhance type inference. This provides _no runtime type-safety_!
  *
- * @template T The input and the output value.
+ * @template Value The input and the output value.
  */
-export function any<T = any>(): Shape<T>;
+export function any<Value = any>(): Shape<Value>;
 
 /**
  * Creates a shape that is constrained with a
@@ -17,26 +17,26 @@ export function any<T = any>(): Shape<T>;
  * @param cb The type predicate that returns `true` if value conforms the required type, or `false` otherwise.
  * @param options The constraint options or an issue message.
  * @returns The shape that has the narrowed output.
- * @template T The output value.
+ * @template Value The input and the output value.
  */
-export function any<T>(
+export function any<Value>(
   /**
    * @param value The input value.
    * @param options Parsing options.
    * @returns `true` if value conforms the predicate, or `false` otherwise.
    */
-  cb: (value: any, options: Readonly<ApplyOptions>) => value is T,
+  cb: (value: any, options: Readonly<ApplyOptions>) => value is Value,
   options?: RefineOptions | Message
-): Shape<T>;
+): Shape<Value>;
 
 /**
  * Creates a shape that is constrained with a predicate.
  *
  * @param cb The predicate that returns truthy result if value is valid, or returns falsy result otherwise.
  * @param options The constraint options or an issue message.
- * @template T The output value.
+ * @template Value The input and the output value.
  */
-export function any<T = any>(
+export function any<Value = any>(
   /**
    * @param value The input value.
    * @param options Parsing options.
@@ -44,7 +44,7 @@ export function any<T = any>(
    */
   cb: (value: any, options: Readonly<ApplyOptions>) => boolean,
   options?: RefineOptions | Message
-): Shape<T>;
+): Shape<Value>;
 
 export function any(
   cb?: (value: any, options: Readonly<ApplyOptions>) => boolean,

--- a/src/main/dsl/array.ts
+++ b/src/main/dsl/array.ts
@@ -6,24 +6,27 @@ import { ConstraintOptions, Message } from '../types';
  *
  * @param options The constraint options or an issue message.
  */
-export function array(options?: ConstraintOptions | Message): ArrayShape<null, null>;
+export function array(options?: ConstraintOptions | Message): ArrayShape<[], Shape>;
 
 /**
  * Creates the array shape with elements that conform the element shape.
  *
- * @param shape The shape of an array element.
+ * @param shape The shape of array elements.
  * @param options The constraint options or an issue message.
- * @template S The shape of array elements.
+ * @template ValueShape The shape of array elements.
  */
-export function array<S extends AnyShape | null>(shape: S, options?: ConstraintOptions | Message): ArrayShape<null, S>;
+export function array<ValueShape extends AnyShape>(
+  shape: ValueShape,
+  options?: ConstraintOptions | Message
+): ArrayShape<[], ValueShape>;
 
 export function array(
   shape?: AnyShape | ConstraintOptions | Message,
   options?: ConstraintOptions | Message
-): ArrayShape<any, any> {
-  if (shape === null || shape === undefined || shape instanceof Shape) {
-    return new ArrayShape(null, shape || null, options);
+): ArrayShape<[], AnyShape> {
+  if (shape instanceof Shape) {
+    return new ArrayShape([], shape, options);
   } else {
-    return new ArrayShape(null, null, shape);
+    return new ArrayShape([], new Shape(), shape);
   }
 }

--- a/src/main/dsl/const.ts
+++ b/src/main/dsl/const.ts
@@ -6,9 +6,9 @@ import { ConstraintOptions, Literal, Message } from '../types';
  *
  * @param value The value to which the input must be strictly equal.
  * @param options The constraint options or an issue message.
- * @template T The expected value.
+ * @template Value The expected value.
  */
-function const_<T extends Literal>(value: T, options?: ConstraintOptions | Message): ConstShape<T> {
+function const_<Value extends Literal>(value: Value, options?: ConstraintOptions | Message): ConstShape<Value> {
   return new ConstShape(value, options);
 }
 

--- a/src/main/dsl/enum.ts
+++ b/src/main/dsl/enum.ts
@@ -7,27 +7,27 @@ import { ReadonlyDict } from '../utils';
  *
  * @param values The array of values allowed for the input.
  * @param options The constraint options or an issue message.
- * @template T Allowed values.
- * @template U The array of allowed values.
+ * @template Value The union of allowed enum values.
+ * @template ValuesArray The array of allowed values.
  */
-function enum_<T extends Literal, U extends readonly [T, ...T[]]>(
-  values: U,
+function enum_<Value extends Literal, ValuesArray extends readonly [Value, ...Value[]]>(
+  values: ValuesArray,
   options?: ConstraintOptions | Message
-): EnumShape<U[number]>;
+): EnumShape<ValuesArray[number]>;
 
 /**
  * Creates the shape that constrains input with values of
  * [the enum-like object](https://www.typescriptlang.org/docs/handbook/enums.html).
  *
- * @param valueMapping The native enum or a mapping object.
+ * @param values The native enum or a mapping object.
  * @param options The constraint options or an issue message.
- * @template T Allowed values.
- * @template U The object that maps from the key to an enum value.
+ * @template Value The union of allowed enum values.
+ * @template ValuesDict The object that maps from the key to an enum value.
  */
-function enum_<T extends Literal, U extends ReadonlyDict<T>>(
-  valueMapping: U,
+function enum_<Value extends Literal, ValuesDict extends ReadonlyDict<Value>>(
+  values: ValuesDict,
   options?: ConstraintOptions | Message
-): EnumShape<U[keyof U]>;
+): EnumShape<ValuesDict[keyof ValuesDict]>;
 
 function enum_(source: any[] | ReadonlyDict, options?: ConstraintOptions | Message): EnumShape<any> {
   return new EnumShape(source, options);

--- a/src/main/dsl/function.ts
+++ b/src/main/dsl/function.ts
@@ -14,24 +14,27 @@ function function_(options?: ConstraintOptions | Message): FunctionShape<ArraySh
  *
  * @param argShapes The array of argument shapes.
  * @param options The constraint options or an issue message.
- * @template A The array of argument shapes.
+ * @template ArgShapes The array of argument shapes.
  */
-function function_<A extends readonly [AnyShape, ...AnyShape[]] | []>(
-  argShapes: A,
+function function_<ArgShapes extends readonly [AnyShape, ...AnyShape[]] | []>(
+  argShapes: ArgShapes,
   options?: ConstraintOptions | Message
-): FunctionShape<ArrayShape<A, null>, null, null>;
+): FunctionShape<ArrayShape<ArgShapes, null>, null, null>;
 
 /**
  * Creates a shape of a function with arguments parsed by an array shape.
  *
  * @param argsShape The shape of the array of arguments.
  * @param options The constraint options or an issue message.
- * @template A The shape of the array of arguments.
+ * @template InputArgValues The array of input arguments.
+ * @template OutputArgValues The array of input arguments.
+ * @template ArgsShape The shape of the array of arguments.
  */
-function function_<I extends readonly any[], O extends readonly any[], A extends Shape<I, O>>(
-  argsShape: A,
-  options?: ConstraintOptions | Message
-): FunctionShape<A, null, null>;
+function function_<
+  InputArgValues extends readonly any[],
+  OutputArgValues extends readonly any[],
+  ArgsShape extends Shape<InputArgValues, OutputArgValues>
+>(argsShape: ArgsShape, options?: ConstraintOptions | Message): FunctionShape<ArgsShape, null, null>;
 
 function function_(
   argShapes?: Shape | AnyShape[] | ConstraintOptions | Message,

--- a/src/main/dsl/instanceOf.ts
+++ b/src/main/dsl/instanceOf.ts
@@ -6,11 +6,11 @@ import { ConstraintOptions, Message } from '../types';
  *
  * @param ctor The instance constructor.
  * @param options The constraint options or an issue message.
- * @template C The instance constructor.
+ * @template Ctor The instance constructor.
  */
-export function instanceOf<C extends new (...args: any[]) => any>(
-  ctor: C,
+export function instanceOf<Ctor extends new (...args: any[]) => any>(
+  ctor: Ctor,
   options?: ConstraintOptions | Message
-): InstanceShape<C> {
+): InstanceShape<Ctor> {
   return new InstanceShape(ctor, options);
 }

--- a/src/main/dsl/intersection.ts
+++ b/src/main/dsl/intersection.ts
@@ -6,13 +6,13 @@ import { ConstraintOptions, Message } from '../types';
  *
  * @param shapes The array of shapes.
  * @param options The constraint options or an issue message.
- * @template U The tuple of intersected shapes.
+ * @template Shapes The tuple of intersected shapes.
  */
-export function intersection<U extends [AnyShape, ...AnyShape[]]>(
-  shapes: U,
+export function intersection<Shapes extends [AnyShape, ...AnyShape[]]>(
+  shapes: Shapes,
   options?: ConstraintOptions | Message
-): IntersectionShape<U> {
-  return new IntersectionShape<U>(shapes, options);
+): IntersectionShape<Shapes> {
+  return new IntersectionShape<Shapes>(shapes, options);
 }
 
 export { intersection as and };

--- a/src/main/dsl/lazy.ts
+++ b/src/main/dsl/lazy.ts
@@ -4,8 +4,8 @@ import { AnyShape, LazyShape } from '../shapes';
  * Creates the shape that resolves the underlying shape on-demand.
  *
  * @param shapeProvider The provider that returns the resolved shape.
- * @template S The resolved shape.
+ * @template ProvidedShape The provided shape.
  */
-export function lazy<S extends AnyShape>(shapeProvider: () => S): LazyShape<S> {
+export function lazy<ProvidedShape extends AnyShape>(shapeProvider: () => ProvidedShape): LazyShape<ProvidedShape> {
   return new LazyShape(shapeProvider);
 }

--- a/src/main/dsl/map.ts
+++ b/src/main/dsl/map.ts
@@ -7,13 +7,13 @@ import { ConstraintOptions, Message } from '../types';
  * @param keyShape The key shape.
  * @param valueShape The value shape.
  * @param options The type constraint options or an issue message.
- * @template K The key shape.
- * @template V The value shape.
+ * @template KeyShape The key shape.
+ * @template ValueShape The value shape.
  */
-export function map<K extends AnyShape, V extends AnyShape>(
-  keyShape: K,
-  valueShape: V,
+export function map<KeyShape extends AnyShape, ValueShape extends AnyShape>(
+  keyShape: KeyShape,
+  valueShape: ValueShape,
   options?: ConstraintOptions | Message
-): MapShape<K, V> {
+): MapShape<KeyShape, ValueShape> {
   return new MapShape(keyShape, valueShape, options);
 }

--- a/src/main/dsl/not.ts
+++ b/src/main/dsl/not.ts
@@ -6,8 +6,11 @@ import { ConstraintOptions, Message } from '../types';
  *
  * @param shape The shape to which the output must not conform.
  * @param options The constraint options or an issue message.
- * @template S The shape to which the output must not conform.
+ * @template ExcludedShape The shape to which the output must not conform.
  */
-export function not<S extends AnyShape>(shape: S, options?: ConstraintOptions | Message): NotShape<Shape, S> {
+export function not<ExcludedShape extends AnyShape>(
+  shape: ExcludedShape,
+  options?: ConstraintOptions | Message
+): NotShape<Shape, ExcludedShape> {
   return new Shape().not(shape, options);
 }

--- a/src/main/dsl/object.ts
+++ b/src/main/dsl/object.ts
@@ -7,10 +7,11 @@ import { ReadonlyDict } from '../utils';
  *
  * @param shapes The mapping from an object key to a corresponding shape.
  * @param options The constraint options or an issue message.
+ * @template PropertyShapes The mapping from a string object key to a corresponding value shape.
  */
-export function object<P extends ReadonlyDict<AnyShape>>(
-  shapes: P,
+export function object<PropertyShapes extends ReadonlyDict<AnyShape>>(
+  shapes: PropertyShapes,
   options?: ConstraintOptions | Message
-): ObjectShape<P, null> {
+): ObjectShape<PropertyShapes, null> {
   return new ObjectShape(shapes, null, options);
 }

--- a/src/main/dsl/object.ts
+++ b/src/main/dsl/object.ts
@@ -7,11 +7,11 @@ import { ReadonlyDict } from '../utils';
  *
  * @param shapes The mapping from an object key to a corresponding shape.
  * @param options The constraint options or an issue message.
- * @template PropertyShapes The mapping from a string object key to a corresponding value shape.
+ * @template PropShapes The mapping from a string object key to a corresponding value shape.
  */
-export function object<PropertyShapes extends ReadonlyDict<AnyShape>>(
-  shapes: PropertyShapes,
+export function object<PropShapes extends ReadonlyDict<AnyShape>>(
+  shapes: PropShapes,
   options?: ConstraintOptions | Message
-): ObjectShape<PropertyShapes, null> {
+): ObjectShape<PropShapes, null> {
   return new ObjectShape(shapes, null, options);
 }

--- a/src/main/dsl/promise.ts
+++ b/src/main/dsl/promise.ts
@@ -6,8 +6,11 @@ import { ConstraintOptions, Message } from '../types';
  *
  * @param shape The shape of the resolved value.
  * @param options The constraint options or an issue message.
- * @template S The shape of the resolved value.
+ * @template ValueShape The shape of the resolved value.
  */
-export function promise<S extends AnyShape>(shape: S, options?: ConstraintOptions | Message): PromiseShape<S> {
+export function promise<ValueShape extends AnyShape>(
+  shape: ValueShape,
+  options?: ConstraintOptions | Message
+): PromiseShape<ValueShape> {
   return new PromiseShape(shape, options);
 }

--- a/src/main/dsl/record.ts
+++ b/src/main/dsl/record.ts
@@ -6,9 +6,12 @@ import { ConstraintOptions, Message } from '../types';
  *
  * @param valueShape The shape of the record values.
  * @param options The constraint options or an issue message.
- * @template V The value shape.
+ * @template ValueShape The value shape.
  */
-export function record<V extends AnyShape>(valueShape: V, options?: ConstraintOptions | Message): RecordShape<null, V>;
+export function record<ValueShape extends AnyShape>(
+  valueShape: ValueShape,
+  options?: ConstraintOptions | Message
+): RecordShape<null, ValueShape>;
 
 /**
  * Creates the shape that describes an object with string keys and values that conform the given shape.
@@ -16,14 +19,14 @@ export function record<V extends AnyShape>(valueShape: V, options?: ConstraintOp
  * @param keyShape The shape of record keys.
  * @param valueShape The shape of the record values.
  * @param options The constraint options or an issue message.
- * @template K The key shape.
- * @template V The value shape.
+ * @template KeyShape The key shape.
+ * @template ValueShape The value shape.
  */
-export function record<K extends Shape<string, PropertyKey>, V extends AnyShape>(
-  keyShape: K,
-  valueShape: V,
+export function record<KeyShape extends Shape<string, PropertyKey>, ValueShape extends AnyShape>(
+  keyShape: KeyShape,
+  valueShape: ValueShape,
   options?: ConstraintOptions | Message
-): RecordShape<K, V>;
+): RecordShape<KeyShape, ValueShape>;
 
 export function record(
   keyShape: AnyShape,

--- a/src/main/dsl/set.ts
+++ b/src/main/dsl/set.ts
@@ -6,8 +6,11 @@ import { ConstraintOptions, Message } from '../types';
  *
  * @param shape The value shape
  * @param options The constraint options or an issue message.
- * @template S The value shape.
+ * @template ValueShape The value shape.
  */
-export function set<S extends AnyShape>(shape: S, options?: ConstraintOptions | Message): SetShape<S> {
+export function set<ValueShape extends AnyShape>(
+  shape: ValueShape,
+  options?: ConstraintOptions | Message
+): SetShape<ValueShape> {
   return new SetShape(shape, options);
 }

--- a/src/main/dsl/transform.ts
+++ b/src/main/dsl/transform.ts
@@ -5,9 +5,9 @@ import { ApplyOptions } from '../types';
  * Creates the shape that synchronously transforms the input value.
  *
  * @param cb The callback that transforms the input value.
- * @template T The output value.
+ * @template TransformedValue The output value.
  */
-export function transform<T>(
+export function transform<TransformedValue>(
   /**
    * The callback that transforms the input value.
    *
@@ -16,8 +16,8 @@ export function transform<T>(
    * @return The transformation result.
    * @throws {@linkcode ValidationError} to notify that the transformation cannot be successfully completed.
    */
-  cb: (value: any, options: Readonly<ApplyOptions>) => T
-): TransformShape<T> {
+  cb: (value: any, options: Readonly<ApplyOptions>) => TransformedValue
+): TransformShape<TransformedValue> {
   return new TransformShape(cb);
 }
 
@@ -25,9 +25,9 @@ export function transform<T>(
  * Creates the shape that asynchronously transforms the input value.
  *
  * @param cb The callback that transforms the input value.
- * @template T The output value.
+ * @template TransformedValue The output value.
  */
-export function transformAsync<T>(
+export function transformAsync<TransformedValue>(
   /**
    * The callback that transforms the input value.
    *
@@ -36,7 +36,7 @@ export function transformAsync<T>(
    * @return The transformation result.
    * @throws {@linkcode ValidationError} to notify that the transformation cannot be successfully completed.
    */
-  cb: (value: any, options: Readonly<ApplyOptions>) => Promise<T>
-): TransformShape<T> {
+  cb: (value: any, options: Readonly<ApplyOptions>) => Promise<TransformedValue>
+): TransformShape<TransformedValue> {
   return new TransformShape(cb, true);
 }

--- a/src/main/dsl/tuple.ts
+++ b/src/main/dsl/tuple.ts
@@ -6,12 +6,12 @@ import { ConstraintOptions, Message } from '../types';
  *
  * @param shapes The array of tuple element shapes.
  * @param options The constraint options or an issue message.
- * @template U The tuple elements.
+ * @template HeadShapes The head tuple elements.
  */
-export function tuple<U extends readonly [AnyShape, ...AnyShape[]]>(
-  shapes: U,
+export function tuple<HeadShapes extends readonly [AnyShape, ...AnyShape[]]>(
+  shapes: HeadShapes,
   options?: ConstraintOptions | Message
-): ArrayShape<U, null>;
+): ArrayShape<HeadShapes, null>;
 
 /**
  * Creates the tuple shape with rest elements.
@@ -19,14 +19,14 @@ export function tuple<U extends readonly [AnyShape, ...AnyShape[]]>(
  * @param shapes The array of tuple element shapes.
  * @param restShape The shape of rest elements.
  * @param options The constraint options or an issue message.
- * @template U The head tuple elements.
- * @template R The rest tuple elements.
+ * @template HeadShapes The head tuple elements.
+ * @template RestShape The rest tuple elements.
  */
-export function tuple<U extends readonly [AnyShape, ...AnyShape[]], R extends AnyShape | null>(
-  shapes: U,
-  restShape: R,
+export function tuple<HeadShapes extends readonly [AnyShape, ...AnyShape[]], RestShape extends AnyShape | null>(
+  shapes: HeadShapes,
+  restShape: RestShape,
   options?: ConstraintOptions | Message
-): ArrayShape<U, R>;
+): ArrayShape<HeadShapes, RestShape>;
 
 export function tuple(
   shapes: [AnyShape, ...AnyShape[]],

--- a/src/main/dsl/union.ts
+++ b/src/main/dsl/union.ts
@@ -6,13 +6,13 @@ import { ConstraintOptions, Message } from '../types';
  *
  * @param shapes The array of shapes to try.
  * @param options The constraint options or an issue message.
- * @template U The tuple of united shapes.
+ * @template Shapes The tuple of united shapes.
  */
-export function union<U extends [AnyShape, ...AnyShape[]]>(
-  shapes: U,
+export function union<Shapes extends [AnyShape, ...AnyShape[]]>(
+  shapes: Shapes,
   options?: ConstraintOptions | Message
-): UnionShape<U> {
-  return new UnionShape<U>(shapes, options);
+): UnionShape<Shapes> {
+  return new UnionShape<Shapes>(shapes, options);
 }
 
 export { union as or };

--- a/src/main/shapes/BigIntShape.ts
+++ b/src/main/shapes/BigIntShape.ts
@@ -6,9 +6,12 @@ import { CoercibleShape } from './CoercibleShape';
 import { NEVER, Result } from './Shape';
 
 /**
- * The shape of the bigint value.
+ * The shape of a bigint value.
  */
 export class BigIntShape extends CoercibleShape<bigint> {
+  /**
+   * Returns issues associated with an invalid input value type.
+   */
   protected _typeIssueFactory;
 
   /**

--- a/src/main/shapes/BigIntShape.ts
+++ b/src/main/shapes/BigIntShape.ts
@@ -1,7 +1,7 @@
 import { CODE_TYPE, MESSAGE_BIGINT_TYPE } from '../constants';
 import { TYPE_ARRAY, TYPE_BIGINT, TYPE_BOOLEAN, TYPE_NUMBER, TYPE_OBJECT, TYPE_STRING } from '../Type';
 import { ApplyOptions, ConstraintOptions, Message } from '../types';
-import { getCanonicalValueOf, createIssueFactory, isArray, ok } from '../utils';
+import { createIssueFactory, getCanonicalValueOf, isArray, ok } from '../utils';
 import { CoercibleShape } from './CoercibleShape';
 import { NEVER, Result } from './Shape';
 

--- a/src/main/shapes/BooleanShape.ts
+++ b/src/main/shapes/BooleanShape.ts
@@ -6,9 +6,12 @@ import { CoercibleShape } from './CoercibleShape';
 import { NEVER, Result } from './Shape';
 
 /**
- * The shape of the boolean value.
+ * The shape of a boolean value.
  */
 export class BooleanShape extends CoercibleShape<boolean> {
+  /**
+   * Returns issues associated with an invalid input value type.
+   */
   protected _typeIssueFactory;
 
   /**

--- a/src/main/shapes/BooleanShape.ts
+++ b/src/main/shapes/BooleanShape.ts
@@ -1,7 +1,7 @@
 import { CODE_TYPE, MESSAGE_BOOLEAN_TYPE } from '../constants';
 import { TYPE_ARRAY, TYPE_BOOLEAN, TYPE_NUMBER, TYPE_OBJECT, TYPE_STRING } from '../Type';
 import { ApplyOptions, ConstraintOptions, Message } from '../types';
-import { getCanonicalValueOf, createIssueFactory, isArray, ok } from '../utils';
+import { createIssueFactory, getCanonicalValueOf, isArray, ok } from '../utils';
 import { CoercibleShape } from './CoercibleShape';
 import { NEVER, Result } from './Shape';
 

--- a/src/main/shapes/CoercibleShape.ts
+++ b/src/main/shapes/CoercibleShape.ts
@@ -1,21 +1,21 @@
 import { Shape } from './Shape';
 
 /**
- * The shape which value can be coerced to a proper type during parsing.
+ * The shape can coerce input value type during parsing.
  *
- * @template I The input value.
- * @template O The output value.
+ * @template InputValue The input value.
+ * @template OutputValue The output value.
  */
-export class CoercibleShape<I = any, O = I> extends Shape<I, O> {
+export class CoercibleShape<InputValue = any, OutputValue = InputValue> extends Shape<InputValue, OutputValue> {
   /**
-   * `true` if input value is coerced to required type during parsing, or `false` otherwise.
+   * `true` if input value is coerced to the required type during parsing, or `false` otherwise.
    */
   isCoerced = false;
 
   /**
-   * Enables input value coercion.
+   * Enables an input value coercion.
    *
-   * @returns The clone of the shape, or this shape if it is already coerced.
+   * @returns The clone of the shape.
    */
   coerce(): this {
     const shape = this._clone();

--- a/src/main/shapes/ConstShape.ts
+++ b/src/main/shapes/ConstShape.ts
@@ -4,12 +4,19 @@ import { createIssueFactory } from '../utils';
 import { Result, Shape } from './Shape';
 
 /**
- * The shape that constrains an input to be exactly equal to the expected value.
+ * The shape of a constant value.
  *
- * @template T The expected value.
+ * @template Value The expected constant value.
  */
-export class ConstShape<T> extends Shape<T> {
+export class ConstShape<Value> extends Shape<Value> {
+  /**
+   * Returns `true` if an input is equal to the const value, or `false` otherwise.
+   */
   protected _typePredicate: (input: unknown) => boolean;
+
+  /**
+   * Returns issues associated with an invalid input value type.
+   */
   protected _typeIssueFactory;
 
   /**
@@ -17,13 +24,13 @@ export class ConstShape<T> extends Shape<T> {
    *
    * @param value The expected value.
    * @param options The type constraint options or an issue message.
-   * @template T The expected value.
+   * @template Value The expected value.
    */
   constructor(
     /**
-     * The expected value.
+     * The expected constant value.
      */
-    readonly value: T,
+    readonly value: Value,
     options?: ConstraintOptions | Message
   ) {
     super();
@@ -36,7 +43,7 @@ export class ConstShape<T> extends Shape<T> {
     return [this.value];
   }
 
-  protected _apply(input: unknown, options: ApplyOptions): Result<T> {
+  protected _apply(input: unknown, options: ApplyOptions): Result<Value> {
     const { _applyChecks } = this;
 
     if (!this._typePredicate(input)) {

--- a/src/main/shapes/DateShape.ts
+++ b/src/main/shapes/DateShape.ts
@@ -1,7 +1,7 @@
 import { CODE_TYPE, MESSAGE_DATE_TYPE } from '../constants';
 import { TYPE_ARRAY, TYPE_DATE, TYPE_NUMBER, TYPE_OBJECT, TYPE_STRING } from '../Type';
 import { ApplyOptions, ConstraintOptions, Message } from '../types';
-import { getCanonicalValueOf, createIssueFactory, isArray, isValidDate, ok } from '../utils';
+import { createIssueFactory, getCanonicalValueOf, isArray, isValidDate, ok } from '../utils';
 import { CoercibleShape } from './CoercibleShape';
 import { NEVER, Result } from './Shape';
 

--- a/src/main/shapes/DateShape.ts
+++ b/src/main/shapes/DateShape.ts
@@ -9,6 +9,9 @@ import { NEVER, Result } from './Shape';
  * The shape of the `Date` object.
  */
 export class DateShape extends CoercibleShape<Date> {
+  /**
+   * Returns issues associated with an invalid input value type.
+   */
   protected _typeIssueFactory;
 
   /**

--- a/src/main/shapes/EnumShape.ts
+++ b/src/main/shapes/EnumShape.ts
@@ -1,7 +1,7 @@
 import { CODE_ENUM, MESSAGE_ENUM } from '../constants';
 import { TYPE_ARRAY, TYPE_OBJECT } from '../Type';
 import { ApplyOptions, ConstraintOptions, Message } from '../types';
-import { getCanonicalValueOf, createIssueFactory, isArray, ok, ReadonlyDict, unique } from '../utils';
+import { createIssueFactory, getCanonicalValueOf, isArray, ok, ReadonlyDict, unique } from '../utils';
 import { CoercibleShape } from './CoercibleShape';
 import { NEVER, Result } from './Shape';
 

--- a/src/main/shapes/EnumShape.ts
+++ b/src/main/shapes/EnumShape.ts
@@ -6,16 +6,19 @@ import { CoercibleShape } from './CoercibleShape';
 import { NEVER, Result } from './Shape';
 
 /**
- * The shape that constrains an input to be one of values.
+ * The shape of a value enumeration.
  *
- * @template T Allowed values.
+ * @template Value The union of allowed enum values.
  */
-export class EnumShape<T> extends CoercibleShape<T> {
+export class EnumShape<Value> extends CoercibleShape<Value> {
   /**
    * The array of unique enum values.
    */
-  readonly values: T[];
+  readonly values: readonly Value[];
 
+  /**
+   * Returns issues associated with an invalid input value type.
+   */
   protected _typeIssueFactory;
 
   /**
@@ -23,13 +26,13 @@ export class EnumShape<T> extends CoercibleShape<T> {
    *
    * @param source The array of allowed values, a const key-value mapping, or an enum object.
    * @param options The type constraint options or an issue message.
-   * @template T Allowed values.
+   * @template Value The union of allowed enum values.
    */
   constructor(
     /**
-     * The array of allowed values, a const key-value mapping, or an enum object.
+     * The array of allowed values, a const key-value mapping, or an TypeScript enum object.
      */
-    readonly source: readonly T[] | ReadonlyDict<T>,
+    readonly source: readonly Value[] | ReadonlyDict<Value>,
     options?: ConstraintOptions | Message
   ) {
     super();
@@ -51,7 +54,7 @@ export class EnumShape<T> extends CoercibleShape<T> {
     return inputs.concat(TYPE_ARRAY, TYPE_OBJECT);
   }
 
-  protected _apply(input: any, options: ApplyOptions): Result<T> {
+  protected _apply(input: any, options: ApplyOptions): Result<Value> {
     const { values, _applyChecks } = this;
 
     let output = input;

--- a/src/main/shapes/FunctionShape.ts
+++ b/src/main/shapes/FunctionShape.ts
@@ -3,49 +3,50 @@ import { TYPE_FUNCTION } from '../Type';
 import { ApplyOptions, ConstraintOptions, Message, ParseOptions } from '../types';
 import { applyShape, copyChecks, createIssueFactory, getErrorMessage, isArray, ok, unshiftIssuesPath } from '../utils';
 import { ValidationError } from '../ValidationError';
-import { AnyShape, defaultApplyOptions, Input, Output, Result, Shape } from './Shape';
+import { AnyShape, defaultApplyOptions, INPUT, OUTPUT, Result, Shape } from './Shape';
 
-type InferThis<F> = F extends (this: infer T, ...args: any[]) => any ? T : any;
+type ShapeValue<
+  Shape extends AnyShape | null | undefined,
+  Leg extends INPUT | OUTPUT,
+  DefaultValue = any
+> = Shape extends null | undefined ? DefaultValue : Shape extends AnyShape ? Shape[Leg] : DefaultValue;
 
-// prettier-ignore
-type TryInput<S extends AnyShape | null | undefined, T = any> =
-  S extends null | undefined ? T : S extends AnyShape ? Input<S> : T;
-
-// prettier-ignore
-type TryOutput<S extends AnyShape | null | undefined, T = any> =
-  S extends null | undefined ? T : S extends AnyShape ? Output<S> : T;
+type ThisType<F> = F extends (this: infer T, ...args: any[]) => any ? T : any;
 
 // prettier-ignore
 type Awaited<T> =
   T extends null | undefined ? T :
-  T extends object & { then(fn: infer F, ...args: any): any }
-    ? F extends (value: infer V, ...args: any) => any ? Awaited<V> : never
-    : T;
+  T extends object & { then(fn: infer F, ...args: any): any } ?
+    F extends (value: infer V, ...args: any) => any ? Awaited<V> : never :
+  T;
 
-type Promisify<T> = Promise<Awaited<T>>;
+type ToPromise<T> = Promise<Awaited<T>>;
 
-type Awaitable<T> = T extends Awaited<T> ? Awaited<T> | Promisify<T> : Promisify<T>;
+type Awaitable<T> = Awaited<T> extends T ? Promise<T> | T : T;
 
 /**
- * The shape of the function value.
+ * The shape of a function.
  *
- * @template A The shape of the array of arguments.
- * @template R The return value shape, or `null` if unconstrained.
- * @template T The shape of `this` argument, or `null` if unconstrained.
+ * @template ArgsShape The shape of the array of arguments.
+ * @template ReturnShape The return value shape, or `null` if unconstrained.
+ * @template ThisShape The shape of `this` argument, or `null` if unconstrained.
  */
 export class FunctionShape<
-  A extends Shape<readonly any[], readonly any[]>,
-  R extends AnyShape | null,
-  T extends AnyShape | null
+  ArgsShape extends Shape<readonly any[], readonly any[]>,
+  ReturnShape extends AnyShape | null,
+  ThisShape extends AnyShape | null
 > extends Shape<
-  (this: TryOutput<T>, ...args: Output<A>) => TryInput<R>,
-  (this: TryInput<T>, ...args: Input<A>) => TryOutput<R>
+  (this: ShapeValue<ThisShape, OUTPUT>, ...args: ArgsShape[OUTPUT]) => ShapeValue<ReturnShape, INPUT>,
+  (this: ShapeValue<ThisShape, INPUT>, ...args: ArgsShape[INPUT]) => ShapeValue<ReturnShape, OUTPUT>
 > {
   /**
    * `true` if input functions are wrapped during parsing to ensure runtime signature type-safety, or `false` otherwise.
    */
   isStrict = false;
 
+  /**
+   * Returns issues associated with an invalid input value type.
+   */
   protected _typeIssueFactory;
 
   /**
@@ -60,20 +61,23 @@ export class FunctionShape<
    * @param returnShape The return value shape, or `null` if unconstrained.
    * @param thisShape The shape of `this` argument, or `null` if unconstrained.
    * @param options The type constraint options or the type issue message.
+   * @template ArgsShape The shape of the array of arguments.
+   * @template ReturnShape The return value shape, or `null` if unconstrained.
+   * @template ThisShape The shape of `this` argument, or `null` if unconstrained.
    */
   constructor(
     /**
      * The shape of the array of arguments.
      */
-    readonly argsShape: A,
+    readonly argsShape: ArgsShape,
     /**
      * The return value shape, or `null` if unconstrained.
      */
-    readonly returnShape: R,
+    readonly returnShape: ReturnShape,
     /**
      * The shape of `this` value, or `null` if unconstrained.
      */
-    readonly thisShape: T,
+    readonly thisShape: ThisShape,
     options?: ConstraintOptions | Message
   ) {
     super();
@@ -95,7 +99,7 @@ export class FunctionShape<
    * @returns The new function shape.
    * @template S The return value shape.
    */
-  return<S extends AnyShape | null>(shape: S): FunctionShape<A, S, T> {
+  return<S extends AnyShape | null>(shape: S): FunctionShape<ArgsShape, S, ThisShape> {
     return copyChecks(this, new FunctionShape(this.argsShape, shape, this.thisShape));
   }
 
@@ -106,7 +110,7 @@ export class FunctionShape<
    * @returns The new function shape.
    * @template S The shape of `this` argument.
    */
-  this<S extends AnyShape | null>(shape: S): FunctionShape<A, R, S> {
+  this<S extends AnyShape | null>(shape: S): FunctionShape<ArgsShape, ReturnShape, S> {
     return copyChecks(this, new FunctionShape(this.argsShape, this.returnShape, shape));
   }
 
@@ -129,16 +133,22 @@ export class FunctionShape<
   /**
    * Wraps a function to ensure runtime signature type-safety. The returned wrapper function ensures that `fn` receives
    * arguments and `this` values that conform {@linkcode argsShape} and {@linkcode thisShape} respectively, and
-   * _synchronously_ returns the value that conforms {@link returnShape}.
+   * _synchronously_ returns the value that conforms {@linkcode returnShape}.
    *
    * @param fn The underlying function.
    * @param options Parsing options used by the wrapper. By default, options provided to {@linkcode strict} are used.
    * @returns The wrapper function.
+   * @template F The function to wrap.
    */
-  ensureSignature<F extends (this: TryOutput<T>, ...args: Output<A>) => TryInput<R>>(
+  ensureSignature<
+    F extends (this: ShapeValue<ThisShape, OUTPUT>, ...args: ArgsShape[OUTPUT]) => ShapeValue<ReturnShape, INPUT>
+  >(
     fn: F,
     options?: Readonly<ParseOptions>
-  ): (this: TryInput<T, InferThis<F>>, ...args: Input<A>) => TryOutput<R, ReturnType<F>>;
+  ): (
+    this: ShapeValue<ThisShape, INPUT, ThisType<F>>,
+    ...args: ArgsShape[INPUT]
+  ) => ShapeValue<ReturnShape, OUTPUT, ReturnType<F>>;
 
   ensureSignature(fn: Function, options = this._parseOptions || defaultApplyOptions) {
     const { argsShape, returnShape, thisShape } = this;
@@ -164,7 +174,7 @@ export class FunctionShape<
   /**
    * Wraps a function to ensure runtime signature type-safety. The returned wrapper function ensures that `fn` receives
    * arguments and `this` values that conform {@linkcode argsShape} and {@linkcode thisShape} respectively, and
-   * _asynchronously_ returns the value that conforms {@link returnShape}.
+   * _asynchronously_ returns the value that conforms {@linkcode returnShape}.
    *
    * Use this method if {@link isAsyncSignature some shapes that describe the function signature} are
    * {@link Shape.isAsync async}.
@@ -172,11 +182,20 @@ export class FunctionShape<
    * @param fn The underlying function.
    * @param options Parsing options used by the wrapper. By default, options provided to {@linkcode strict} are used.
    * @returns The wrapper function.
+   * @template F The function to wrap.
    */
-  ensureAsyncSignature<F extends (this: TryOutput<T>, ...args: Output<A>) => Awaitable<TryInput<R>>>(
+  ensureAsyncSignature<
+    F extends (
+      this: ShapeValue<ThisShape, OUTPUT>,
+      ...args: ArgsShape[OUTPUT]
+    ) => Awaitable<ShapeValue<ReturnShape, INPUT>>
+  >(
     fn: F,
     options?: Readonly<ParseOptions>
-  ): (this: TryInput<T, InferThis<F>>, ...args: Input<A>) => Promisify<TryOutput<R, ReturnType<F>>>;
+  ): (
+    this: ShapeValue<ThisShape, INPUT, ThisType<F>>,
+    ...args: ArgsShape[INPUT]
+  ) => ToPromise<ShapeValue<ReturnShape, OUTPUT, ReturnType<F>>>;
 
   ensureAsyncSignature(fn: Function, options = this._parseOptions || defaultApplyOptions) {
     const { argsShape, returnShape, thisShape } = this;
@@ -214,7 +233,10 @@ export class FunctionShape<
     return [TYPE_FUNCTION];
   }
 
-  protected _apply(input: any, options: ApplyOptions): Result<(this: TryInput<T>, ...args: Input<A>) => TryOutput<R>> {
+  protected _apply(
+    input: any,
+    options: ApplyOptions
+  ): Result<(this: ShapeValue<ThisShape, INPUT>, ...args: ArgsShape[INPUT]) => ShapeValue<ReturnShape, OUTPUT>> {
     const { _applyChecks } = this;
 
     let issues = null;

--- a/src/main/shapes/InstanceShape.ts
+++ b/src/main/shapes/InstanceShape.ts
@@ -7,9 +7,12 @@ import { Result, Shape } from './Shape';
 /**
  * The shape of the class instance.
  *
- * @template C The class constructor.
+ * @template Ctor The class constructor.
  */
-export class InstanceShape<C extends new (...args: any[]) => any> extends Shape<InstanceType<C>> {
+export class InstanceShape<Ctor extends new (...args: any) => any> extends Shape<InstanceType<Ctor>> {
+  /**
+   * Returns issues associated with an invalid input value type.
+   */
   protected _typeIssueFactory;
 
   /**
@@ -17,9 +20,9 @@ export class InstanceShape<C extends new (...args: any[]) => any> extends Shape<
    *
    * @param ctor The class constructor.
    * @param options The type constraint options or the type issue message.
-   * @template C The class constructor.
+   * @template Ctor The class constructor.
    */
-  constructor(readonly ctor: C, options?: ConstraintOptions | Message) {
+  constructor(readonly ctor: Ctor, options?: ConstraintOptions | Message) {
     super();
 
     this._typeIssueFactory = createIssueFactory(CODE_INSTANCE, MESSAGE_INSTANCE, options, ctor);
@@ -46,7 +49,7 @@ export class InstanceShape<C extends new (...args: any[]) => any> extends Shape<
     return [TYPE_OBJECT];
   }
 
-  protected _apply(input: unknown, options: ApplyOptions): Result<InstanceType<C>> {
+  protected _apply(input: unknown, options: ApplyOptions): Result<InstanceType<Ctor>> {
     const { _applyChecks } = this;
 
     if (!(input instanceof this.ctor)) {

--- a/src/main/shapes/IntersectionShape.ts
+++ b/src/main/shapes/IntersectionShape.ts
@@ -21,34 +21,41 @@ import { AnyShape, DeepPartialProtocol, DeepPartialShape, INPUT, NEVER, OUTPUT, 
 export type ToIntersection<U extends AnyShape> =
   (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I extends AnyShape ? I : never : never;
 
-export type DeepPartialIntersectionShape<U extends readonly AnyShape[]> = IntersectionShape<{
-  [K in keyof U]: U[K] extends AnyShape ? DeepPartialShape<U[K]> : never;
+export type DeepPartialIntersectionShape<Shapes extends readonly AnyShape[]> = IntersectionShape<{
+  [K in keyof Shapes]: DeepPartialShape<Shapes[K]>;
 }>;
 
 /**
  * The shape that requires an input to conform all given shapes.
  *
- * @template U The array of shapes that comprise an intersection.
+ * @template Shapes The array of shapes that comprise an intersection.
  */
-export class IntersectionShape<U extends readonly AnyShape[]>
-  extends Shape<ToIntersection<U[number]>[INPUT], ToIntersection<U[number]>[OUTPUT]>
-  implements DeepPartialProtocol<DeepPartialIntersectionShape<U>>
+export class IntersectionShape<Shapes extends readonly AnyShape[]>
+  extends Shape<ToIntersection<Shapes[number]>[INPUT], ToIntersection<Shapes[number]>[OUTPUT]>
+  implements DeepPartialProtocol<DeepPartialIntersectionShape<Shapes>>
 {
+  /**
+   * The intersection constraint options or an issue message.
+   */
   protected _options;
+
+  /**
+   * Returns issues associated with an invalid input value type.
+   */
   protected _typeIssueFactory;
 
   /**
    * Creates a new {@linkcode IntersectionShape} instance.
    *
    * @param shapes The array of shapes that comprise an intersection.
-   * @param options The union constraint options or an issue message.
-   * @template U The array of shapes that comprise an intersection.
+   * @param options The intersection constraint options or an issue message.
+   * @template Shapes The array of shapes that comprise an intersection.
    */
   constructor(
     /**
      * The array of shapes that comprise an intersection.
      */
-    readonly shapes: U,
+    readonly shapes: Shapes,
     options?: ConstraintOptions | Message
   ) {
     super();
@@ -76,7 +83,7 @@ export class IntersectionShape<U extends readonly AnyShape[]>
     return new IntersectionShape(shapes);
   }
 
-  deepPartial(): DeepPartialIntersectionShape<U> {
+  deepPartial(): DeepPartialIntersectionShape<Shapes> {
     return copyUnsafeChecks(this, new IntersectionShape<any>(this.shapes.map(toDeepPartialShape), this._options));
   }
 
@@ -88,7 +95,7 @@ export class IntersectionShape<U extends readonly AnyShape[]>
     return distributeTypes(this.shapes.map(getShapeInputs));
   }
 
-  protected _apply(input: any, options: ApplyOptions): Result<ToIntersection<U[number]>[OUTPUT]> {
+  protected _apply(input: any, options: ApplyOptions): Result<ToIntersection<Shapes[number]>[OUTPUT]> {
     const { shapes } = this;
     const shapesLength = shapes.length;
 
@@ -126,7 +133,7 @@ export class IntersectionShape<U extends readonly AnyShape[]>
     return issues;
   }
 
-  protected _applyAsync(input: any, options: ApplyOptions): Promise<Result<ToIntersection<U[number]>[OUTPUT]>> {
+  protected _applyAsync(input: any, options: ApplyOptions): Promise<Result<ToIntersection<Shapes[number]>[OUTPUT]>> {
     return new Promise(resolve => {
       const { shapes } = this;
       const shapesLength = shapes.length;
@@ -178,7 +185,7 @@ export class IntersectionShape<U extends readonly AnyShape[]>
     input: any,
     outputs: any[] | null,
     options: ApplyOptions
-  ): Result<ToIntersection<U[number]>[OUTPUT]> {
+  ): Result<ToIntersection<Shapes[number]>[OUTPUT]> {
     const { shapes, _applyChecks } = this;
 
     let output = input;

--- a/src/main/shapes/LazyShape.ts
+++ b/src/main/shapes/LazyShape.ts
@@ -6,11 +6,11 @@ import { AnyShape, DeepPartialProtocol, DeepPartialShape, INPUT, OUTPUT, Result,
 /**
  * Lazily resolves a shape using the provider callback.
  *
- * @template S The resolved shape.
+ * @template ProvidedShape The provided shape.
  */
-export class LazyShape<S extends AnyShape>
-  extends Shape<S[INPUT], S[OUTPUT]>
-  implements DeepPartialProtocol<LazyShape<DeepPartialShape<S>>>
+export class LazyShape<ProvidedShape extends AnyShape>
+  extends Shape<ProvidedShape[INPUT], ProvidedShape[OUTPUT]>
+  implements DeepPartialProtocol<LazyShape<DeepPartialShape<ProvidedShape>>>
 {
   /**
    * The provider that returns the memoized shape.
@@ -22,12 +22,12 @@ export class LazyShape<S extends AnyShape>
    *
    * @param shapeProvider The provider callback that returns the shape to which {@linkcode LazyShape} delegates input
    * handling. The provider is called only once.
-   * @template S The resolved shape.
+   * @template ProvidedShape The provided shape.
    */
-  constructor(shapeProvider: () => S) {
+  constructor(shapeProvider: () => ProvidedShape) {
     super();
 
-    let shape: S | null = null;
+    let shape: ProvidedShape | null = null;
 
     this._shapeProvider = () => {
       if (shape !== null || (shape = shapeProvider()) instanceof Shape) {
@@ -41,7 +41,7 @@ export class LazyShape<S extends AnyShape>
   /**
    * The lazy-loaded shape.
    */
-  get shape(): S {
+  get shape(): ProvidedShape {
     Object.defineProperty(this, 'shape', { configurable: true, value: undefined });
 
     const shape = this._shapeProvider();
@@ -51,7 +51,7 @@ export class LazyShape<S extends AnyShape>
     return shape;
   }
 
-  deepPartial(): LazyShape<DeepPartialShape<S>> {
+  deepPartial(): LazyShape<DeepPartialShape<ProvidedShape>> {
     const { _shapeProvider } = this;
 
     return copyUnsafeChecks(this, new LazyShape(() => toDeepPartialShape(_shapeProvider())));
@@ -65,15 +65,15 @@ export class LazyShape<S extends AnyShape>
     return this.shape.inputs.slice(0);
   }
 
-  protected _apply(input: unknown, options: ApplyOptions): Result<S[OUTPUT]> {
+  protected _apply(input: unknown, options: ApplyOptions): Result<ProvidedShape[OUTPUT]> {
     return this._handleResult(this.shape['_apply'](input, options), input, options);
   }
 
-  protected _applyAsync(input: unknown, options: ApplyOptions): Promise<Result<S[OUTPUT]>> {
+  protected _applyAsync(input: unknown, options: ApplyOptions): Promise<Result<ProvidedShape[OUTPUT]>> {
     return this.shape['_applyAsync'](input, options).then(result => this._handleResult(result, input, options));
   }
 
-  private _handleResult(result: Result, input: unknown, options: ApplyOptions): Result<S[OUTPUT]> {
+  private _handleResult(result: Result, input: unknown, options: ApplyOptions): Result<ProvidedShape[OUTPUT]> {
     const { _applyChecks } = this;
 
     let output = input;

--- a/src/main/shapes/MapShape.ts
+++ b/src/main/shapes/MapShape.ts
@@ -8,7 +8,7 @@ import {
   copyUnsafeChecks,
   createIssueFactory,
   isArray,
-  isIterable,
+  isIterableObject,
   isMapEntry,
   isObjectLike,
   ok,
@@ -30,14 +30,21 @@ import {
 /**
  * The shape of a `Map` instance.
  *
- * @template K The key shape.
- * @template V The value shape.
+ * @template KeyShape The key shape.
+ * @template ValueShape The value shape.
  */
-export class MapShape<K extends AnyShape, V extends AnyShape>
-  extends CoercibleShape<Map<K[INPUT], V[INPUT]>, Map<K[OUTPUT], V[OUTPUT]>>
-  implements DeepPartialProtocol<MapShape<DeepPartialShape<K>, OptionalDeepPartialShape<V>>>
+export class MapShape<KeyShape extends AnyShape, ValueShape extends AnyShape>
+  extends CoercibleShape<Map<KeyShape[INPUT], ValueShape[INPUT]>, Map<KeyShape[OUTPUT], ValueShape[OUTPUT]>>
+  implements DeepPartialProtocol<MapShape<DeepPartialShape<KeyShape>, OptionalDeepPartialShape<ValueShape>>>
 {
+  /**
+   * The type constraint options or an issue message.
+   */
   protected _options;
+
+  /**
+   * Returns issues associated with an invalid input value type.
+   */
   protected _typeIssueFactory;
 
   /**
@@ -46,18 +53,18 @@ export class MapShape<K extends AnyShape, V extends AnyShape>
    * @param keyShape The key shape.
    * @param valueShape The value shape.
    * @param options The type constraint options or an issue message.
-   * @template K The key shape.
-   * @template V The value shape.
+   * @template KeyShape The key shape.
+   * @template ValueShape The value shape.
    */
   constructor(
     /**
      * The key shape.
      */
-    readonly keyShape: K,
+    readonly keyShape: KeyShape,
     /**
      * The value shape.
      */
-    readonly valueShape: V,
+    readonly valueShape: ValueShape,
     options?: ConstraintOptions | Message
   ) {
     super();
@@ -70,7 +77,7 @@ export class MapShape<K extends AnyShape, V extends AnyShape>
     return this.valueShape;
   }
 
-  deepPartial(): MapShape<DeepPartialShape<K>, OptionalDeepPartialShape<V>> {
+  deepPartial(): MapShape<DeepPartialShape<KeyShape>, OptionalDeepPartialShape<ValueShape>> {
     const keyShape = toDeepPartialShape(this.keyShape);
     const valueShape = toDeepPartialShape(this.valueShape).optional();
 
@@ -89,7 +96,7 @@ export class MapShape<K extends AnyShape, V extends AnyShape>
     }
   }
 
-  protected _apply(input: any, options: ApplyOptions): Result<Map<K[OUTPUT], V[OUTPUT]>> {
+  protected _apply(input: any, options: ApplyOptions): Result<Map<KeyShape[OUTPUT], ValueShape[OUTPUT]>> {
     let changed = false;
     let entries;
 
@@ -162,7 +169,7 @@ export class MapShape<K extends AnyShape, V extends AnyShape>
     return issues;
   }
 
-  protected _applyAsync(input: any, options: ApplyOptions): Promise<Result<Map<K[OUTPUT], V[OUTPUT]>>> {
+  protected _applyAsync(input: any, options: ApplyOptions): Promise<Result<Map<KeyShape[OUTPUT], ValueShape[OUTPUT]>>> {
     return new Promise(resolve => {
       let changed = false;
       let entries: [unknown, unknown][];
@@ -259,7 +266,7 @@ export class MapShape<K extends AnyShape, V extends AnyShape>
   /**
    * Coerces a value to an array of `Map` entries, or returns {@linkcode NEVER} if coercion isn't possible.
    *
-   * @param value The non-`Map` value to coerce.
+   * @param value A non-`Map` value to coerce.
    */
   protected _coerceEntries(value: any): [unknown, unknown][] {
     if (isArray(value)) {
@@ -268,7 +275,7 @@ export class MapShape<K extends AnyShape, V extends AnyShape>
 
     value = getCanonicalValueOf(value);
 
-    if (isIterable(value)) {
+    if (isIterableObject(value)) {
       value = Array.from(value);
 
       return value.every(isMapEntry) ? value : NEVER;

--- a/src/main/shapes/MapShape.ts
+++ b/src/main/shapes/MapShape.ts
@@ -3,10 +3,10 @@ import { TYPE_ARRAY, TYPE_MAP, TYPE_OBJECT } from '../Type';
 import { ApplyOptions, ConstraintOptions, Issue, Message } from '../types';
 import {
   applyShape,
-  getCanonicalValueOf,
   concatIssues,
   copyUnsafeChecks,
   createIssueFactory,
+  getCanonicalValueOf,
   isArray,
   isIterableObject,
   isMapEntry,

--- a/src/main/shapes/NeverShape.ts
+++ b/src/main/shapes/NeverShape.ts
@@ -7,6 +7,9 @@ import { Result, Shape } from './Shape';
  * The shape that doesn't match any input.
  */
 export class NeverShape extends Shape<never> {
+  /**
+   * Returns issues associated with an invalid input value type.
+   */
   protected _typeIssueFactory;
 
   /**

--- a/src/main/shapes/NumberShape.ts
+++ b/src/main/shapes/NumberShape.ts
@@ -18,7 +18,7 @@ import {
 } from '../constants';
 import { TYPE_ARRAY, TYPE_BOOLEAN, TYPE_DATE, TYPE_NUMBER, TYPE_OBJECT, TYPE_STRING } from '../Type';
 import { ApplyOptions, ConstraintOptions, Literal, Message } from '../types';
-import { addCheck, getCanonicalValueOf, createIssueFactory, isArray, isNumber, ok } from '../utils';
+import { addCheck, createIssueFactory, getCanonicalValueOf, isArray, isNumber, ok } from '../utils';
 import { CoercibleShape } from './CoercibleShape';
 import { AllowLiteralShape, NEVER, ReplaceLiteralShape, Result } from './Shape';
 

--- a/src/main/shapes/NumberShape.ts
+++ b/src/main/shapes/NumberShape.ts
@@ -23,11 +23,18 @@ import { CoercibleShape } from './CoercibleShape';
 import { AllowLiteralShape, NEVER, ReplaceLiteralShape, Result } from './Shape';
 
 /**
- * The shape that constrains the input as a number.
+ * The shape of a number value.
  */
 export class NumberShape extends CoercibleShape<number> {
-  protected _typeIssueFactory;
+  /**
+   * Returns `true` if an input is equal to the const value, or `false` otherwise.
+   */
   protected _typePredicate = isNumber;
+
+  /**
+   * Returns issues associated with an invalid input value type.
+   */
+  protected _typeIssueFactory;
 
   /**
    * Creates a new {@linkcode NumberShape} instance.
@@ -167,10 +174,19 @@ export class NumberShape extends CoercibleShape<number> {
    *
    * This constraint uses the
    * [modulo operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder) which may
-   * produce unexpected results when used with floating point numbers. This happens because of
+   * produce unexpected results when used with floating point numbers. Unexpected results happen because of
    * [the way numbers are represented by IEEE 754](https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html).
    *
-   * Use a custom check to constrain input to be a multiple of a real number.
+   * Use a custom check to constrain input to be a multiple of a real number:
+   *
+   * ```ts
+   * const precision = 100;
+   *
+   * d.number().refine(
+   *   (value, param) => Math.trunc(value * precision) % Math.trunc(param * precision) === 0,
+   *   { param: 0.05 }
+   * );
+   * ```
    *
    * @param value The positive number by which the input should be divisible without a remainder.
    * @param options The constraint options or an issue message.

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -37,11 +37,11 @@ import {
 
 // prettier-ignore
 type InferObject<
-  PropertyShapes extends ReadonlyDict<AnyShape>,
+  PropShapes extends ReadonlyDict<AnyShape>,
   RestShape extends AnyShape | null,
   Leg extends INPUT | OUTPUT
 > = Squash<
-  & UndefinedToOptional<{ [K in keyof PropertyShapes]: PropertyShapes[K][Leg] }>
+  & UndefinedToOptional<{ [K in keyof PropShapes]: PropShapes[K][Leg] }>
   & (RestShape extends null | undefined ? {} : RestShape extends AnyShape ? { [key: string]: RestShape[Leg] } : {})
 >;
 
@@ -53,19 +53,16 @@ type Squash<T> = { [K in keyof T]: T[K] } & {};
 
 type StringKeyof<T extends object> = Extract<keyof T, string>;
 
-type OptionalProps<PropertyShapes extends ReadonlyDict<AnyShape>> = {
-  [K in keyof PropertyShapes]: AllowLiteralShape<PropertyShapes[K], undefined>;
+type OptionalProps<PropShapes extends ReadonlyDict<AnyShape>> = {
+  [K in keyof PropShapes]: AllowLiteralShape<PropShapes[K], undefined>;
 };
 
-type RequiredProps<PropertyShapes extends ReadonlyDict<AnyShape>> = {
-  [K in keyof PropertyShapes]: DenyLiteralShape<PropertyShapes[K], undefined>;
+type RequiredProps<PropShapes extends ReadonlyDict<AnyShape>> = {
+  [K in keyof PropShapes]: DenyLiteralShape<PropShapes[K], undefined>;
 };
 
-type DeepPartialObjectShape<
-  PropertyShapes extends ReadonlyDict<AnyShape>,
-  RestShape extends AnyShape | null
-> = ObjectShape<
-  { [K in keyof PropertyShapes]: OptionalDeepPartialShape<PropertyShapes[K]> },
+type DeepPartialObjectShape<PropShapes extends ReadonlyDict<AnyShape>, RestShape extends AnyShape | null> = ObjectShape<
+  { [K in keyof PropShapes]: OptionalDeepPartialShape<PropShapes[K]> },
   RestShape extends null | undefined ? null : RestShape extends AnyShape ? OptionalDeepPartialShape<RestShape> : null
 >;
 
@@ -74,19 +71,19 @@ export type KeysMode = 'preserved' | 'stripped' | 'exact';
 /**
  * The shape of an object.
  *
- * @template PropertyShapes The mapping from a string object key to a corresponding value shape.
+ * @template PropShapes The mapping from a string object key to a corresponding value shape.
  * @template RestShape The shape that constrains values of
  * [a string index signature](https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures), or `null`
  * if there's no index signature.
  */
-export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShape extends AnyShape | null>
-  extends Shape<InferObject<PropertyShapes, RestShape, INPUT>, InferObject<PropertyShapes, RestShape, OUTPUT>>
-  implements DeepPartialProtocol<DeepPartialObjectShape<PropertyShapes, RestShape>>
+export class ObjectShape<PropShapes extends ReadonlyDict<AnyShape>, RestShape extends AnyShape | null>
+  extends Shape<InferObject<PropShapes, RestShape, INPUT>, InferObject<PropShapes, RestShape, OUTPUT>>
+  implements DeepPartialProtocol<DeepPartialObjectShape<PropShapes, RestShape>>
 {
   /**
    * The array of known object keys.
    */
-  readonly keys: readonly StringKeyof<PropertyShapes>[];
+  readonly keys: readonly StringKeyof<PropShapes>[];
 
   /**
    * The mode of keys handling.
@@ -127,7 +124,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
    * then values thea fall under the index signature are unconstrained.
    * @param options The type constraint options or an issue message.
    * @param keysMode The mode of keys handling.
-   * @template PropertyShapes The mapping from an object key to a corresponding value shape.
+   * @template PropShapes The mapping from an object key to a corresponding value shape.
    * @template RestShape The shape that constrains values of
    * [a string index signature](https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures).
    */
@@ -135,7 +132,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
     /**
      * The mapping from an object key to a corresponding value shape.
      */
-    readonly shapes: PropertyShapes,
+    readonly shapes: PropShapes,
     /**
      * The shape that constrains values of
      * [a string index signature](https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures).
@@ -146,7 +143,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
   ) {
     super();
 
-    this.keys = Object.keys(shapes) as StringKeyof<PropertyShapes>[];
+    this.keys = Object.keys(shapes) as StringKeyof<PropShapes>[];
     this.keysMode = keysMode;
 
     this._options = options;
@@ -177,7 +174,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
    */
   extend<T extends ReadonlyDict<AnyShape>>(
     shape: ObjectShape<T, any>
-  ): ObjectShape<Pick<PropertyShapes, Exclude<keyof PropertyShapes, keyof T>> & T, RestShape>;
+  ): ObjectShape<Pick<PropShapes, Exclude<keyof PropShapes, keyof T>> & T, RestShape>;
 
   /**
    * Add properties to an object shape.
@@ -191,7 +188,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
    */
   extend<T extends ReadonlyDict<AnyShape>>(
     shapes: T
-  ): ObjectShape<Pick<PropertyShapes, Exclude<keyof PropertyShapes, keyof T>> & T, RestShape>;
+  ): ObjectShape<Pick<PropShapes, Exclude<keyof PropShapes, keyof T>> & T, RestShape>;
 
   extend(shape: ObjectShape<any, any> | ReadonlyDict) {
     const shapes = Object.assign({}, this.shapes, shape instanceof ObjectShape ? shape.shapes : shape);
@@ -206,9 +203,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
    * @returns The new object shape.
    * @template K The tuple of keys to pick.
    */
-  pick<K extends readonly StringKeyof<PropertyShapes>[]>(
-    keys: K
-  ): ObjectShape<Pick<PropertyShapes, K[number]>, RestShape> {
+  pick<K extends readonly StringKeyof<PropShapes>[]>(keys: K): ObjectShape<Pick<PropShapes, K[number]>, RestShape> {
     const shapes: Dict<AnyShape> = {};
 
     for (const key in this.shapes) {
@@ -226,9 +221,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
    * @returns The new object shape.
    * @template K The tuple of keys to omit.
    */
-  omit<K extends readonly StringKeyof<PropertyShapes>[]>(
-    keys: K
-  ): ObjectShape<Omit<PropertyShapes, K[number]>, RestShape> {
+  omit<K extends readonly StringKeyof<PropShapes>[]>(keys: K): ObjectShape<Omit<PropShapes, K[number]>, RestShape> {
     const shapes: Dict<AnyShape> = {};
 
     for (const key in this.shapes) {
@@ -244,7 +237,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
    *
    * @returns The new object shape.
    */
-  partial(): ObjectShape<OptionalProps<PropertyShapes>, RestShape>;
+  partial(): ObjectShape<OptionalProps<PropShapes>, RestShape>;
 
   /**
    * Returns an object shape with keys marked as optional.
@@ -253,9 +246,9 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
    * @returns The new object shape.
    * @template K The array of string keys.
    */
-  partial<K extends readonly StringKeyof<PropertyShapes>[]>(
+  partial<K extends readonly StringKeyof<PropShapes>[]>(
     keys: K
-  ): ObjectShape<Omit<PropertyShapes, K[number]> & OptionalProps<Pick<PropertyShapes, K[number]>>, RestShape>;
+  ): ObjectShape<Omit<PropShapes, K[number]> & OptionalProps<Pick<PropShapes, K[number]>>, RestShape>;
 
   partial(keys?: string[]) {
     const shapes: Dict<AnyShape> = {};
@@ -266,7 +259,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
     return copyUnsafeChecks(this, new ObjectShape<any, any>(shapes, this.restShape, this._options, this.keysMode));
   }
 
-  deepPartial(): DeepPartialObjectShape<PropertyShapes, RestShape> {
+  deepPartial(): DeepPartialObjectShape<PropShapes, RestShape> {
     const shapes: Dict<AnyShape> = {};
 
     for (const key in this.shapes) {
@@ -283,7 +276,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
    *
    * @returns The new object shape.
    */
-  required(): ObjectShape<RequiredProps<PropertyShapes>, RestShape>;
+  required(): ObjectShape<RequiredProps<PropShapes>, RestShape>;
 
   /**
    * Returns an object shape with keys marked as required.
@@ -292,9 +285,9 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
    * @returns The new object shape.
    * @template K The array of string keys.
    */
-  required<K extends readonly StringKeyof<PropertyShapes>[]>(
+  required<K extends readonly StringKeyof<PropShapes>[]>(
     keys: K
-  ): ObjectShape<Omit<PropertyShapes, K[number]> & RequiredProps<Pick<PropertyShapes, K[number]>>, RestShape>;
+  ): ObjectShape<Omit<PropShapes, K[number]> & RequiredProps<Pick<PropShapes, K[number]>>, RestShape>;
 
   required(keys?: string[]) {
     const shapes: Dict<AnyShape> = {};
@@ -311,7 +304,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
    * @param options The constraint options or an issue message.
    * @returns The new object shape.
    */
-  exact(options?: ConstraintOptions | Message): ObjectShape<PropertyShapes, null> {
+  exact(options?: ConstraintOptions | Message): ObjectShape<PropShapes, null> {
     const shape = new ObjectShape(this.shapes, null, this._options, 'exact');
 
     shape._exactIssueFactory = createIssueFactory(CODE_UNKNOWN_KEYS, MESSAGE_UNKNOWN_KEYS, options);
@@ -324,7 +317,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
    *
    * @returns The new object shape.
    */
-  strip(): ObjectShape<PropertyShapes, null> {
+  strip(): ObjectShape<PropShapes, null> {
     return copyUnsafeChecks(this, new ObjectShape(this.shapes, null, this._options, 'stripped'));
   }
 
@@ -333,7 +326,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
    *
    * @returns The new object shape.
    */
-  preserve(): ObjectShape<PropertyShapes, null> {
+  preserve(): ObjectShape<PropShapes, null> {
     return copyUnsafeChecks(this, new ObjectShape(this.shapes, null, this._options));
   }
 
@@ -346,14 +339,14 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
    * @returns The new object shape.
    * @template S The index signature shape.
    */
-  rest<S extends AnyShape | null>(restShape: S): ObjectShape<PropertyShapes, S> {
+  rest<S extends AnyShape | null>(restShape: S): ObjectShape<PropShapes, S> {
     return copyUnsafeChecks(this, new ObjectShape(this.shapes, restShape, this._options));
   }
 
   /**
    * Returns the enum shape of keys of this object.
    */
-  keyof(): EnumShape<StringKeyof<PropertyShapes>> {
+  keyof(): EnumShape<StringKeyof<PropShapes>> {
     return new EnumShape(this.keys);
   }
 
@@ -374,7 +367,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
     return [TYPE_OBJECT];
   }
 
-  protected _apply(input: any, options: ApplyOptions): Result<InferObject<PropertyShapes, RestShape, OUTPUT>> {
+  protected _apply(input: any, options: ApplyOptions): Result<InferObject<PropShapes, RestShape, OUTPUT>> {
     if (!this._typePredicate(input)) {
       return this._typeIssueFactory(input, options);
     }
@@ -388,7 +381,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
   protected _applyAsync(
     input: any,
     options: ApplyOptions
-  ): Promise<Result<InferObject<PropertyShapes, RestShape, OUTPUT>>> {
+  ): Promise<Result<InferObject<PropShapes, RestShape, OUTPUT>>> {
     return new Promise(resolve => {
       if (!this._typePredicate(input)) {
         resolve(this._typeIssueFactory(input, options));
@@ -411,7 +404,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
 
       for (const key in input) {
         const value = input[key];
-        const index = keys.indexOf(key as StringKeyof<PropertyShapes>);
+        const index = keys.indexOf(key as StringKeyof<PropShapes>);
 
         let valueShape: AnyShape | null = restShape;
 
@@ -574,7 +567,7 @@ export class ObjectShape<PropertyShapes extends ReadonlyDict<AnyShape>, RestShap
 
     for (const key in input) {
       const value = input[key];
-      const index = keys.indexOf(key as StringKeyof<PropertyShapes>);
+      const index = keys.indexOf(key as StringKeyof<PropShapes>);
 
       let valueShape: AnyShape | null = restShape;
 

--- a/src/main/shapes/ObjectShape.ts
+++ b/src/main/shapes/ObjectShape.ts
@@ -47,7 +47,7 @@ type InferObject<
 
 type UndefinedToOptional<T> = Omit<T, OptionalKeys<T>> & { [K in OptionalKeys<T>]?: T[K] };
 
-type OptionalKeys<T> = { [K in keyof T]: undefined extends T[K] ? K : never }[keyof T];
+type OptionalKeys<T> = { [K in keyof T]: undefined extends Extract<T[K], undefined> ? K : never }[keyof T];
 
 type Squash<T> = { [K in keyof T]: T[K] } & {};
 

--- a/src/main/shapes/SetShape.ts
+++ b/src/main/shapes/SetShape.ts
@@ -10,10 +10,10 @@ import { TYPE_ARRAY, TYPE_OBJECT, TYPE_SET } from '../Type';
 import { ApplyOptions, ConstraintOptions, Issue, Message } from '../types';
 import {
   addCheck,
-  getCanonicalValueOf,
   concatIssues,
   copyUnsafeChecks,
   createIssueFactory,
+  getCanonicalValueOf,
   isArray,
   isIterableObject,
   ok,

--- a/src/main/shapes/SetShape.ts
+++ b/src/main/shapes/SetShape.ts
@@ -15,7 +15,7 @@ import {
   copyUnsafeChecks,
   createIssueFactory,
   isArray,
-  isIterable,
+  isIterableObject,
   ok,
   toArrayIndex,
   toDeepPartialShape,
@@ -27,27 +27,34 @@ import { AnyShape, DeepPartialProtocol, INPUT, NEVER, OptionalDeepPartialShape, 
 /**
  * The shape of a `Set` instance.
  *
- * @template S The value shape.
+ * @template ValueShape The value shape.
  */
-export class SetShape<S extends AnyShape>
-  extends CoercibleShape<Set<S[INPUT]>, Set<S[OUTPUT]>>
-  implements DeepPartialProtocol<SetShape<OptionalDeepPartialShape<S>>>
+export class SetShape<ValueShape extends AnyShape>
+  extends CoercibleShape<Set<ValueShape[INPUT]>, Set<ValueShape[OUTPUT]>>
+  implements DeepPartialProtocol<SetShape<OptionalDeepPartialShape<ValueShape>>>
 {
+  /**
+   * The type constraint options or the type issue message.
+   */
   protected _options;
+
+  /**
+   * Returns issues associated with an invalid input value type.
+   */
   protected _typeIssueFactory;
 
   /**
    * Creates a new {@linkcode SetShape} instance.
    *
-   * @param shape The value shape
+   * @param shape The value shape.
    * @param options The type constraint options or the type issue message.
-   * @template S The value shape.
+   * @template ValueShape The value shape.
    */
   constructor(
     /**
-     * The value shape
+     * The value shape.
      */
-    readonly shape: S,
+    readonly shape: ValueShape,
     options?: ConstraintOptions | Message
   ) {
     super();
@@ -105,7 +112,7 @@ export class SetShape<S extends AnyShape>
     });
   }
 
-  deepPartial(): SetShape<OptionalDeepPartialShape<S>> {
+  deepPartial(): SetShape<OptionalDeepPartialShape<ValueShape>> {
     return copyUnsafeChecks(this, new SetShape<any>(toDeepPartialShape(this.shape).optional(), this._options));
   }
 
@@ -121,7 +128,7 @@ export class SetShape<S extends AnyShape>
     }
   }
 
-  protected _apply(input: any, options: ApplyOptions): Result<Set<S[OUTPUT]>> {
+  protected _apply(input: any, options: ApplyOptions): Result<Set<ValueShape[OUTPUT]>> {
     let changed = false;
     let values;
     let issues = null;
@@ -169,7 +176,7 @@ export class SetShape<S extends AnyShape>
     return issues;
   }
 
-  protected _applyAsync(input: any, options: ApplyOptions): Promise<Result<Set<S[OUTPUT]>>> {
+  protected _applyAsync(input: any, options: ApplyOptions): Promise<Result<Set<ValueShape[OUTPUT]>>> {
     return new Promise(resolve => {
       let changed = false;
       let values: unknown[];
@@ -240,7 +247,7 @@ export class SetShape<S extends AnyShape>
     if (isArray(value)) {
       return value;
     }
-    if (isIterable(value)) {
+    if (isIterableObject(value)) {
       return Array.from(value);
     }
     return [value];

--- a/src/main/shapes/StringShape.ts
+++ b/src/main/shapes/StringShape.ts
@@ -10,7 +10,7 @@ import {
 } from '../constants';
 import { TYPE_ARRAY, TYPE_BIGINT, TYPE_BOOLEAN, TYPE_NUMBER, TYPE_OBJECT, TYPE_STRING } from '../Type';
 import { ApplyOptions, ConstraintOptions, Message } from '../types';
-import { addCheck, getCanonicalValueOf, createIssueFactory, isArray, isValidDate, ok } from '../utils';
+import { addCheck, createIssueFactory, getCanonicalValueOf, isArray, isValidDate, ok } from '../utils';
 import { CoercibleShape } from './CoercibleShape';
 import { NEVER, Result } from './Shape';
 

--- a/src/main/shapes/StringShape.ts
+++ b/src/main/shapes/StringShape.ts
@@ -15,9 +15,12 @@ import { CoercibleShape } from './CoercibleShape';
 import { NEVER, Result } from './Shape';
 
 /**
- * The shape that constrains the input as a string.
+ * The shape of a string value.
  */
 export class StringShape extends CoercibleShape<string> {
+  /**
+   * Returns issues associated with an invalid input value type.
+   */
   protected _typeIssueFactory;
 
   /**

--- a/src/main/shapes/SymbolShape.ts
+++ b/src/main/shapes/SymbolShape.ts
@@ -5,9 +5,12 @@ import { createIssueFactory } from '../utils';
 import { Result, Shape } from './Shape';
 
 /**
- * The shape of the arbitrary symbol.
+ * The shape of an arbitrary symbol value.
  */
 export class SymbolShape extends Shape<symbol> {
+  /**
+   * Returns issues associated with an invalid input value type.
+   */
   protected _typeIssueFactory;
 
   /**

--- a/src/main/shapes/UnionShape.ts
+++ b/src/main/shapes/UnionShape.ts
@@ -29,7 +29,7 @@ export type DeepPartialUnionShape<Shapes extends readonly AnyShape[]> = UnionSha
 /**
  * The shape that requires an input to conform at least one of shapes.
  *
- * @template UnitedShapes The array of shapes that comprise a union.
+ * @template Shapes The array of shapes that comprise a union.
  */
 export class UnionShape<Shapes extends readonly AnyShape[]>
   extends Shape<Shapes[number][INPUT], Shapes[number][OUTPUT]>

--- a/src/main/shapes/UnionShape.ts
+++ b/src/main/shapes/UnionShape.ts
@@ -22,20 +22,27 @@ import { AnyShape, DeepPartialProtocol, DeepPartialShape, INPUT, OUTPUT, Result,
  */
 export type Lookup = (input: any) => readonly AnyShape[];
 
-export type DeepPartialUnionShape<U extends readonly AnyShape[]> = UnionShape<{
-  [K in keyof U]: U[K] extends AnyShape ? DeepPartialShape<U[K]> : never;
+export type DeepPartialUnionShape<Shapes extends readonly AnyShape[]> = UnionShape<{
+  [K in keyof Shapes]: DeepPartialShape<Shapes[K]>;
 }>;
 
 /**
  * The shape that requires an input to conform at least one of shapes.
  *
- * @template U The array of shapes that comprise a union.
+ * @template UnitedShapes The array of shapes that comprise a union.
  */
-export class UnionShape<U extends readonly AnyShape[]>
-  extends Shape<U[number][INPUT], U[number][OUTPUT]>
-  implements DeepPartialProtocol<DeepPartialUnionShape<U>>
+export class UnionShape<Shapes extends readonly AnyShape[]>
+  extends Shape<Shapes[number][INPUT], Shapes[number][OUTPUT]>
+  implements DeepPartialProtocol<DeepPartialUnionShape<Shapes>>
 {
+  /**
+   * The union constraint options or an issue message.
+   */
   protected _options;
+
+  /**
+   * Returns issues associated with an invalid input value type.
+   */
   protected _typeIssueFactory;
 
   /**
@@ -43,13 +50,13 @@ export class UnionShape<U extends readonly AnyShape[]>
    *
    * @param shapes The array of shapes that comprise a union.
    * @param options The union constraint options or an issue message.
-   * @template U The array of shapes that comprise a union.
+   * @template Shapes The array of shapes that comprise a union.
    */
   constructor(
     /**
      * The array of shapes that comprise a union.
      */
-    readonly shapes: U,
+    readonly shapes: Shapes,
     options?: ConstraintOptions | Message
   ) {
     super();
@@ -86,7 +93,7 @@ export class UnionShape<U extends readonly AnyShape[]>
     return new UnionShape(shapes);
   }
 
-  deepPartial(): DeepPartialUnionShape<U> {
+  deepPartial(): DeepPartialUnionShape<Shapes> {
     return copyUnsafeChecks(this, new UnionShape<any>(this.shapes.map(toDeepPartialShape), this._options));
   }
 
@@ -99,7 +106,7 @@ export class UnionShape<U extends readonly AnyShape[]>
     return ([] as unknown[]).concat(...this.shapes.map(getShapeInputs));
   }
 
-  protected _apply(input: unknown, options: ApplyOptions): Result<U[number][OUTPUT]> {
+  protected _apply(input: unknown, options: ApplyOptions): Result<Shapes[number][OUTPUT]> {
     const { _applyChecks } = this;
 
     let result = null;
@@ -143,7 +150,7 @@ export class UnionShape<U extends readonly AnyShape[]>
     return issues;
   }
 
-  protected _applyAsync(input: unknown, options: ApplyOptions): Promise<Result<U[number][OUTPUT]>> {
+  protected _applyAsync(input: unknown, options: ApplyOptions): Promise<Result<Shapes[number][OUTPUT]>> {
     return new Promise(resolve => {
       const { _applyChecks } = this;
 

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -50,8 +50,8 @@ export interface Check {
   readonly key: any;
 
   /**
-   * The callback that validates the shape output and returns the array of issues or throws a {@linkcode Validation}
-   * error.
+   * The callback that validates the shape output and returns the array of issues or throws a
+   * {@linkcode ValidationError}.
    */
   readonly callback: CheckCallback;
 

--- a/src/main/utils/lang.ts
+++ b/src/main/utils/lang.ts
@@ -20,7 +20,7 @@ export function isPlainObject(value: any): boolean {
   return isObjectLike(value) && ((proto = Object.getPrototypeOf(value)) === null || proto.constructor === Object);
 }
 
-export function isIterable(value: any): value is Iterable<any> {
+export function isIterableObject(value: any): value is Iterable<any> {
   return isObjectLike(value) && ((typeof Symbol !== 'undefined' && Symbol.iterator in value) || !isNaN(value.length));
 }
 

--- a/src/test/dsl/array.test.ts
+++ b/src/test/dsl/array.test.ts
@@ -1,3 +1,4 @@
+import { Shape } from '../../main';
 import * as d from '../../main';
 
 describe('array', () => {
@@ -5,15 +6,15 @@ describe('array', () => {
     const arrShape = d.array();
 
     expect(arrShape).toBeInstanceOf(d.ArrayShape);
-    expect(arrShape.shapes).toBeNull();
-    expect(arrShape.restShape).toBeNull();
+    expect(arrShape.headShapes.length).toBe(0);
+    expect(arrShape.restShape).toEqual(new Shape());
   });
 
   test('returns an array shape with elements constrained by a rest shape', () => {
     const restShape = d.number();
     const arrShape = d.array(restShape);
 
-    expect(arrShape.shapes).toBeNull();
+    expect(arrShape.headShapes.length).toBe(0);
     expect(arrShape.restShape).toBe(restShape);
   });
 });

--- a/src/test/dsl/array.test.ts
+++ b/src/test/dsl/array.test.ts
@@ -1,5 +1,5 @@
-import { Shape } from '../../main';
 import * as d from '../../main';
+import { Shape } from '../../main';
 
 describe('array', () => {
   test('returns an unconstrained array shape', () => {

--- a/src/test/dsl/function.test-d.ts
+++ b/src/test/dsl/function.test-d.ts
@@ -70,6 +70,7 @@ expectType<(this: number, arg: boolean) => boolean>(
     })
 );
 
+// arg2 is excessive
 expectNotType<(this: number, arg1: boolean, arg2: unknown) => string>(
   d
     .fn([d.boolean()])
@@ -121,3 +122,117 @@ expectType<(this: number) => string>(
 expectType<() => number>(d.fn().ensureSignature(() => 111));
 
 // ensureAsyncSignature
+
+expectType<() => Promise<string>>(
+  d
+    .fn()
+    .return(d.promise(d.string()))
+    .ensureAsyncSignature(async function () {
+      return 'aaa';
+    })
+);
+
+expectType<(this: number, arg: boolean) => Promise<boolean>>(
+  d
+    .fn([d.boolean().transform(() => 111)])
+    .this(d.number().transform(() => 'aaa'))
+    .return(d.string().transform(() => true))
+    .ensureAsyncSignature(function (arg) {
+      expectType<string>(this);
+      expectType<number>(arg);
+
+      return 'aaa';
+    })
+);
+
+expectType<(this: number, arg: boolean) => Promise<boolean>>(
+  d
+    .fn([d.boolean().transform(() => 111)])
+    .this(d.number().transform(() => 'aaa'))
+    .return(d.string().transform(() => true))
+    .ensureAsyncSignature(async function (arg) {
+      expectType<string>(this);
+      expectType<number>(arg);
+
+      return 'aaa';
+    })
+);
+
+expectType<(this: number, arg: boolean) => Promise<boolean>>(
+  d
+    .fn([d.boolean().transformAsync(() => Promise.resolve(111))])
+    .this(d.number().transform(() => 'aaa'))
+    .return(d.string().transform(() => true))
+    .ensureAsyncSignature(function (arg) {
+      expectType<string>(this);
+      expectType<number>(arg);
+
+      return 'aaa';
+    })
+);
+
+// arg2 is excessive
+expectNotType<(this: number, arg1: boolean, arg2: unknown) => Promise<string>>(
+  d
+    .fn([d.boolean()])
+    .this(d.number())
+    .return(d.string())
+    .ensureAsyncSignature(function () {
+      expectType<number>(this);
+      return 'aaa';
+    })
+);
+
+expectType<(this: number, arg: boolean) => Promise<string>>(
+  d
+    .fn([d.boolean()])
+    .this(d.number())
+    .return(d.string())
+    .ensureAsyncSignature(function () {
+      expectType<number>(this);
+      return 'aaa';
+    })
+);
+
+expectType<(this: number) => Promise<string>>(
+  d
+    .fn()
+    .this(d.number())
+    .return(d.string())
+    .ensureAsyncSignature(function () {
+      expectType<number>(this);
+      return 'aaa';
+    })
+);
+
+expectType<(this: number) => Promise<string>>(
+  d
+    .fn()
+    .return(d.string())
+    .ensureAsyncSignature(function (this: number) {
+      return 'aaa';
+    })
+);
+
+expectType<(this: number) => Promise<string>>(
+  d
+    .fn()
+    .return(d.promise(d.string()))
+    .ensureAsyncSignature(async function (this: number) {
+      return 'aaa';
+    })
+);
+
+expectType<(this: number) => Promise<string>>(
+  d.fn().ensureAsyncSignature(function (this: number) {
+    return 'aaa';
+  })
+);
+
+expectType<() => Promise<string>>(
+  d.fn().ensureAsyncSignature(async function () {
+    return 'aaa';
+  })
+);
+
+expectType<() => Promise<number>>(d.fn().ensureAsyncSignature(() => 111));

--- a/src/test/dsl/function.test-d.ts
+++ b/src/test/dsl/function.test-d.ts
@@ -1,5 +1,5 @@
 import * as d from 'doubter';
-import { expectType } from 'tsd';
+import { expectNotType, expectType } from 'tsd';
 
 // Alias
 
@@ -54,3 +54,70 @@ expectType<(this: string) => any>(d.fn().this(d.string()).__output);
 expectType<(this: number) => any>(d.fn().this(d.string().transform(parseFloat)).__input);
 
 expectType<(this: string) => any>(d.fn().this(d.string().transform(parseFloat)).__output);
+
+// ensureSignature
+
+expectType<(this: number, arg: boolean) => boolean>(
+  d
+    .fn([d.boolean().transform(() => 111)])
+    .this(d.number().transform(() => 'aaa'))
+    .return(d.string().transform(() => true))
+    .ensureSignature(function (arg) {
+      expectType<string>(this);
+      expectType<number>(arg);
+
+      return 'aaa';
+    })
+);
+
+expectNotType<(this: number, arg1: boolean, arg2: unknown) => string>(
+  d
+    .fn([d.boolean()])
+    .this(d.number())
+    .return(d.string())
+    .ensureSignature(function () {
+      expectType<number>(this);
+      return 'aaa';
+    })
+);
+
+expectType<(this: number, arg: boolean) => string>(
+  d
+    .fn([d.boolean()])
+    .this(d.number())
+    .return(d.string())
+    .ensureSignature(function () {
+      expectType<number>(this);
+      return 'aaa';
+    })
+);
+
+expectType<(this: number) => string>(
+  d
+    .fn()
+    .this(d.number())
+    .return(d.string())
+    .ensureSignature(function () {
+      expectType<number>(this);
+      return 'aaa';
+    })
+);
+
+expectType<(this: number) => string>(
+  d
+    .fn()
+    .return(d.string())
+    .ensureSignature(function (this: number) {
+      return 'aaa';
+    })
+);
+
+expectType<(this: number) => string>(
+  d.fn().ensureSignature(function (this: number) {
+    return 'aaa';
+  })
+);
+
+expectType<() => number>(d.fn().ensureSignature(() => 111));
+
+// ensureAsyncSignature

--- a/src/test/dsl/function.test.ts
+++ b/src/test/dsl/function.test.ts
@@ -13,21 +13,21 @@ describe('function', () => {
     const shape = d.fn();
 
     expect(shape.argsShape).toBeInstanceOf(ArrayShape);
-    expect(shape.argsShape.shapes.length).toBe(0);
+    expect(shape.argsShape.headShapes.length).toBe(0);
   });
 
   test('wraps arguments into an array shape', () => {
     const shape = d.fn([d.string()]);
 
-    expect(shape.argsShape.shapes.length).toBe(1);
-    expect(shape.argsShape.shapes[0]).toBeInstanceOf(StringShape);
+    expect(shape.argsShape.headShapes.length).toBe(1);
+    expect(shape.argsShape.headShapes[0]).toBeInstanceOf(StringShape);
   });
 
   test('recognizes options as the first argument', () => {
     const shape = d.fn({ message: 'aaa' });
 
     expect(shape.argsShape).toBeInstanceOf(ArrayShape);
-    expect(shape.argsShape.shapes.length).toBe(0);
+    expect(shape.argsShape.headShapes.length).toBe(0);
 
     expect(shape.try(111)).toEqual({
       ok: false,

--- a/src/test/dsl/object.test-d.ts
+++ b/src/test/dsl/object.test-d.ts
@@ -1,4 +1,4 @@
-import * as d from 'doubter';
+import * as d from '../../main';
 import { expectType } from 'tsd';
 
 expectType<{ aaa?: string }>(

--- a/src/test/dsl/object.test-d.ts
+++ b/src/test/dsl/object.test-d.ts
@@ -1,5 +1,5 @@
-import * as d from '../../main';
 import { expectType } from 'tsd';
+import * as d from '../../main';
 
 expectType<{ aaa?: string }>(
   d.object({

--- a/src/test/dsl/object.test-d.ts
+++ b/src/test/dsl/object.test-d.ts
@@ -1,5 +1,5 @@
+import * as d from 'doubter';
 import { expectType } from 'tsd';
-import * as d from '../../main';
 
 expectType<{ aaa?: string }>(
   d.object({

--- a/src/test/dsl/tuple.test-d.ts
+++ b/src/test/dsl/tuple.test-d.ts
@@ -1,7 +1,9 @@
 import * as d from 'doubter';
-import { expectType } from 'tsd';
+import { expectType, expectNotType } from 'tsd';
 
 expectType<[string, number]>(d.tuple([d.string(), d.number()]).__output);
+
+expectNotType<[string, number, ...unknown[]]>(d.tuple([d.string(), d.number()]).__output);
 
 expectType<number>(d.tuple([d.string(), d.number()]).shapes[1].__output);
 

--- a/src/test/dsl/tuple.test-d.ts
+++ b/src/test/dsl/tuple.test-d.ts
@@ -1,5 +1,5 @@
 import * as d from 'doubter';
-import { expectType, expectNotType } from 'tsd';
+import { expectNotType, expectType } from 'tsd';
 
 expectType<[string, number]>(d.tuple([d.string(), d.number()]).__output);
 

--- a/src/test/dsl/tuple.test-d.ts
+++ b/src/test/dsl/tuple.test-d.ts
@@ -5,6 +5,6 @@ expectType<[string, number]>(d.tuple([d.string(), d.number()]).__output);
 
 expectNotType<[string, number, ...unknown[]]>(d.tuple([d.string(), d.number()]).__output);
 
-expectType<number>(d.tuple([d.string(), d.number()]).shapes[1].__output);
+expectType<number>(d.tuple([d.string(), d.number()]).headShapes[1].__output);
 
 expectType<[string, number, ...boolean[]]>(d.tuple([d.string(), d.number()], d.boolean()).__output);

--- a/src/test/perf/array.perf.js
+++ b/src/test/perf/array.perf.js
@@ -4,6 +4,29 @@ const myzod = require('myzod');
 const valita = require('@badrap/valita');
 const doubter = require('../../../lib');
 
+describe('array()', () => {
+  const value = [1, 2, 3];
+
+  test('Ajv', measure => {
+    const validate = new Ajv().compile({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'array',
+    });
+
+    measure(() => {
+      validate(value);
+    });
+  });
+
+  test('doubter', measure => {
+    const shape = doubter.array();
+
+    measure(() => {
+      shape.parse(value);
+    });
+  });
+});
+
 describe('array(number())', () => {
   const value = [1, 2, 3];
 

--- a/src/test/shapes/ArrayShape.test.ts
+++ b/src/test/shapes/ArrayShape.test.ts
@@ -33,13 +33,13 @@ describe('ArrayShape', () => {
 
     const arrShape = new ArrayShape([shape1], restShape);
 
-    expect(arrShape.shapes).toEqual([shape1]);
+    expect(arrShape.headShapes).toEqual([shape1]);
     expect(arrShape.restShape).toBe(restShape);
     expect(arrShape.inputs).toEqual([TYPE_ARRAY]);
   });
 
   test('raises an issue if an input is not an unconstrained array', () => {
-    const arrShape = new ArrayShape(null, null);
+    const arrShape = new ArrayShape([], new Shape());
 
     const result = arrShape.try('aaa');
 
@@ -50,7 +50,7 @@ describe('ArrayShape', () => {
   });
 
   test('does not check array elements if there are no tuple element shapes and no rest element shape', () => {
-    const arrShape = new ArrayShape(null, null);
+    const arrShape = new ArrayShape([], new Shape());
 
     const arr = [111, 222];
     const result = arrShape.try(arr) as Ok<unknown>;
@@ -84,7 +84,7 @@ describe('ArrayShape', () => {
 
     const restApplySpy = jest.spyOn<Shape, any>(restShape, '_apply');
 
-    const arrShape = new ArrayShape(null, restShape);
+    const arrShape = new ArrayShape([], restShape);
 
     const arr = [111, 222];
     const result = arrShape.try(arr) as Ok<unknown>;
@@ -140,7 +140,7 @@ describe('ArrayShape', () => {
   });
 
   test('raises an issue if an input is not an array', () => {
-    const arrShape = new ArrayShape(null, new Shape());
+    const arrShape = new ArrayShape([], new Shape());
 
     expect(arrShape.try('aaa')).toEqual({
       ok: false,
@@ -160,7 +160,7 @@ describe('ArrayShape', () => {
   test('raises a single issue captured by the rest shape', () => {
     const restShape = new Shape().check(() => [{ code: 'xxx' }]);
 
-    const arrShape = new ArrayShape(null, restShape);
+    const arrShape = new ArrayShape([], restShape);
 
     expect(arrShape.try(['aaa', 'bbb'])).toEqual({
       ok: false,
@@ -171,7 +171,7 @@ describe('ArrayShape', () => {
   test('raises multiple issues captured by the rest shape in verbose mode', () => {
     const restShape = new Shape().check(() => [{ code: 'xxx' }]);
 
-    const arrShape = new ArrayShape(null, restShape);
+    const arrShape = new ArrayShape([], restShape);
 
     expect(arrShape.try(['aaa', 'bbb'], { verbose: true })).toEqual({
       ok: false,
@@ -212,7 +212,7 @@ describe('ArrayShape', () => {
   });
 
   test('applies checks', () => {
-    const arrShape = new ArrayShape(null, new Shape()).check(() => [{ code: 'xxx' }]);
+    const arrShape = new ArrayShape([], new Shape()).check(() => [{ code: 'xxx' }]);
 
     expect(arrShape.try([111])).toEqual({
       ok: false,
@@ -266,7 +266,7 @@ describe('ArrayShape', () => {
     test('returns the rest element shape', () => {
       const restShape = new Shape();
 
-      const arrShape = new ArrayShape(null, restShape);
+      const arrShape = new ArrayShape([], restShape);
 
       expect(arrShape.at(0)).toBe(restShape);
       expect(arrShape.at(1)).toBe(restShape);
@@ -288,14 +288,14 @@ describe('ArrayShape', () => {
     test('returns the shape clone with updated rest elements', () => {
       const restShape = new Shape();
 
-      expect(new ArrayShape(null, null).rest(restShape).restShape).toBe(restShape);
+      expect(new ArrayShape([], null).rest(restShape).restShape).toBe(restShape);
     });
 
     test('copies unsafe checks', () => {
       const cbMock1 = jest.fn();
       const cbMock2 = jest.fn();
 
-      const arrShape = new ArrayShape(null, null).check(cbMock1, { unsafe: true }).check(cbMock2);
+      const arrShape = new ArrayShape([], null).check(cbMock1, { unsafe: true }).check(cbMock2);
 
       arrShape.rest(new Shape()).parse([]);
 
@@ -306,7 +306,7 @@ describe('ArrayShape', () => {
 
   describe('length', () => {
     test('checks length', () => {
-      const arrShape = new ArrayShape(null, new Shape()).length(2);
+      const arrShape = new ArrayShape([], new Shape()).length(2);
 
       expect(arrShape.try([111, 222])).toEqual({ ok: true, value: [111, 222] });
       expect(arrShape.try([111])).toEqual({ ok: false, issues: expect.any(Array) });
@@ -316,7 +316,7 @@ describe('ArrayShape', () => {
 
   describe('min', () => {
     test('checks min length', () => {
-      const arrShape = new ArrayShape(null, new Shape()).min(2);
+      const arrShape = new ArrayShape([], new Shape()).min(2);
 
       expect(arrShape.try([111, 222])).toEqual({ ok: true, value: [111, 222] });
       expect(arrShape.try([111])).toEqual({
@@ -328,7 +328,7 @@ describe('ArrayShape', () => {
 
   describe('max', () => {
     test('checks max length', () => {
-      const arrShape = new ArrayShape(null, new Shape()).max(2);
+      const arrShape = new ArrayShape([], new Shape()).max(2);
 
       expect(arrShape.try([111, 222])).toEqual({ ok: true, value: [111, 222] });
       expect(arrShape.try([111, 222, 333])).toEqual({
@@ -356,7 +356,7 @@ describe('ArrayShape', () => {
     });
 
     test('raises an issue if deep partial element is invalid', () => {
-      const arrShape = new ArrayShape(null, new NumberShape()).deepPartial();
+      const arrShape = new ArrayShape([], new NumberShape()).deepPartial();
 
       expect(arrShape.try(['aaa'])).toEqual({
         ok: false,
@@ -379,7 +379,7 @@ describe('ArrayShape', () => {
     });
 
     test('parses deep partial array', () => {
-      const arrShape = new ArrayShape(null, new ObjectShape({ key1: new StringShape() }, null)).deepPartial();
+      const arrShape = new ArrayShape([], new ObjectShape({ key1: new StringShape() }, null)).deepPartial();
 
       expect(arrShape.parse([undefined])).toEqual([undefined]);
       expect(arrShape.parse([{}])).toEqual([{}]);
@@ -390,7 +390,7 @@ describe('ArrayShape', () => {
 
   describe('coerce', () => {
     test('allow unknown input type when shape is coerced and elements are unconstrained', () => {
-      const arrShape = new ArrayShape(null, null).coerce();
+      const arrShape = new ArrayShape([], null).coerce();
 
       expect(arrShape.inputs).toEqual([TYPE_UNKNOWN]);
     });
@@ -432,7 +432,7 @@ describe('ArrayShape', () => {
     });
 
     test('coerces a non-array to an array', () => {
-      const arrShape = new ArrayShape(null, new Shape()).coerce();
+      const arrShape = new ArrayShape([], new Shape()).coerce();
 
       expect(arrShape.parse('aaa')).toEqual(['aaa']);
     });
@@ -450,13 +450,13 @@ describe('ArrayShape', () => {
     });
 
     test('coerces a Set', () => {
-      const arrShape = new ArrayShape(null, new Shape()).coerce();
+      const arrShape = new ArrayShape([], new Shape()).coerce();
 
       expect(arrShape.parse(new Set(['aaa']))).toEqual(['aaa']);
     });
 
     test('coerces a Map to an array of entries', () => {
-      const arrShape = new ArrayShape(null, new Shape()).coerce();
+      const arrShape = new ArrayShape([], new Shape()).coerce();
 
       expect(
         arrShape.parse(
@@ -472,13 +472,13 @@ describe('ArrayShape', () => {
     });
 
     test('coerces an array-like object', () => {
-      const arrShape = new ArrayShape(null, new Shape()).coerce();
+      const arrShape = new ArrayShape([], new Shape()).coerce();
 
       expect(arrShape.parse({ length: 1, 0: 'aaa' })).toEqual(['aaa']);
     });
 
     test('coerces a String wrapper', () => {
-      const arrShape = new ArrayShape(null, new Shape()).coerce();
+      const arrShape = new ArrayShape([], new Shape()).coerce();
 
       expect(arrShape.parse(new String('aaa'))).toEqual(['aaa']);
     });
@@ -495,7 +495,7 @@ describe('ArrayShape', () => {
 
   describe('async', () => {
     test('raises an issue if an input is not an unconstrained array', async () => {
-      const arrShape = new ArrayShape(null, asyncShape);
+      const arrShape = new ArrayShape([], asyncShape);
 
       const result = await arrShape.tryAsync('aaa');
 
@@ -506,7 +506,7 @@ describe('ArrayShape', () => {
     });
 
     test('downgrades to sync implementation if there are no async element shapes', async () => {
-      const arrShape = new ArrayShape(null, new Shape());
+      const arrShape = new ArrayShape([], new Shape());
 
       const applySpy = jest.spyOn<Shape, any>(arrShape, '_apply');
 
@@ -562,7 +562,7 @@ describe('ArrayShape', () => {
     test('parses rest elements', async () => {
       const restApplySpy = jest.spyOn<Shape, any>(asyncShape, '_applyAsync');
 
-      const arrShape = new ArrayShape(null, asyncShape);
+      const arrShape = new ArrayShape([], asyncShape);
 
       const arr = [111, 222];
       const result = (await arrShape.tryAsync(arr)) as Ok<unknown>;
@@ -588,7 +588,7 @@ describe('ArrayShape', () => {
     });
 
     test('applies checks', async () => {
-      const arrShape = new ArrayShape(null, asyncShape).check(() => [{ code: 'xxx' }]);
+      const arrShape = new ArrayShape([], asyncShape).check(() => [{ code: 'xxx' }]);
 
       await expect(arrShape.tryAsync([111])).resolves.toEqual({
         ok: false,
@@ -598,7 +598,7 @@ describe('ArrayShape', () => {
 
     describe('coerce', () => {
       test('coerces a non-array to an array', async () => {
-        const arrShape = new ArrayShape(null, asyncShape).coerce();
+        const arrShape = new ArrayShape([], asyncShape).coerce();
 
         await expect(arrShape.parseAsync('aaa')).resolves.toEqual(['aaa']);
       });

--- a/src/test/shapes/FunctionShape.test.ts
+++ b/src/test/shapes/FunctionShape.test.ts
@@ -73,38 +73,38 @@ describe('FunctionShape', () => {
     });
   });
 
-  describe('isAsyncFunction', () => {
+  describe('isAsyncSignature', () => {
     test('wrapper is async if any of the arguments is async', () => {
       const argsShape = new ArrayShape([asyncShape], null);
 
-      expect(new FunctionShape(argsShape, null, null).isAsyncFunction).toBe(true);
+      expect(new FunctionShape(argsShape, null, null).isAsyncSignature).toBe(true);
     });
 
     test('wrapper is async if return shape is async', () => {
-      expect(new FunctionShape(arrayShape, asyncShape, null).isAsyncFunction).toBe(true);
+      expect(new FunctionShape(arrayShape, asyncShape, null).isAsyncSignature).toBe(true);
     });
 
     test('wrapper is async if this shape is async', () => {
-      expect(new FunctionShape(arrayShape, null, asyncShape).isAsyncFunction).toBe(true);
+      expect(new FunctionShape(arrayShape, null, asyncShape).isAsyncSignature).toBe(true);
     });
   });
 
-  describe('insure', () => {
-    test('marks shape is insured', () => {
+  describe('strict', () => {
+    test('marks shape is ensured', () => {
       const cbMock = jest.fn();
 
       const shape = new FunctionShape(arrayShape.check(cbMock), null, null);
 
-      expect(shape.isInsured).toBe(false);
-      expect(shape.insure().isInsured).toBe(true);
+      expect(shape.isStrict).toBe(false);
+      expect(shape.strict().isStrict).toBe(true);
     });
 
     test('sets options used by the wrapper', () => {
       const cbMock = jest.fn();
 
       new FunctionShape(arrayShape.check(cbMock), null, null)
-        .insure({ coerced: true })
-        .insureFunction(() => undefined)();
+        .strict({ coerced: true })
+        .ensureSignature(() => undefined)();
 
       expect(cbMock).toHaveBeenCalledTimes(1);
       expect(cbMock).toHaveBeenNthCalledWith(1, [], undefined, { coerced: true });
@@ -112,7 +112,7 @@ describe('FunctionShape', () => {
 
     test('wraps a function', () => {
       const fn = () => undefined;
-      const wrapper = new FunctionShape(arrayShape, null, null).insure().parse(fn);
+      const wrapper = new FunctionShape(arrayShape, null, null).strict().parse(fn);
 
       expect(wrapper).not.toBe(fn);
 
@@ -130,12 +130,12 @@ describe('FunctionShape', () => {
     });
   });
 
-  describe('insureFunction', () => {
+  describe('ensureSignature', () => {
     test('wraps a function with 0 arguments', () => {
       const fnMock = jest.fn();
       const shape = new FunctionShape(arrayShape, null, null);
 
-      shape.insureFunction(fnMock)();
+      shape.ensureSignature(fnMock)();
 
       expect(fnMock).toHaveBeenCalledTimes(1);
       expect(fnMock).toHaveBeenNthCalledWith(1);
@@ -149,7 +149,7 @@ describe('FunctionShape', () => {
 
       const applySpy = jest.spyOn<Shape, any>(argShape, '_apply');
 
-      shape.insureFunction(fnMock)('aaa');
+      shape.ensureSignature(fnMock)('aaa');
 
       expect(fnMock).toHaveBeenCalledTimes(1);
       expect(fnMock).toHaveBeenNthCalledWith(1, 'aaa');
@@ -165,7 +165,7 @@ describe('FunctionShape', () => {
         new ObjectShape({ key1: new StringShape() }, null)
       );
 
-      expect(() => shape.insureFunction(() => undefined).call({ key1: 111 } as any)).toThrow(
+      expect(() => shape.ensureSignature(() => undefined).call({ key1: 111 } as any)).toThrow(
         new ValidationError([
           { code: CODE_TYPE, path: ['this', 'key1'], input: 111, message: MESSAGE_STRING_TYPE, param: TYPE_STRING },
         ])
@@ -175,7 +175,7 @@ describe('FunctionShape', () => {
     test('raises an issue if an argument is invalid', () => {
       const shape = new FunctionShape(new ArrayShape([new StringShape(), new NumberShape()], null), null, null);
 
-      expect(() => shape.insureFunction(() => undefined).call(undefined, 111, 'aaa')).toThrow(
+      expect(() => shape.ensureSignature(() => undefined).call(undefined, 111, 'aaa')).toThrow(
         new ValidationError([
           { code: CODE_TYPE, path: ['arguments', 0], input: 111, message: MESSAGE_STRING_TYPE, param: TYPE_STRING },
         ])
@@ -185,7 +185,7 @@ describe('FunctionShape', () => {
     test('raises issues if arguments are invalid in verbose mode', () => {
       const shape = new FunctionShape(new ArrayShape([new StringShape(), new NumberShape()], null), null, null);
 
-      expect(() => shape.insureFunction(() => undefined, { verbose: true }).call(undefined, 111, 'aaa')).toThrow(
+      expect(() => shape.ensureSignature(() => undefined, { verbose: true }).call(undefined, 111, 'aaa')).toThrow(
         new ValidationError([
           { code: CODE_TYPE, path: ['arguments', 0], input: 111, message: MESSAGE_STRING_TYPE, param: TYPE_STRING },
           { code: CODE_TYPE, path: ['arguments', 1], input: 'aaa', message: MESSAGE_NUMBER_TYPE, param: TYPE_NUMBER },
@@ -196,7 +196,7 @@ describe('FunctionShape', () => {
     test('raises an issue if a return value is invalid', () => {
       const shape = new FunctionShape(new ArrayShape(null, null), new StringShape(), null);
 
-      expect(() => shape.insureFunction(() => 111 as any)()).toThrow(
+      expect(() => shape.ensureSignature(() => 111 as any)()).toThrow(
         new ValidationError([
           { code: CODE_TYPE, path: ['return'], input: 111, message: MESSAGE_STRING_TYPE, param: TYPE_STRING },
         ])
@@ -204,12 +204,12 @@ describe('FunctionShape', () => {
     });
   });
 
-  describe('insureAsyncFunction', () => {
+  describe('ensureAsyncSignature', () => {
     test('wraps a function with 0 arguments', async () => {
       const fnMock = jest.fn();
       const shape = new FunctionShape(arrayShape, null, null);
 
-      await shape.insureAsyncFunction(fnMock)();
+      await shape.ensureAsyncSignature(fnMock)();
 
       expect(fnMock).toHaveBeenCalledTimes(1);
       expect(fnMock).toHaveBeenNthCalledWith(1);
@@ -223,7 +223,7 @@ describe('FunctionShape', () => {
 
       const applySpy = jest.spyOn<Shape, any>(argShape, '_apply');
 
-      await shape.insureAsyncFunction(fnMock)('aaa');
+      await shape.ensureAsyncSignature(fnMock)('aaa');
 
       expect(fnMock).toHaveBeenCalledTimes(1);
       expect(fnMock).toHaveBeenNthCalledWith(1, 'aaa');
@@ -239,7 +239,7 @@ describe('FunctionShape', () => {
         new ObjectShape({ key1: new StringShape() }, null)
       );
 
-      await expect(shape.insureAsyncFunction(() => undefined).call({ key1: 111 } as any)).rejects.toEqual(
+      await expect(shape.ensureAsyncSignature(() => undefined).call({ key1: 111 } as any)).rejects.toEqual(
         new ValidationError([
           { code: CODE_TYPE, path: ['this', 'key1'], input: 111, message: MESSAGE_STRING_TYPE, param: TYPE_STRING },
         ])
@@ -249,7 +249,7 @@ describe('FunctionShape', () => {
     test('raises an issue if an argument is invalid', async () => {
       const shape = new FunctionShape(new ArrayShape([new StringShape(), new NumberShape()], null), null, null);
 
-      await expect(shape.insureAsyncFunction(() => undefined).call(undefined, 111, 'aaa')).rejects.toEqual(
+      await expect(shape.ensureAsyncSignature(() => undefined).call(undefined, 111, 'aaa')).rejects.toEqual(
         new ValidationError([
           { code: CODE_TYPE, path: ['arguments', 0], input: 111, message: MESSAGE_STRING_TYPE, param: TYPE_STRING },
         ])
@@ -260,7 +260,7 @@ describe('FunctionShape', () => {
       const shape = new FunctionShape(new ArrayShape([new StringShape(), new NumberShape()], null), null, null);
 
       await expect(
-        shape.insureAsyncFunction(() => undefined, { verbose: true }).call(undefined, 111, 'aaa')
+        shape.ensureAsyncSignature(() => undefined, { verbose: true }).call(undefined, 111, 'aaa')
       ).rejects.toEqual(
         new ValidationError([
           { code: CODE_TYPE, path: ['arguments', 0], input: 111, message: MESSAGE_STRING_TYPE, param: TYPE_STRING },
@@ -272,7 +272,7 @@ describe('FunctionShape', () => {
     test('raises an issue if a return value is invalid', async () => {
       const shape = new FunctionShape(new ArrayShape(null, null), new StringShape(), null);
 
-      await expect(shape.insureAsyncFunction(() => 111 as any)()).rejects.toEqual(
+      await expect(shape.ensureAsyncSignature(() => 111 as any)()).rejects.toEqual(
         new ValidationError([
           { code: CODE_TYPE, path: ['return'], input: 111, message: MESSAGE_STRING_TYPE, param: TYPE_STRING },
         ])

--- a/src/test/shapes/FunctionShape.test.ts
+++ b/src/test/shapes/FunctionShape.test.ts
@@ -10,7 +10,7 @@ import {
   StringShape,
   ValidationError,
 } from '../../main';
-import { CODE_ARRAY_MAX, CODE_TYPE, MESSAGE_NUMBER_TYPE, MESSAGE_STRING_TYPE } from '../../main/constants';
+import { CODE_TUPLE, CODE_TYPE, MESSAGE_NUMBER_TYPE, MESSAGE_STRING_TYPE } from '../../main/constants';
 import { TYPE_FUNCTION, TYPE_NUMBER, TYPE_STRING } from '../../main/Type';
 
 describe('FunctionShape', () => {
@@ -28,7 +28,7 @@ describe('FunctionShape', () => {
   let asyncShape: AsyncShape;
 
   beforeEach(() => {
-    arrayShape = new ArrayShape(null, null).length(0);
+    arrayShape = new ArrayShape([], null).length(0);
     asyncShape = new AsyncShape();
   });
 
@@ -36,6 +36,7 @@ describe('FunctionShape', () => {
     const shape = new FunctionShape(arrayShape, null, null);
 
     expect(shape.isAsync).toBe(false);
+    expect(shape.isAsyncSignature).toBe(false);
     expect(shape.argsShape).toBe(arrayShape);
     expect(shape.returnShape).toBeNull();
     expect(shape.thisShape).toBeNull();
@@ -90,7 +91,7 @@ describe('FunctionShape', () => {
   });
 
   describe('strict', () => {
-    test('marks shape is ensured', () => {
+    test('marks shape is strict', () => {
       const cbMock = jest.fn();
 
       const shape = new FunctionShape(arrayShape.check(cbMock), null, null);
@@ -119,10 +120,10 @@ describe('FunctionShape', () => {
       expect(() => wrapper('aaa')).toThrow(
         new ValidationError([
           {
-            code: CODE_ARRAY_MAX,
+            code: CODE_TUPLE,
             path: ['arguments'],
             input: ['aaa'],
-            message: 'Must have the maximum length of 0',
+            message: 'Must be a tuple of length 0',
             param: 0,
           },
         ])
@@ -160,7 +161,7 @@ describe('FunctionShape', () => {
 
     test('raises an issue if this is invalid', () => {
       const shape = new FunctionShape(
-        new ArrayShape(null, null),
+        new ArrayShape([], null),
         null,
         new ObjectShape({ key1: new StringShape() }, null)
       );
@@ -194,7 +195,7 @@ describe('FunctionShape', () => {
     });
 
     test('raises an issue if a return value is invalid', () => {
-      const shape = new FunctionShape(new ArrayShape(null, null), new StringShape(), null);
+      const shape = new FunctionShape(new ArrayShape([], null), new StringShape(), null);
 
       expect(() => shape.ensureSignature(() => 111 as any)()).toThrow(
         new ValidationError([
@@ -234,7 +235,7 @@ describe('FunctionShape', () => {
 
     test('raises an issue if this is invalid', async () => {
       const shape = new FunctionShape(
-        new ArrayShape(null, null),
+        new ArrayShape([], null),
         null,
         new ObjectShape({ key1: new StringShape() }, null)
       );
@@ -270,7 +271,7 @@ describe('FunctionShape', () => {
     });
 
     test('raises an issue if a return value is invalid', async () => {
-      const shape = new FunctionShape(new ArrayShape(null, null), new StringShape(), null);
+      const shape = new FunctionShape(new ArrayShape([], null), new StringShape(), null);
 
       await expect(shape.ensureAsyncSignature(() => 111 as any)()).rejects.toEqual(
         new ValidationError([

--- a/src/test/shapes/IntersectionShape.test.ts
+++ b/src/test/shapes/IntersectionShape.test.ts
@@ -109,8 +109,8 @@ describe('IntersectionShape', () => {
 
   test('raises an issue if child outputs cannot be intersected', () => {
     const andShape = new IntersectionShape([
-      new ArrayShape(null, new StringShape()),
-      new ArrayShape(null, new StringShape().transform(parseFloat)),
+      new ArrayShape([], new StringShape()),
+      new ArrayShape([], new StringShape().transform(parseFloat)),
     ]);
 
     expect(andShape.try(['111.222'])).toEqual({
@@ -155,7 +155,7 @@ describe('IntersectionShape', () => {
       const shape2 = new Shape();
       const shape3 = new Shape();
       const objShape = new ObjectShape({ 1: shape1, key1: shape2 }, null);
-      const arrShape = new ArrayShape(null, shape3);
+      const arrShape = new ArrayShape([], shape3);
 
       const andShape = new IntersectionShape([objShape, arrShape]);
 
@@ -257,8 +257,8 @@ describe('IntersectionShape', () => {
 
     test('raises an issue if child outputs cannot be intersected', async () => {
       const andShape = new IntersectionShape([
-        new ArrayShape(null, new StringShape()),
-        new ArrayShape(null, new StringShape().transformAsync(value => Promise.resolve(value)).transform(parseFloat)),
+        new ArrayShape([], new StringShape()),
+        new ArrayShape([], new StringShape().transformAsync(value => Promise.resolve(value)).transform(parseFloat)),
       ]);
 
       await expect(andShape.tryAsync(['111.222'])).resolves.toEqual({

--- a/src/test/shapes/UnionShape.test.ts
+++ b/src/test/shapes/UnionShape.test.ts
@@ -174,7 +174,7 @@ describe('UnionShape', () => {
       const shape2 = new Shape();
       const shape3 = new Shape();
       const objShape = new ObjectShape({ 1: shape1, key1: shape2 }, null);
-      const arrShape = new ArrayShape(null, shape3);
+      const arrShape = new ArrayShape([], shape3);
 
       const orShape = new UnionShape([objShape, arrShape]);
 
@@ -191,7 +191,7 @@ describe('UnionShape', () => {
       const shape2 = new Shape();
       const shape3 = new Shape();
       const objShape = new ObjectShape({ 1: shape1, key1: shape2 }, null);
-      const arrShape = new ArrayShape(null, shape3);
+      const arrShape = new ArrayShape([], shape3);
 
       const orShape = new UnionShape([objShape, arrShape]);
 

--- a/src/test/utils/lang.test.ts
+++ b/src/test/utils/lang.test.ts
@@ -2,7 +2,7 @@ import {
   getCanonicalValueOf,
   isEqual,
   isEqualOrSubclass,
-  isIterable,
+  isIterableObject,
   isPlainObject,
   isValidDate,
 } from '../../main/utils';
@@ -43,21 +43,21 @@ describe('isPlainObject', () => {
   });
 });
 
-describe('isIterable', () => {
+describe('isIterableObject', () => {
   test('returns value type', () => {
-    expect(isIterable(new Map())).toBe(true);
-    expect(isIterable(new Set())).toBe(true);
-    expect(isIterable([])).toBe(true);
-    expect(isIterable({ [Symbol.iterator]: 111 })).toBe(true);
-    expect(isIterable({ [Symbol.iterator]: () => null })).toBe(true);
-    expect(isIterable({ length: null })).toBe(true);
-    expect(isIterable({ length: 111 })).toBe(true);
-    expect(isIterable({ length: '111' })).toBe(true);
-    expect(isIterable({ length: { valueOf: () => 111 } })).toBe(true);
+    expect(isIterableObject(new Map())).toBe(true);
+    expect(isIterableObject(new Set())).toBe(true);
+    expect(isIterableObject([])).toBe(true);
+    expect(isIterableObject({ [Symbol.iterator]: 111 })).toBe(true);
+    expect(isIterableObject({ [Symbol.iterator]: () => null })).toBe(true);
+    expect(isIterableObject({ length: null })).toBe(true);
+    expect(isIterableObject({ length: 111 })).toBe(true);
+    expect(isIterableObject({ length: '111' })).toBe(true);
+    expect(isIterableObject({ length: { valueOf: () => 111 } })).toBe(true);
 
-    expect(isIterable({ length: undefined })).toBe(false);
-    expect(isIterable({ length: 'aaa' })).toBe(false);
-    expect(isIterable('')).toBe(false);
+    expect(isIterableObject({ length: undefined })).toBe(false);
+    expect(isIterableObject({ length: 'aaa' })).toBe(false);
+    expect(isIterableObject('')).toBe(false);
   });
 });
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,5 +5,28 @@
   "excludeExternals": true,
   "excludeInternal": true,
   "disableSources": true,
-  "readme": "none"
+  "readme": "none",
+  "intentionallyNotExported": [
+    "ApplyChecksCallback",
+    "Awaitable",
+    "DeepPartialArrayShape",
+    "DeepPartialIntersectionShape",
+    "DeepPartialObjectShape",
+    "DeepPartialUnionShape",
+    "Dict",
+    "OptionalDeepPartialShape",
+    "ExcludeLiteral",
+    "InferRecord",
+    "Lookup",
+    "OptionalKeys",
+    "OptionalProps",
+    "ReadonlyDict",
+    "RequiredProps",
+    "ShapeValue",
+    "ThisType",
+    "ToIntersection",
+    "ToPromise",
+    "INPUT",
+    "OUTPUT"
+  ]
 }


### PR DESCRIPTION
- `FunctionShape` infers types of `this` and return values from the implementation;
- Simplified `ArrayShape` and `ObjectShape` types;
- `ArrayShape.headShapes` are now required and cannot be `null`;
- Verbose generics naming for better readability;