### PR TITLE
Override built-in type coercion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1491,6 +1491,32 @@ input to the following types:
 - [`Map`](#coerce-to-a-map)
 - [`Set`](#coerce-to-a-set)
 
+## Overriding type coercion
+
+You can override the build-in type coercion with a custom callback:
+
+```ts
+const yesNoShape = d.boolean().coerce(value => {
+  if (value === 'yes') {
+    return true;
+  }
+  if (value === 'no') {
+    return false;
+  }
+  // Coercion is not possible
+  return d.NEVER;
+});
+
+d.array(yesNoShape).parse(['yes', 'no'])
+// ⮕ [true, false]
+
+yesNoShape.parse('true')
+// ❌ ValidationError: type at /: Must be a boolean
+```
+
+The callback passed to `corce` method is called only if the input value doesn't conform the requested type. If coercion
+isn't possible, return `d.NEVER`.
+
 # Introspection
 
 Doubter provides various features to introspect your shapes at runtime. Let's start by accessing a shape input types
@@ -1957,38 +1983,6 @@ shape.parse(['42', '33']);
 
 shape.parse(['seventeen']);
 // ❌ ValidationError: kaputs at /0: Must be a number-like
-```
-
-## Overriding type coercion
-
-You can extend existing shapes and override type coercion that they implement.
-
-```ts
-class YesNoShape extends d.BooleanShape {
-
-  protected _coerce(value: unknown): boolean {
-    if (value === 'yes') {
-      return true;
-    }
-    if (value === 'no') {
-      return false;
-    }
-    // Coercion is not possible
-    return d.NEVER;
-  }
-}
-```
-
-This shape can be used alongside built-in shapes:
-
-```ts
-const yesNoShape = new YesNoShape().coerce();
-
-d.array(yesNoShape).parse(['yes', 'no'])
-// ⮕ [true, false]
-
-yesNoShape.parse('true')
-// ❌ ValidationError: type at /: Must be a boolean
 ```
 
 ## Implementing deep partial support

--- a/src/main/shape/ArrayShape.ts
+++ b/src/main/shape/ArrayShape.ts
@@ -46,7 +46,7 @@ type DeepPartialArrayShape<HeadShapes extends readonly AnyShape[], RestShape ext
  * @template RestShape The shape of rest elements, or `null` if there are no rest elements.
  */
 export class ArrayShape<HeadShapes extends readonly AnyShape[], RestShape extends AnyShape | null>
-  extends CoercibleShape<InferArray<HeadShapes, RestShape, INPUT>, InferArray<HeadShapes, RestShape, OUTPUT>>
+  extends CoercibleShape<InferArray<HeadShapes, RestShape, INPUT>, InferArray<HeadShapes, RestShape, OUTPUT>, unknown[]>
   implements DeepPartialProtocol<DeepPartialArrayShape<HeadShapes, RestShape>>
 {
   /**
@@ -273,9 +273,10 @@ export class ArrayShape<HeadShapes extends readonly AnyShape[], RestShape extend
   }
 
   /**
-   * Coerces a value to an array or returns {@linkcode NEVER} if coercion isn't possible.
+   * Coerces a value to an array.
    *
    * @param value The non-array value to coerce.
+   * @returns An array, or {@linkcode NEVER} if coercion isn't possible.
    */
   protected _coerce(value: unknown): unknown[] {
     value = getCanonicalValueOf(value);

--- a/src/main/shape/BigIntShape.ts
+++ b/src/main/shape/BigIntShape.ts
@@ -54,9 +54,10 @@ export class BigIntShape extends CoercibleShape<bigint> {
   }
 
   /**
-   * Coerces a value to a bigint or returns {@linkcode NEVER} if coercion isn't possible.
+   * Coerces a value to a bigint.
    *
    * @param value The non-bigint value to coerce.
+   * @returns A bigint value, or {@linkcode NEVER} if coercion isn't possible.
    */
   protected _coerce(value: any): bigint {
     if (isArray(value) && value.length === 1 && typeof (value = value[0]) === 'bigint') {

--- a/src/main/shape/BooleanShape.ts
+++ b/src/main/shape/BooleanShape.ts
@@ -54,9 +54,10 @@ export class BooleanShape extends CoercibleShape<boolean> {
   }
 
   /**
-   * Coerces a value to a boolean or returns {@linkcode NEVER} if coercion isn't possible.
+   * Coerces a value to a boolean.
    *
    * @param value The non-boolean value to coerce.
+   * @returns A boolean value, or {@linkcode NEVER} if coercion isn't possible.
    */
   protected _coerce(value: unknown): boolean {
     if (isArray(value) && value.length === 1 && typeof (value = value[0]) === 'boolean') {

--- a/src/main/shape/CoercibleShape.ts
+++ b/src/main/shape/CoercibleShape.ts
@@ -5,8 +5,13 @@ import { Shape } from './Shape';
  *
  * @template InputValue The input value.
  * @template OutputValue The output value.
+ * @template CoercedValue The value to which an input is coerced.
  */
-export class CoercibleShape<InputValue = any, OutputValue = InputValue> extends Shape<InputValue, OutputValue> {
+export abstract class CoercibleShape<
+  InputValue = any,
+  OutputValue = InputValue,
+  CoercedValue = InputValue
+> extends Shape<InputValue, OutputValue> {
   /**
    * `true` if input value is coerced to the required type during parsing, or `false` otherwise.
    */
@@ -15,11 +20,31 @@ export class CoercibleShape<InputValue = any, OutputValue = InputValue> extends 
   /**
    * Enables an input value coercion.
    *
+   * @param cb The callback that overrides the built-in coercion.
    * @returns The clone of the shape.
    */
-  coerce(): this {
+  coerce(
+    /**
+     * @param value The value to coerce.
+     * @returns The coerced value, or {@linkcode NEVER} if coercion isn't possible.
+     */
+    cb?: (value: unknown) => CoercedValue
+  ): this {
     const shape = this._clone();
+
     shape.isCoerced = true;
+
+    if (cb !== undefined) {
+      shape._coerce = cb;
+    }
     return shape;
   }
+
+  /**
+   * Coerces an input value to another type.
+   *
+   * @param value The value to coerce.
+   * @returns The coerced value, or {@linkcode NEVER} if coercion isn't possible.
+   */
+  protected abstract _coerce(value: unknown): CoercedValue;
 }

--- a/src/main/shape/DateShape.ts
+++ b/src/main/shape/DateShape.ts
@@ -54,9 +54,10 @@ export class DateShape extends CoercibleShape<Date> {
   }
 
   /**
-   * Coerces a value to a `Date` or returns {@linkcode NEVER} if coercion isn't possible.
+   * Coerces a value to a `Date`.
    *
    * @param value The non-`Date` value to coerce.
+   * @returns A `Date` value, or {@linkcode NEVER} if coercion isn't possible.
    */
   protected _coerce(value: unknown): Date {
     if (isArray(value) && value.length === 1 && isValidDate((value = value[0]))) {

--- a/src/main/shape/EnumShape.ts
+++ b/src/main/shape/EnumShape.ts
@@ -75,11 +75,12 @@ export class EnumShape<Value> extends CoercibleShape<Value> {
   }
 
   /**
-   * Coerces a value to an enum value or returns {@linkcode NEVER} if coercion isn't possible.
+   * Coerces a value to an enum value.
    *
    * @param value The non-enum value to coerce.
+   * @returns An enum value, or {@linkcode NEVER} if coercion isn't possible.
    */
-  protected _coerce(value: any): unknown {
+  protected _coerce(value: any): Value {
     const { source } = this;
 
     if (isArray(value) && value.length === 1 && this.values.includes((value = value[0]))) {

--- a/src/main/shape/MapShape.ts
+++ b/src/main/shape/MapShape.ts
@@ -34,7 +34,11 @@ import {
  * @template ValueShape The value shape.
  */
 export class MapShape<KeyShape extends AnyShape, ValueShape extends AnyShape>
-  extends CoercibleShape<Map<KeyShape[INPUT], ValueShape[INPUT]>, Map<KeyShape[OUTPUT], ValueShape[OUTPUT]>>
+  extends CoercibleShape<
+    Map<KeyShape[INPUT], ValueShape[INPUT]>,
+    Map<KeyShape[OUTPUT], ValueShape[OUTPUT]>,
+    [unknown, unknown][]
+  >
   implements DeepPartialProtocol<MapShape<DeepPartialShape<KeyShape>, OptionalDeepPartialShape<ValueShape>>>
 {
   /**
@@ -108,7 +112,7 @@ export class MapShape<KeyShape extends AnyShape, ValueShape extends AnyShape>
       // Not a Map
       !(input instanceof Map && (entries = Array.from(input))) &&
       // No coercion or not coercible
-      (!(options.coerced || this.isCoerced) || !(changed = (entries = this._coerceEntries(input)) !== NEVER))
+      (!(options.coerced || this.isCoerced) || !(changed = (entries = this._coerce(input)) !== NEVER))
     ) {
       return this._typeIssueFactory(input, options);
     }
@@ -186,7 +190,7 @@ export class MapShape<KeyShape extends AnyShape, ValueShape extends AnyShape>
         // Not a Map
         !(input instanceof Map && (entries = Array.from(input))) &&
         // No coercion or not coercible
-        (!(options.coerced || this.isCoerced) || !(changed = (entries = this._coerceEntries(input)) !== NEVER))
+        (!(options.coerced || this.isCoerced) || !(changed = (entries = this._coerce(input)) !== NEVER))
       ) {
         resolve(this._typeIssueFactory(input, options));
         return;
@@ -272,11 +276,12 @@ export class MapShape<KeyShape extends AnyShape, ValueShape extends AnyShape>
   }
 
   /**
-   * Coerces a value to an array of `Map` entries, or returns {@linkcode NEVER} if coercion isn't possible.
+   * Coerces a value to an array of `Map` entries.
    *
    * @param value A non-`Map` value to coerce.
+   * @returns An array of entries, or {@linkcode NEVER} if coercion isn't possible.
    */
-  protected _coerceEntries(value: any): [unknown, unknown][] {
+  protected _coerce(value: any): [unknown, unknown][] {
     if (isArray(value)) {
       return value.every(isMapEntry) ? value : NEVER;
     }

--- a/src/main/shape/NumberShape.ts
+++ b/src/main/shape/NumberShape.ts
@@ -112,9 +112,10 @@ export class NumberShape extends CoercibleShape<number> {
   }
 
   /**
-   * Coerces a value to a number (not `NaN`) or returns {@linkcode NEVER} if coercion isn't possible.
+   * Coerces a value to a number (not `NaN`).
    *
    * @param value The non-number value to coerce.
+   * @returns A number value, or {@linkcode NEVER} if coercion isn't possible.
    */
   protected _coerce(value: any): number {
     if (isArray(value) && value.length === 1 && typeof (value = value[0]) === 'number') {

--- a/src/main/shape/SetShape.ts
+++ b/src/main/shape/SetShape.ts
@@ -22,7 +22,7 @@ import { AnyShape, DeepPartialProtocol, INPUT, NEVER, OptionalDeepPartialShape, 
  * @template ValueShape The value shape.
  */
 export class SetShape<ValueShape extends AnyShape>
-  extends CoercibleShape<Set<ValueShape[INPUT]>, Set<ValueShape[OUTPUT]>>
+  extends CoercibleShape<Set<ValueShape[INPUT]>, Set<ValueShape[OUTPUT]>, unknown[]>
   implements DeepPartialProtocol<SetShape<OptionalDeepPartialShape<ValueShape>>>
 {
   /**
@@ -84,7 +84,7 @@ export class SetShape<ValueShape extends AnyShape>
       // Not a Set
       !(input instanceof Set && (values = Array.from(input))) &&
       // No coercion or not coercible
-      (!(options.coerced || this.isCoerced) || !(changed = (values = this._coerceValues(input)) !== NEVER))
+      (!(options.coerced || this.isCoerced) || !(changed = (values = this._coerce(input)) !== NEVER))
     ) {
       return this._typeIssueFactory(input, options);
     }
@@ -132,7 +132,7 @@ export class SetShape<ValueShape extends AnyShape>
         // Not a Set
         !(input instanceof Set && (values = Array.from(input))) &&
         // No coercion or not coercible
-        (!(options.coerced || this.isCoerced) || !(changed = (values = this._coerceValues(input)) !== NEVER))
+        (!(options.coerced || this.isCoerced) || !(changed = (values = this._coerce(input)) !== NEVER))
       ) {
         resolve(this._typeIssueFactory(input, options));
         return;
@@ -184,11 +184,12 @@ export class SetShape<ValueShape extends AnyShape>
   }
 
   /**
-   * Coerces a value to an array of `Set` values, or returns {@linkcode NEVER} if coercion isn't possible.
+   * Coerces a value to an array of `Set` values.
    *
    * @param value The non-`Set` value to coerce.
+   * @returns An array, or {@linkcode NEVER} if coercion isn't possible.
    */
-  protected _coerceValues(value: unknown): unknown[] {
+  protected _coerce(value: unknown): unknown[] {
     value = getCanonicalValueOf(value);
 
     if (isArray(value)) {

--- a/src/main/shape/StringShape.ts
+++ b/src/main/shape/StringShape.ts
@@ -54,9 +54,10 @@ export class StringShape extends CoercibleShape<string> {
   }
 
   /**
-   * Coerces a value to a string or returns {@linkcode NEVER} if coercion isn't possible.
+   * Coerces a value to a string.
    *
    * @param value The non-string value to coerce.
+   * @returns A string value, or {@linkcode NEVER} if coercion isn't possible.
    */
   protected _coerce(value: any): string {
     if (isArray(value) && value.length === 1 && typeof (value = value[0]) === 'string') {

--- a/src/test/README.test.ts
+++ b/src/test/README.test.ts
@@ -118,6 +118,21 @@ describe('JSON shape', () => {
   });
 });
 
+test('Overriding type coercion', () => {
+  const yesNoShape = d.boolean().coerce(value => {
+    if (value === 'yes') {
+      return true;
+    }
+    if (value === 'no') {
+      return false;
+    }
+    // Coercion is not possible
+    return d.NEVER;
+  });
+
+  expect(d.array(yesNoShape).parse(['yes', 'no'])).toEqual([true, false]);
+});
+
 test('Circular object references', () => {
   interface User {
     friends: User[];
@@ -180,22 +195,5 @@ describe('Advanced shapes', () => {
       ok: false,
       issues: [{ code: 'kaputs', message: 'Must be a number-like', input: 'seventeen', path: [0] }],
     });
-  });
-
-  test('YesNoShape', () => {
-    class YesNoShape extends d.BooleanShape {
-      protected _coerce(value: unknown): boolean {
-        if (value === 'yes') {
-          return true;
-        }
-        if (value === 'no') {
-          return false;
-        }
-        // 🟡 Return NEVER if coercion isn't possible
-        return d.NEVER;
-      }
-    }
-
-    expect(d.array(new YesNoShape().coerce()).parse(['yes', 'no'])).toEqual([true, false]);
   });
 });

--- a/src/test/shapes/CoercibleShape.test.ts
+++ b/src/test/shapes/CoercibleShape.test.ts
@@ -1,0 +1,17 @@
+import { StringShape } from '../../main';
+
+describe('CoercibleShape', () => {
+  test('does not coerce values of a valid type', () => {
+    const cbMock = jest.fn();
+    const shape = new StringShape().coerce(cbMock);
+
+    expect(shape.parse('aaa')).toBe('aaa');
+    expect(cbMock).not.toHaveBeenCalled();
+  });
+
+  test('applies coercion callback', () => {
+    const shape = new StringShape().coerce(value => '__' + value);
+
+    expect(shape.parse(111)).toBe('__111');
+  });
+});


### PR DESCRIPTION
You can override the build-in type coercion with a custom callback:

```ts
const yesNoShape = d.boolean().coerce(value => {
  if (value === 'yes') {
    return true;
  }
  if (value === 'no') {
    return false;
  }
  // Coercion is not possible
  return d.NEVER;
});

d.array(yesNoShape).parse(['yes', 'no'])
// ⮕ [true, false]

yesNoShape.parse('true')
// ❌ ValidationError: type at /: Must be a boolean
```

The callback passed to `corce` method is called only if the input value doesn't conform the requested type. If coercion
isn't possible, return `d.NEVER`.