### PR TITLE
Renamed coercion flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ parseOrDefault(42);
 Parsing methods accept options argument.
 
 ```ts
-d.number().parse('42', { coerced: true });
+d.number().parse('42', { coerce: true });
 // ⮕ 42
 ```
 
@@ -206,7 +206,7 @@ If `true` then Doubter collects all issues during parsing, otherwise parsing is 
 encountered. Refer to [Verbose mode](#verbose-mode) section for more details.
 
 </dd>
-<dt><code>coerced</code></dt>
+<dt><code>coerce</code></dt>
 <dd>
 
 If `true` then all shapes that support type coercion would try to coerce an input to a required type. Refer to
@@ -1449,7 +1449,7 @@ For example, you can coerce input values to string type:
 ```ts
 const shape1 = d.string().coerce();
 
-shape1.isCoerced // ⮕ true
+shape1.isCoercing // ⮕ true
 
 shape1.parse([8080]);
 // ⮕ '8080'
@@ -1459,7 +1459,7 @@ shape1.parse(null);
 ```
 
 Coercion can be enabled on shape-by-shape basis (as shown in the example above), or it can be enabled for all shapes
-when [`coerced` option](#parsing-and-trying) is passed to `parse*` or `try*` methods:
+when [`coerce` option](#parsing-and-trying) is passed to `parse*` or `try*` methods:
 
 ```ts
 const shape2 = d.object({
@@ -1472,7 +1472,7 @@ shape2.parse(
     name: ['Jake'],
     birthday: '1949-01-24'
   },
-  { coerced: true }
+  { coerce: true }
 );
 // ⮕ { name: 'Jake', birthday: new Date(-660700800000) }
 ```
@@ -3733,7 +3733,7 @@ raise a validation issue. You can mark individual params as optional and
 
 2. Query params are strings. So `name` doesn't require additional attention since it's constrained by
 [`d.string`](#string). On the other hand, `age` is an integer, so [type coercion](#type-coercion) must be enabled to
-coerce `age` to a number. To do this we're going to pass the [`coerced` option](#parsing-and-trying) to the `parse`
+coerce `age` to a number. To do this we're going to pass the [`coerce` option](#parsing-and-trying) to the `parse`
 method.
 
 3. We also added [`catch`](#fallback-value), so when `age` cannot be parsed as a positive integer, Doubter returns
@@ -3746,7 +3746,7 @@ import qs from 'qs';
 
 const query = queryShape.parse(
   qs.parse('name=Frodo&age=50'),
-  { coerced: true }
+  { coerce: true }
 );
 // ⮕ { name: 'Frodo', age: 50 }
 ```
@@ -3756,7 +3756,7 @@ const query = queryShape.parse(
 ```ts
 queryShape.parse(
   qs.parse('age=-33'),
-  { coerced: true }
+  { coerce: true }
 );
 // ⮕ { age: undefined }
 ```
@@ -3787,7 +3787,7 @@ accidental usage of an unvalidated env variable.
 ```ts
 const env = envShape.parse(
   process.env,
-  { coerced: true }
+  { coerce: true }
 );
 // ⮕ { NODE_ENV: 'test' | 'production', DAYS_IN_YEAR: number }
 ```

--- a/src/main/shape/ArrayShape.ts
+++ b/src/main/shape/ArrayShape.ts
@@ -128,7 +128,7 @@ export class ArrayShape<HeadShapes extends readonly AnyShape[], RestShape extend
   protected _getInputs(): unknown[] {
     const { headShapes, restShape } = this;
 
-    if (!this.isCoerced) {
+    if (!this.isCoercing) {
       return [TYPE_ARRAY];
     }
     if (headShapes.length > 1) {
@@ -157,7 +157,7 @@ export class ArrayShape<HeadShapes extends readonly AnyShape[], RestShape extend
 
     if (
       // Not an array or not coercible
-      (!isArray(output) && (!(options.coerced || this.isCoerced) || (output = this._coerce(input)) === NEVER)) ||
+      (!isArray(output) && (!(options.coerce || this.isCoercing) || (output = this._coerce(input)) === NEVER)) ||
       // Invalid tuple length
       (outputLength = output.length) < headShapesLength ||
       (restShape === null && outputLength !== headShapesLength)
@@ -215,7 +215,7 @@ export class ArrayShape<HeadShapes extends readonly AnyShape[], RestShape extend
 
       if (
         // Not an array or not coercible
-        (!isArray(output) && (!(options.coerced || this.isCoerced) || (output = this._coerce(input)) === NEVER)) ||
+        (!isArray(output) && (!(options.coerce || this.isCoercing) || (output = this._coerce(input)) === NEVER)) ||
         // Invalid tuple length
         (outputLength = output.length) < headShapesLength ||
         (restShape === null && outputLength !== headShapesLength)

--- a/src/main/shape/BigIntShape.ts
+++ b/src/main/shape/BigIntShape.ts
@@ -27,7 +27,7 @@ export class BigIntShape extends CoercibleShape<bigint> {
   }
 
   protected _getInputs(): unknown[] {
-    if (this.isCoerced) {
+    if (this.isCoercing) {
       return [TYPE_BIGINT, TYPE_OBJECT, TYPE_STRING, TYPE_NUMBER, TYPE_BOOLEAN, TYPE_ARRAY, null, undefined];
     } else {
       return [TYPE_BIGINT];
@@ -43,7 +43,7 @@ export class BigIntShape extends CoercibleShape<bigint> {
 
     if (
       typeof output !== 'bigint' &&
-      (!(changed = options.coerced || this.isCoerced) || (output = this._coerce(input)) === NEVER)
+      (!(changed = options.coerce || this.isCoercing) || (output = this._coerce(input)) === NEVER)
     ) {
       return this._typeIssueFactory(input, options);
     }

--- a/src/main/shape/BooleanShape.ts
+++ b/src/main/shape/BooleanShape.ts
@@ -27,7 +27,7 @@ export class BooleanShape extends CoercibleShape<boolean> {
   }
 
   protected _getInputs(): unknown[] {
-    if (this.isCoerced) {
+    if (this.isCoercing) {
       return [TYPE_BOOLEAN, TYPE_OBJECT, TYPE_STRING, TYPE_NUMBER, TYPE_ARRAY, null, undefined];
     } else {
       return [TYPE_BOOLEAN];
@@ -43,7 +43,7 @@ export class BooleanShape extends CoercibleShape<boolean> {
 
     if (
       typeof output !== 'boolean' &&
-      (!(changed = options.coerced || this.isCoerced) || (output = this._coerce(input)) === NEVER)
+      (!(changed = options.coerce || this.isCoercing) || (output = this._coerce(input)) === NEVER)
     ) {
       return this._typeIssueFactory(input, options);
     }

--- a/src/main/shape/CoercibleShape.ts
+++ b/src/main/shape/CoercibleShape.ts
@@ -13,9 +13,9 @@ export abstract class CoercibleShape<
   CoercedValue = InputValue
 > extends Shape<InputValue, OutputValue> {
   /**
-   * `true` if input value is coerced to the required type during parsing, or `false` otherwise.
+   * `true` if this shapes coerces input values to the required type during parsing, or `false` otherwise.
    */
-  isCoerced = false;
+  isCoercing = false;
 
   /**
    * Enables an input value coercion.
@@ -32,7 +32,7 @@ export abstract class CoercibleShape<
   ): this {
     const shape = this._clone();
 
-    shape.isCoerced = true;
+    shape.isCoercing = true;
 
     if (cb !== undefined) {
       shape._coerce = cb;

--- a/src/main/shape/DateShape.ts
+++ b/src/main/shape/DateShape.ts
@@ -27,7 +27,7 @@ export class DateShape extends CoercibleShape<Date> {
   }
 
   protected _getInputs(): unknown[] {
-    if (this.isCoerced) {
+    if (this.isCoercing) {
       return [TYPE_DATE, TYPE_OBJECT, TYPE_STRING, TYPE_NUMBER, TYPE_ARRAY];
     } else {
       return [TYPE_DATE];
@@ -43,7 +43,7 @@ export class DateShape extends CoercibleShape<Date> {
 
     if (
       !isValidDate(input) &&
-      (!(changed = options.coerced || this.isCoerced) || (output = this._coerce(input)) === NEVER)
+      (!(changed = options.coerce || this.isCoercing) || (output = this._coerce(input)) === NEVER)
     ) {
       return this._typeIssueFactory(input, options);
     }

--- a/src/main/shape/EnumShape.ts
+++ b/src/main/shape/EnumShape.ts
@@ -46,7 +46,7 @@ export class EnumShape<Value> extends CoercibleShape<Value> {
   protected _getInputs(): unknown[] {
     const inputs: unknown[] = this.values.slice(0);
 
-    if (!this.isCoerced || inputs.length === 0) {
+    if (!this.isCoercing || inputs.length === 0) {
       return inputs;
     }
     if (!isArray(this.source)) {
@@ -64,7 +64,7 @@ export class EnumShape<Value> extends CoercibleShape<Value> {
 
     if (
       !values.includes(output) &&
-      (!(changed = options.coerced || this.isCoerced) || (output = this._coerce(input)) === NEVER)
+      (!(changed = options.coerce || this.isCoercing) || (output = this._coerce(input)) === NEVER)
     ) {
       return this._typeIssueFactory(input, options);
     }

--- a/src/main/shape/MapShape.ts
+++ b/src/main/shape/MapShape.ts
@@ -93,7 +93,7 @@ export class MapShape<KeyShape extends AnyShape, ValueShape extends AnyShape>
   }
 
   protected _getInputs(): unknown[] {
-    if (this.isCoerced) {
+    if (this.isCoercing) {
       return [TYPE_MAP, TYPE_OBJECT, TYPE_ARRAY];
     } else {
       return [TYPE_MAP];
@@ -112,7 +112,7 @@ export class MapShape<KeyShape extends AnyShape, ValueShape extends AnyShape>
       // Not a Map
       !(input instanceof Map && (entries = Array.from(input))) &&
       // No coercion or not coercible
-      (!(options.coerced || this.isCoerced) || !(changed = (entries = this._coerce(input)) !== NEVER))
+      (!(options.coerce || this.isCoercing) || !(changed = (entries = this._coerce(input)) !== NEVER))
     ) {
       return this._typeIssueFactory(input, options);
     }
@@ -190,7 +190,7 @@ export class MapShape<KeyShape extends AnyShape, ValueShape extends AnyShape>
         // Not a Map
         !(input instanceof Map && (entries = Array.from(input))) &&
         // No coercion or not coercible
-        (!(options.coerced || this.isCoerced) || !(changed = (entries = this._coerce(input)) !== NEVER))
+        (!(options.coerce || this.isCoercing) || !(changed = (entries = this._coerce(input)) !== NEVER))
       ) {
         resolve(this._typeIssueFactory(input, options));
         return;

--- a/src/main/shape/NumberShape.ts
+++ b/src/main/shape/NumberShape.ts
@@ -85,7 +85,7 @@ export class NumberShape extends CoercibleShape<number> {
   }
 
   protected _getInputs(): unknown[] {
-    if (this.isCoerced) {
+    if (this.isCoercing) {
       return [TYPE_NUMBER, TYPE_OBJECT, TYPE_STRING, TYPE_BOOLEAN, TYPE_ARRAY, TYPE_DATE, null, undefined];
     } else {
       return [TYPE_NUMBER];
@@ -101,7 +101,7 @@ export class NumberShape extends CoercibleShape<number> {
 
     if (
       !this._typePredicate(output) &&
-      (!(changed = options.coerced || this.isCoerced) || (output = this._coerce(input)) === NEVER)
+      (!(changed = options.coerce || this.isCoercing) || (output = this._coerce(input)) === NEVER)
     ) {
       return this._typeIssueFactory(input, options);
     }

--- a/src/main/shape/PromiseShape.ts
+++ b/src/main/shape/PromiseShape.ts
@@ -48,7 +48,7 @@ export class PromiseShape<ValueShape extends AnyShape>
   }
 
   protected _getInputs(): unknown[] {
-    if (this.isCoerced) {
+    if (this.isCoercing) {
       return this.shape.inputs.concat(TYPE_PROMISE);
     } else {
       return [TYPE_PROMISE];
@@ -68,7 +68,7 @@ export class PromiseShape<ValueShape extends AnyShape>
 
     if (
       !(input instanceof Promise) &&
-      (!(options.coerced || this.isCoerced) || (output = this._coerce(input)) === NEVER)
+      (!(options.coerce || this.isCoercing) || (output = this._coerce(input)) === NEVER)
     ) {
       return Promise.resolve(this._typeIssueFactory(input, options));
     }

--- a/src/main/shape/SetShape.ts
+++ b/src/main/shape/SetShape.ts
@@ -68,7 +68,7 @@ export class SetShape<ValueShape extends AnyShape>
   }
 
   protected _getInputs(): unknown[] {
-    if (this.isCoerced) {
+    if (this.isCoercing) {
       return this.shape.inputs.concat(TYPE_SET, TYPE_OBJECT, TYPE_ARRAY);
     } else {
       return [TYPE_SET];
@@ -84,7 +84,7 @@ export class SetShape<ValueShape extends AnyShape>
       // Not a Set
       !(input instanceof Set && (values = Array.from(input))) &&
       // No coercion or not coercible
-      (!(options.coerced || this.isCoerced) || !(changed = (values = this._coerce(input)) !== NEVER))
+      (!(options.coerce || this.isCoercing) || !(changed = (values = this._coerce(input)) !== NEVER))
     ) {
       return this._typeIssueFactory(input, options);
     }
@@ -132,7 +132,7 @@ export class SetShape<ValueShape extends AnyShape>
         // Not a Set
         !(input instanceof Set && (values = Array.from(input))) &&
         // No coercion or not coercible
-        (!(options.coerced || this.isCoerced) || !(changed = (values = this._coerce(input)) !== NEVER))
+        (!(options.coerce || this.isCoercing) || !(changed = (values = this._coerce(input)) !== NEVER))
       ) {
         resolve(this._typeIssueFactory(input, options));
         return;

--- a/src/main/shape/Shape.ts
+++ b/src/main/shape/Shape.ts
@@ -51,7 +51,7 @@ import { ValidationError } from '../ValidationError';
  */
 export const NEVER = Object.freeze({}) as never;
 
-export const defaultApplyOptions = Object.freeze<ApplyOptions>({ verbose: false, coerced: false });
+export const defaultApplyOptions = Object.freeze<ApplyOptions>({ verbose: false, coerce: false });
 
 /**
  * Excludes `U` from `T` only if `U` is a literal type.

--- a/src/main/shape/StringShape.ts
+++ b/src/main/shape/StringShape.ts
@@ -27,7 +27,7 @@ export class StringShape extends CoercibleShape<string> {
   }
 
   protected _getInputs(): unknown[] {
-    if (this.isCoerced) {
+    if (this.isCoercing) {
       return [TYPE_STRING, TYPE_OBJECT, TYPE_NUMBER, TYPE_BOOLEAN, TYPE_BIGINT, TYPE_ARRAY, null, undefined];
     } else {
       return [TYPE_STRING];
@@ -43,7 +43,7 @@ export class StringShape extends CoercibleShape<string> {
 
     if (
       typeof output !== 'string' &&
-      (!(changed = options.coerced || this.isCoerced) || (output = this._coerce(input)) === NEVER)
+      (!(changed = options.coerce || this.isCoercing) || (output = this._coerce(input)) === NEVER)
     ) {
       return this._typeIssueFactory(input, options);
     }

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -189,7 +189,7 @@ export interface ApplyOptions {
    *
    * @default false
    */
-  coerced?: boolean;
+  coerce?: boolean;
 
   /**
    * The custom context.

--- a/src/test/README.test.ts
+++ b/src/test/README.test.ts
@@ -20,9 +20,9 @@ describe('Cookbook', () => {
       })
       .partial();
 
-    expect(queryShape.parse(qs.parse('name=Frodo&age=50'), { coerced: true })).toEqual({ name: 'Frodo', age: 50 });
+    expect(queryShape.parse(qs.parse('name=Frodo&age=50'), { coerce: true })).toEqual({ name: 'Frodo', age: 50 });
 
-    expect(queryShape.parse(qs.parse('age=-33'), { coerced: true })).toStrictEqual({ age: undefined });
+    expect(queryShape.parse(qs.parse('age=-33'), { coerce: true })).toStrictEqual({ age: undefined });
   });
 
   test('Type-safe env variables', () => {
@@ -33,7 +33,7 @@ describe('Cookbook', () => {
       })
       .strip();
 
-    expect(envShape.parse(process.env, { coerced: true })).toEqual({
+    expect(envShape.parse(process.env, { coerce: true })).toEqual({
       NODE_ENV: 'test',
       TS_JEST: 1,
     });

--- a/src/test/internal/shapes.test.ts
+++ b/src/test/internal/shapes.test.ts
@@ -33,9 +33,9 @@ describe('createApplyChecksCallback', () => {
         { key: cbMock, callback: cbMock, param: undefined, isUnsafe: false },
       ]);
 
-      expect(applyChecks!(111, null, { verbose: false, coerced: false })).toEqual([{ code: 'xxx' }]);
+      expect(applyChecks!(111, null, { verbose: false, coerce: false })).toEqual([{ code: 'xxx' }]);
       expect(cbMock).toHaveBeenCalledTimes(1);
-      expect(cbMock).toHaveBeenNthCalledWith(1, 111, undefined, { verbose: false, coerced: false });
+      expect(cbMock).toHaveBeenNthCalledWith(1, 111, undefined, { verbose: false, coerce: false });
     });
 
     test('unsafe check merges issues', () => {
@@ -47,10 +47,10 @@ describe('createApplyChecksCallback', () => {
 
       const issues: Issue[] = [];
 
-      expect(applyChecks!(111, issues, { verbose: false, coerced: false })).toEqual(issues);
+      expect(applyChecks!(111, issues, { verbose: false, coerce: false })).toEqual(issues);
       expect(issues).toEqual([{ code: 'xxx' }]);
       expect(cbMock).toHaveBeenCalledTimes(1);
-      expect(cbMock).toHaveBeenNthCalledWith(1, 111, undefined, { verbose: false, coerced: false });
+      expect(cbMock).toHaveBeenNthCalledWith(1, 111, undefined, { verbose: false, coerce: false });
     });
 
     test('safe check is not called when issues present', () => {
@@ -62,7 +62,7 @@ describe('createApplyChecksCallback', () => {
 
       const issues: Issue[] = [];
 
-      expect(applyChecks!(111, issues, { verbose: false, coerced: false })).toEqual(issues);
+      expect(applyChecks!(111, issues, { verbose: false, coerce: false })).toEqual(issues);
       expect(issues.length).toBe(0);
       expect(cbMock).not.toHaveBeenCalled();
     });
@@ -88,7 +88,7 @@ describe('createApplyChecksCallback', () => {
         { key: cbMock, callback: cbMock, param: undefined, isUnsafe: false },
       ]);
 
-      expect(applyChecks!(111, null, { verbose: false, coerced: false })).toEqual([{ code: 'xxx' }]);
+      expect(applyChecks!(111, null, { verbose: false, coerce: false })).toEqual([{ code: 'xxx' }]);
     });
   });
 
@@ -106,11 +106,11 @@ describe('createApplyChecksCallback', () => {
         { key: cbMock4, callback: cbMock4, param: undefined, isUnsafe: true },
       ]);
 
-      expect(applyChecks!(111, null, { verbose: false, coerced: false })).toEqual([{ code: 'BBB' }]);
+      expect(applyChecks!(111, null, { verbose: false, coerce: false })).toEqual([{ code: 'BBB' }]);
       expect(cbMock1).toHaveBeenCalledTimes(1);
-      expect(cbMock1).toHaveBeenNthCalledWith(1, 111, undefined, { verbose: false, coerced: false });
+      expect(cbMock1).toHaveBeenNthCalledWith(1, 111, undefined, { verbose: false, coerce: false });
       expect(cbMock2).toHaveBeenCalledTimes(1);
-      expect(cbMock2).toHaveBeenNthCalledWith(1, 111, undefined, { verbose: false, coerced: false });
+      expect(cbMock2).toHaveBeenNthCalledWith(1, 111, undefined, { verbose: false, coerce: false });
       expect(cbMock3).not.toHaveBeenCalled();
       expect(cbMock4).not.toHaveBeenCalled();
     });

--- a/src/test/shapes/ArrayShape.test.ts
+++ b/src/test/shapes/ArrayShape.test.ts
@@ -77,9 +77,9 @@ describe('ArrayShape', () => {
     expect(result).toEqual({ ok: true, value: arr });
     expect(result.value).toBe(arr);
     expect(applySpy1).toHaveBeenCalledTimes(1);
-    expect(applySpy1).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false }, 0);
+    expect(applySpy1).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerce: false }, 0);
     expect(applySpy2).toHaveBeenCalledTimes(1);
-    expect(applySpy2).toHaveBeenNthCalledWith(1, 222, { verbose: false, coerced: false }, 0);
+    expect(applySpy2).toHaveBeenNthCalledWith(1, 222, { verbose: false, coerce: false }, 0);
   });
 
   test('parses rest elements', () => {
@@ -95,8 +95,8 @@ describe('ArrayShape', () => {
     expect(result).toEqual({ ok: true, value: arr });
     expect(result.value).toBe(arr);
     expect(restApplySpy).toHaveBeenCalledTimes(2);
-    expect(restApplySpy).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false }, 0);
-    expect(restApplySpy).toHaveBeenNthCalledWith(2, 222, { verbose: false, coerced: false }, 0);
+    expect(restApplySpy).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerce: false }, 0);
+    expect(restApplySpy).toHaveBeenNthCalledWith(2, 222, { verbose: false, coerce: false }, 0);
   });
 
   test('parses both tuple and rest elements at the same time', () => {
@@ -116,12 +116,12 @@ describe('ArrayShape', () => {
     expect(result).toEqual({ ok: true, value: arr });
     expect(result.value).toBe(arr);
     expect(applySpy1).toHaveBeenCalledTimes(1);
-    expect(applySpy1).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false }, 0);
+    expect(applySpy1).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerce: false }, 0);
     expect(applySpy2).toHaveBeenCalledTimes(1);
-    expect(applySpy2).toHaveBeenNthCalledWith(1, 222, { verbose: false, coerced: false }, 0);
+    expect(applySpy2).toHaveBeenNthCalledWith(1, 222, { verbose: false, coerce: false }, 0);
     expect(restApplySpy).toHaveBeenCalledTimes(2);
-    expect(restApplySpy).toHaveBeenNthCalledWith(1, 333, { verbose: false, coerced: false }, 0);
-    expect(restApplySpy).toHaveBeenNthCalledWith(2, 444, { verbose: false, coerced: false }, 0);
+    expect(restApplySpy).toHaveBeenNthCalledWith(1, 333, { verbose: false, coerce: false }, 0);
+    expect(restApplySpy).toHaveBeenNthCalledWith(2, 444, { verbose: false, coerce: false }, 0);
   });
 
   test('raises an issue if the tuple length does not match shapes', () => {
@@ -479,7 +479,7 @@ describe('ArrayShape', () => {
 
       await expect(arrShape.tryAsync([])).resolves.toEqual({ ok: true, value: [] });
       expect(applySpy).toHaveBeenCalledTimes(1);
-      expect(applySpy).toHaveBeenNthCalledWith(1, [], { verbose: false, coerced: false }, 0);
+      expect(applySpy).toHaveBeenNthCalledWith(1, [], { verbose: false, coerce: false }, 0);
     });
 
     test('parses tuple elements', async () => {
@@ -500,9 +500,9 @@ describe('ArrayShape', () => {
       expect(result).toEqual({ ok: true, value: arr });
       expect(result.value).toBe(arr);
       expect(applySpy1).toHaveBeenCalledTimes(1);
-      expect(applySpy1).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false }, 0);
+      expect(applySpy1).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerce: false }, 0);
       expect(applySpy2).toHaveBeenCalledTimes(1);
-      expect(applySpy2).toHaveBeenNthCalledWith(1, 222, { verbose: false, coerced: false }, 0);
+      expect(applySpy2).toHaveBeenNthCalledWith(1, 222, { verbose: false, coerce: false }, 0);
     });
 
     test('does not apply tuple element shape if previous shape raised an issue', async () => {
@@ -522,7 +522,7 @@ describe('ArrayShape', () => {
 
       expect(result).toEqual({ ok: false, issues: [{ code: 'xxx', path: [0] }] });
       expect(applySpy1).toHaveBeenCalledTimes(1);
-      expect(applySpy1).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false }, 0);
+      expect(applySpy1).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerce: false }, 0);
       expect(applySpy2).not.toHaveBeenCalled();
     });
 
@@ -537,8 +537,8 @@ describe('ArrayShape', () => {
       expect(result).toEqual({ ok: true, value: arr });
       expect(result.value).toBe(arr);
       expect(restApplySpy).toHaveBeenCalledTimes(2);
-      expect(restApplySpy).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false }, 0);
-      expect(restApplySpy).toHaveBeenNthCalledWith(2, 222, { verbose: false, coerced: false }, 0);
+      expect(restApplySpy).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerce: false }, 0);
+      expect(restApplySpy).toHaveBeenNthCalledWith(2, 222, { verbose: false, coerce: false }, 0);
     });
 
     test('clones an array if a tuple element was transformed', async () => {

--- a/src/test/shapes/BigIntShape.test.ts
+++ b/src/test/shapes/BigIntShape.test.ts
@@ -51,7 +51,7 @@ describe('BigIntShape', () => {
       expect(new BigIntShape().coerce().parse(new Number(111))).toBe(BigInt(111));
       expect(new BigIntShape().coerce().parse([new Number(111)])).toBe(BigInt(111));
       expect(new BigIntShape().coerce().parse(true)).toBe(BigInt(1));
-      expect(new BigIntShape().parse(true, { coerced: true })).toBe(BigInt(1));
+      expect(new BigIntShape().parse(true, { coerce: true })).toBe(BigInt(1));
     });
 
     test('raises an issue if coercion fails', () => {

--- a/src/test/shapes/BooleanShape.test.ts
+++ b/src/test/shapes/BooleanShape.test.ts
@@ -33,7 +33,7 @@ describe('BooleanShape', () => {
       expect(new BooleanShape().coerce().parse(new Boolean(true))).toBe(true);
       expect(new BooleanShape().coerce().parse([new Boolean(true)])).toBe(true);
       expect(new BooleanShape().coerce().parse('true')).toBe(true);
-      expect(new BooleanShape().parse('true', { coerced: true })).toBe(true);
+      expect(new BooleanShape().parse('true', { coerce: true })).toBe(true);
     });
 
     test('raises an issue if coercion fails', () => {

--- a/src/test/shapes/DateShape.test.ts
+++ b/src/test/shapes/DateShape.test.ts
@@ -35,7 +35,7 @@ describe('DateShape', () => {
       expect(new DateShape().coerce().parse(new Number(111))).toEqual(new Date(111));
       expect(new DateShape().coerce().parse([new Number(111)])).toEqual(new Date(111));
       expect(new DateShape().coerce().parse('2020-02-02')).toEqual(new Date('2020-02-02'));
-      expect(new DateShape().parse('2020-02-02', { coerced: true })).toEqual(new Date('2020-02-02'));
+      expect(new DateShape().parse('2020-02-02', { coerce: true })).toEqual(new Date('2020-02-02'));
     });
 
     test('raises an issue if coercion fails', () => {

--- a/src/test/shapes/EnumShape.test.ts
+++ b/src/test/shapes/EnumShape.test.ts
@@ -122,7 +122,7 @@ describe('EnumShape', () => {
       expect(shape.coerce().inputs).toEqual([0, 1, '0', '1', 'AAA', 'BBB', TYPE_ARRAY, TYPE_OBJECT]);
 
       expect(shape.coerce().parse('AAA')).toEqual(NumberMockEnum.AAA);
-      expect(shape.parse('AAA', { coerced: true })).toEqual(NumberMockEnum.AAA);
+      expect(shape.parse('AAA', { coerce: true })).toEqual(NumberMockEnum.AAA);
     });
 
     test('coerces the key of a const object', () => {
@@ -134,7 +134,7 @@ describe('EnumShape', () => {
       expect(shape.coerce().inputs).toEqual(['aaa', 'bbb', 'AAA', 'BBB', TYPE_ARRAY, TYPE_OBJECT]);
 
       expect(shape.coerce().parse('AAA')).toEqual('aaa');
-      expect(shape.parse('AAA', { coerced: true })).toEqual('aaa');
+      expect(shape.parse('AAA', { coerce: true })).toEqual('aaa');
     });
 
     test('coerces from an array', () => {
@@ -143,7 +143,7 @@ describe('EnumShape', () => {
       expect(shape.coerce().inputs).toEqual([111, 222, TYPE_ARRAY, TYPE_OBJECT]);
 
       expect(shape.coerce().parse([111])).toBe(111);
-      expect(shape.parse(111, { coerced: true })).toBe(111);
+      expect(shape.parse(111, { coerce: true })).toBe(111);
     });
   });
 });

--- a/src/test/shapes/FunctionShape.test.ts
+++ b/src/test/shapes/FunctionShape.test.ts
@@ -109,11 +109,11 @@ describe('FunctionShape', () => {
       const cbMock = jest.fn();
 
       new FunctionShape(arrayShape.check(cbMock), null, null)
-        .strict({ coerced: true })
+        .strict({ coerce: true })
         .ensureSignature(() => undefined)();
 
       expect(cbMock).toHaveBeenCalledTimes(1);
-      expect(cbMock).toHaveBeenNthCalledWith(1, [], undefined, { coerced: true });
+      expect(cbMock).toHaveBeenNthCalledWith(1, [], undefined, { coerce: true });
     });
 
     test('wraps a function', () => {
@@ -161,7 +161,7 @@ describe('FunctionShape', () => {
       expect(fnMock).toHaveBeenNthCalledWith(1, 'aaa');
 
       expect(applySpy).toHaveBeenCalledTimes(1);
-      expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerced: false, verbose: false }, 0);
+      expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerce: false, verbose: false }, 0);
     });
 
     test('raises an issue if this is invalid', () => {
@@ -235,7 +235,7 @@ describe('FunctionShape', () => {
       expect(fnMock).toHaveBeenNthCalledWith(1, 'aaa');
 
       expect(applySpy).toHaveBeenCalledTimes(1);
-      expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerced: false, verbose: false }, 0);
+      expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerce: false, verbose: false }, 0);
     });
 
     test('raises an issue if this is invalid', async () => {

--- a/src/test/shapes/LazyShape.test.ts
+++ b/src/test/shapes/LazyShape.test.ts
@@ -43,7 +43,7 @@ describe('LazyShape', () => {
     expect(lazyShape.isAsync).toBe(false);
     expect(lazyShape.parse('aaa')).toBe('aaa');
     expect(applySpy).toHaveBeenCalledTimes(1);
-    expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false }, 0);
+    expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerce: false }, 0);
   });
 
   test('applies checks to transformed value', () => {
@@ -57,7 +57,7 @@ describe('LazyShape', () => {
       issues: [{ code: 'xxx' }],
     });
     expect(checkMock).toHaveBeenCalledTimes(1);
-    expect(checkMock).toHaveBeenNthCalledWith(1, 111, undefined, { verbose: false, coerced: false });
+    expect(checkMock).toHaveBeenNthCalledWith(1, 111, undefined, { verbose: false, coerce: false });
   });
 
   test('does not apply checks if an underlying shape raises an issue', () => {
@@ -252,8 +252,8 @@ describe('LazyShape', () => {
 
       expect(nextNonce()).toBe(2);
       expect(checkMock).toHaveBeenCalledTimes(2);
-      expect(checkMock).toHaveBeenNthCalledWith(1, 111, undefined, { coerced: false, verbose: false });
-      expect(checkMock).toHaveBeenNthCalledWith(2, 111, undefined, { coerced: false, verbose: false });
+      expect(checkMock).toHaveBeenNthCalledWith(1, 111, undefined, { coerce: false, verbose: false });
+      expect(checkMock).toHaveBeenNthCalledWith(2, 111, undefined, { coerce: false, verbose: false });
     });
   });
 
@@ -266,7 +266,7 @@ describe('LazyShape', () => {
       expect(lazyShape.isAsync).toBe(true);
       await expect(lazyShape.parseAsync('aaa')).resolves.toBe('aaa');
       expect(applySpy).toHaveBeenCalledTimes(1);
-      expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false }, 0);
+      expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerce: false }, 0);
     });
 
     test('clears stack if an error is thrown', async () => {
@@ -309,10 +309,10 @@ describe('LazyShape', () => {
       await Promise.all([lazyShape.parseAsync(obj1), lazyShape.parseAsync(obj2)]);
 
       expect(applySpy).toHaveBeenCalledTimes(4);
-      expect(applySpy).toHaveBeenNthCalledWith(1, obj1, { coerced: false, verbose: false }, 0);
-      expect(applySpy).toHaveBeenNthCalledWith(2, obj2, { coerced: false, verbose: false }, 1);
-      expect(applySpy).toHaveBeenNthCalledWith(3, obj1, { coerced: false, verbose: false }, 0);
-      expect(applySpy).toHaveBeenNthCalledWith(4, obj2, { coerced: false, verbose: false }, 1);
+      expect(applySpy).toHaveBeenNthCalledWith(1, obj1, { coerce: false, verbose: false }, 0);
+      expect(applySpy).toHaveBeenNthCalledWith(2, obj2, { coerce: false, verbose: false }, 1);
+      expect(applySpy).toHaveBeenNthCalledWith(3, obj1, { coerce: false, verbose: false }, 0);
+      expect(applySpy).toHaveBeenNthCalledWith(4, obj2, { coerce: false, verbose: false }, 1);
     });
   });
 });

--- a/src/test/shapes/NumberShape.test.ts
+++ b/src/test/shapes/NumberShape.test.ts
@@ -123,7 +123,7 @@ describe('NumberShape', () => {
       expect(new NumberShape().coerce().parse('111')).toBe(111);
       expect(new NumberShape().coerce().parse(true)).toBe(1);
       expect(new NumberShape().coerce().parse([111])).toBe(111);
-      expect(new NumberShape().parse([111], { coerced: true })).toBe(111);
+      expect(new NumberShape().parse([111], { coerce: true })).toBe(111);
     });
 
     test('raises an issue if coercion fails', () => {

--- a/src/test/shapes/ObjectShape.test.ts
+++ b/src/test/shapes/ObjectShape.test.ts
@@ -333,7 +333,7 @@ describe('ObjectShape', () => {
       expect(result).toEqual({ ok: true, value: obj });
       expect(result.value).toBe(obj);
       expect(applySpy1).toHaveBeenCalledTimes(1);
-      expect(applySpy1).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false }, 0);
+      expect(applySpy1).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerce: false }, 0);
     });
 
     test('raises the first issue only', () => {
@@ -426,11 +426,11 @@ describe('ObjectShape', () => {
       expect(result).toEqual({ ok: true, value: obj });
       expect(result.value).toBe(obj);
       expect(applySpy1).toHaveBeenCalledTimes(1);
-      expect(applySpy1).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false }, 0);
+      expect(applySpy1).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerce: false }, 0);
       expect(applySpy2).toHaveBeenCalledTimes(1);
-      expect(applySpy2).toHaveBeenNthCalledWith(1, undefined, { verbose: false, coerced: false }, 0);
+      expect(applySpy2).toHaveBeenNthCalledWith(1, undefined, { verbose: false, coerce: false }, 0);
       expect(restApplySpy).toHaveBeenCalledTimes(1);
-      expect(restApplySpy).toHaveBeenNthCalledWith(1, 'bbb', { verbose: false, coerced: false }, 0);
+      expect(restApplySpy).toHaveBeenNthCalledWith(1, 'bbb', { verbose: false, coerce: false }, 0);
     });
 
     test('raises multiple issues in verbose mode', () => {
@@ -576,11 +576,11 @@ describe('ObjectShape', () => {
       expect(result).toEqual({ ok: true, value: obj });
       expect(result.value).toBe(obj);
       expect(applySpy1).toHaveBeenCalledTimes(1);
-      expect(applySpy1).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false }, 0);
+      expect(applySpy1).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerce: false }, 0);
       expect(applySpy2).toHaveBeenCalledTimes(1);
-      expect(applySpy2).toHaveBeenNthCalledWith(1, undefined, { verbose: false, coerced: false }, 0);
+      expect(applySpy2).toHaveBeenNthCalledWith(1, undefined, { verbose: false, coerce: false }, 0);
       expect(restApplySpy).toHaveBeenCalledTimes(1);
-      expect(restApplySpy).toHaveBeenNthCalledWith(1, 'bbb', { verbose: false, coerced: false }, 0);
+      expect(restApplySpy).toHaveBeenNthCalledWith(1, 'bbb', { verbose: false, coerce: false }, 0);
     });
 
     test('raises multiple issues in verbose mode', async () => {

--- a/src/test/shapes/PromiseShape.test.ts
+++ b/src/test/shapes/PromiseShape.test.ts
@@ -39,7 +39,7 @@ describe('PromiseShape', () => {
     });
 
     expect(checkMock).toHaveBeenCalledTimes(1);
-    expect(checkMock).toHaveBeenNthCalledWith(1, input, undefined, { verbose: false, coerced: false });
+    expect(checkMock).toHaveBeenNthCalledWith(1, input, undefined, { verbose: false, coerce: false });
   });
 
   test('applies unsafe checks if value shape raised issues', async () => {

--- a/src/test/shapes/SetShape.test.ts
+++ b/src/test/shapes/SetShape.test.ts
@@ -57,8 +57,8 @@ describe('SetShape', () => {
     expect(result).toEqual({ ok: true, value: set });
     expect(result.value).toBe(set);
     expect(applySpy).toHaveBeenCalledTimes(2);
-    expect(applySpy).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false }, 0);
-    expect(applySpy).toHaveBeenNthCalledWith(2, 222, { verbose: false, coerced: false }, 0);
+    expect(applySpy).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerce: false }, 0);
+    expect(applySpy).toHaveBeenNthCalledWith(2, 222, { verbose: false, coerce: false }, 0);
   });
 
   test('raises a single issue captured by the value shape', () => {
@@ -201,7 +201,7 @@ describe('SetShape', () => {
 
       await expect(setShape.tryAsync(new Set())).resolves.toEqual({ ok: true, value: new Set() });
       expect(setApplySpy).toHaveBeenCalledTimes(1);
-      expect(setApplySpy).toHaveBeenNthCalledWith(1, new Set(), { verbose: false, coerced: false }, 0);
+      expect(setApplySpy).toHaveBeenNthCalledWith(1, new Set(), { verbose: false, coerce: false }, 0);
     });
 
     test('parses values in a Set', async () => {
@@ -215,8 +215,8 @@ describe('SetShape', () => {
       expect(result).toEqual({ ok: true, value: set });
       expect(result.value).toBe(set);
       expect(applySpy).toHaveBeenCalledTimes(2);
-      expect(applySpy).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false }, 0);
-      expect(applySpy).toHaveBeenNthCalledWith(2, 222, { verbose: false, coerced: false }, 0);
+      expect(applySpy).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerce: false }, 0);
+      expect(applySpy).toHaveBeenNthCalledWith(2, 222, { verbose: false, coerce: false }, 0);
     });
 
     test('does not apply value shape if the previous value raised an issue', async () => {
@@ -237,8 +237,8 @@ describe('SetShape', () => {
       await setShape.tryAsync(set);
 
       expect(applySpy).toHaveBeenCalledTimes(2);
-      expect(applySpy).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerced: false }, 0);
-      expect(applySpy).toHaveBeenNthCalledWith(2, 222, { verbose: false, coerced: false }, 0);
+      expect(applySpy).toHaveBeenNthCalledWith(1, 111, { verbose: false, coerce: false }, 0);
+      expect(applySpy).toHaveBeenNthCalledWith(2, 222, { verbose: false, coerce: false }, 0);
     });
 
     test('returns a new set if some values were transformed', async () => {

--- a/src/test/shapes/Shape.test.ts
+++ b/src/test/shapes/Shape.test.ts
@@ -98,7 +98,7 @@ describe('Shape', () => {
       shape.parse('aaa');
 
       expect(cbMock).toHaveBeenCalledTimes(1);
-      expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', undefined, { verbose: false, coerced: false });
+      expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', undefined, { verbose: false, coerce: false });
     });
 
     test('added parameterized check is applied', () => {
@@ -108,7 +108,7 @@ describe('Shape', () => {
       shape.parse('aaa');
 
       expect(cbMock).toHaveBeenCalledTimes(1);
-      expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', 111, { verbose: false, coerced: false });
+      expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', 111, { verbose: false, coerce: false });
     });
 
     test('applies checks in the same order they were added', () => {
@@ -221,7 +221,7 @@ describe('Shape', () => {
       expect(new Shape().refine(cbMock).try('aaa')).toEqual({ ok: true, value: 'aaa' });
 
       expect(cbMock).toHaveBeenCalledTimes(1);
-      expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', { coerced: false, verbose: false });
+      expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', { coerce: false, verbose: false });
     });
 
     test('does not apply a safe predicate if the preceding check failed', () => {
@@ -647,13 +647,13 @@ describe('Shape', () => {
       shape.try('aaa');
 
       expect(applySpy).toHaveBeenCalledTimes(1);
-      expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerced: false, verbose: false }, 0);
+      expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerce: false, verbose: false }, 0);
     });
 
     test('invokes _apply with options', async () => {
       const shape = new Shape();
       const applySpy = jest.spyOn<Shape, any>(shape, '_apply');
-      const options = { coerced: true };
+      const options = { coerce: true };
 
       shape.try('aaa', options);
 
@@ -755,13 +755,13 @@ describe('Shape', () => {
       shape.parse('aaa');
 
       expect(applySpy).toHaveBeenCalledTimes(1);
-      expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerced: false, verbose: false }, 0);
+      expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerce: false, verbose: false }, 0);
     });
 
     test('invokes _apply with options', async () => {
       const shape = new Shape();
       const applySpy = jest.spyOn<Shape, any>(shape, '_apply');
-      const options = { coerced: true };
+      const options = { coerce: true };
 
       shape.parse('aaa', options);
 
@@ -805,13 +805,13 @@ describe('Shape', () => {
       shape.parseOrDefault('aaa');
 
       expect(applySpy).toHaveBeenCalledTimes(1);
-      expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerced: false, verbose: false }, 0);
+      expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerce: false, verbose: false }, 0);
     });
 
     test('invokes _apply with options', async () => {
       const shape = new Shape();
       const applySpy = jest.spyOn<Shape, any>(shape, '_apply');
-      const options = { coerced: true };
+      const options = { coerce: true };
 
       shape.parseOrDefault('aaa', 'bbb', options);
 
@@ -843,12 +843,12 @@ describe('Shape', () => {
         await asyncShape.tryAsync('aaa');
 
         expect(applySpy).toHaveBeenCalledTimes(1);
-        expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerced: false, verbose: false }, 0);
+        expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerce: false, verbose: false }, 0);
       });
 
       test('invokes _applyAsync with options', async () => {
         const applySpy = jest.spyOn<Shape, any>(asyncShape, '_applyAsync');
-        const options = { coerced: true };
+        const options = { coerce: true };
 
         await asyncShape.tryAsync('aaa', options);
 
@@ -868,12 +868,12 @@ describe('Shape', () => {
         await asyncShape.parseAsync('aaa');
 
         expect(applySpy).toHaveBeenCalledTimes(1);
-        expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerced: false, verbose: false }, 0);
+        expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerce: false, verbose: false }, 0);
       });
 
       test('invokes _applyAsync with options', async () => {
         const applySpy = jest.spyOn<Shape, any>(asyncShape, '_applyAsync');
-        const options = { coerced: true };
+        const options = { coerce: true };
 
         await asyncShape.parseAsync('aaa', options);
 
@@ -893,12 +893,12 @@ describe('Shape', () => {
         await asyncShape.parseOrDefaultAsync('aaa');
 
         expect(applySpy).toHaveBeenCalledTimes(1);
-        expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerced: false, verbose: false }, 0);
+        expect(applySpy).toHaveBeenNthCalledWith(1, 'aaa', { coerce: false, verbose: false }, 0);
       });
 
       test('invokes _applyAsync with options', async () => {
         const applySpy = jest.spyOn<Shape, any>(asyncShape, '_applyAsync');
-        const options = { coerced: true };
+        const options = { coerce: true };
 
         await asyncShape.parseOrDefaultAsync('aaa', 'bbb', options);
 
@@ -924,7 +924,7 @@ describe('TransformShape', () => {
     expect(shape.parse('aaa')).toBe(111);
 
     expect(cbMock).toHaveBeenCalledTimes(1);
-    expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false });
+    expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerce: false });
   });
 
   test('callback can throw a ValidationError', () => {
@@ -952,7 +952,7 @@ describe('TransformShape', () => {
     new TransformShape(() => 111).check(cbMock).parse('aaa');
 
     expect(cbMock).toHaveBeenCalledTimes(1);
-    expect(cbMock).toHaveBeenNthCalledWith(1, 111, undefined, { verbose: false, coerced: false });
+    expect(cbMock).toHaveBeenNthCalledWith(1, 111, undefined, { verbose: false, coerce: false });
   });
 
   describe('async', () => {
@@ -964,7 +964,7 @@ describe('TransformShape', () => {
       await expect(shape.parseAsync('aaa')).resolves.toBe(111);
 
       expect(cbMock).toHaveBeenCalledTimes(1);
-      expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false });
+      expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerce: false });
     });
 
     test('transform callback can reject with ValidationError instances', async () => {
@@ -997,10 +997,10 @@ describe('PipeShape', () => {
     expect(pipeShape.parse('aaa')).toBe('aaa');
 
     expect(applySpy1).toHaveBeenCalledTimes(1);
-    expect(applySpy1).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false }, 0);
+    expect(applySpy1).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerce: false }, 0);
 
     expect(applySpy2).toHaveBeenCalledTimes(1);
-    expect(applySpy2).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false }, 0);
+    expect(applySpy2).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerce: false }, 0);
   });
 
   test('does not apply the output shape if the input shape parsing failed', () => {
@@ -1031,7 +1031,7 @@ describe('PipeShape', () => {
     new PipeShape(new Shape(), new Shape()).check(cbMock).parse('aaa');
 
     expect(cbMock).toHaveBeenCalledTimes(1);
-    expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', undefined, { verbose: false, coerced: false });
+    expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', undefined, { verbose: false, coerce: false });
   });
 
   describe('deepPartial', () => {
@@ -1066,10 +1066,10 @@ describe('PipeShape', () => {
       await expect(pipeShape.parseAsync('aaa')).resolves.toBe('aaa');
 
       expect(applySpy1).toHaveBeenCalledTimes(1);
-      expect(applySpy1).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false }, 0);
+      expect(applySpy1).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerce: false }, 0);
 
       expect(applySpy2).toHaveBeenCalledTimes(1);
-      expect(applySpy2).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerced: false }, 0);
+      expect(applySpy2).toHaveBeenNthCalledWith(1, 'aaa', { verbose: false, coerce: false }, 0);
     });
 
     test('does not apply the output shape if the input shape parsing failed', async () => {
@@ -1100,7 +1100,7 @@ describe('PipeShape', () => {
       await new PipeShape(asyncShape, new Shape()).check(cbMock).parseAsync('aaa');
 
       expect(cbMock).toHaveBeenCalledTimes(1);
-      expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', undefined, { verbose: false, coerced: false });
+      expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', undefined, { verbose: false, coerce: false });
     });
   });
 });
@@ -1146,7 +1146,7 @@ describe('ReplaceLiteralShape', () => {
     new ReplaceLiteralShape(new Shape(), 111, 222).check(cbMock).try(111);
 
     expect(cbMock).toHaveBeenCalledTimes(1);
-    expect(cbMock).toHaveBeenNthCalledWith(1, 222, undefined, { coerced: false, verbose: false });
+    expect(cbMock).toHaveBeenNthCalledWith(1, 222, undefined, { coerce: false, verbose: false });
   });
 
   describe('inputs', () => {
@@ -1200,7 +1200,7 @@ describe('ReplaceLiteralShape', () => {
       await new ReplaceLiteralShape(asyncShape, 111, 222).check(cbMock).tryAsync(111);
 
       expect(cbMock).toHaveBeenCalledTimes(1);
-      expect(cbMock).toHaveBeenNthCalledWith(1, 222, undefined, { coerced: false, verbose: false });
+      expect(cbMock).toHaveBeenNthCalledWith(1, 222, undefined, { coerce: false, verbose: false });
     });
   });
 });
@@ -1248,7 +1248,7 @@ describe('DenyLiteralShape', () => {
     new DenyLiteralShape(new Shape(), 111).check(cbMock).parse('aaa');
 
     expect(cbMock).toHaveBeenCalledTimes(1);
-    expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', undefined, { verbose: false, coerced: false });
+    expect(cbMock).toHaveBeenNthCalledWith(1, 'aaa', undefined, { verbose: false, coerce: false });
   });
 
   test('does not apply checks if shape raises an issue', () => {
@@ -1339,7 +1339,7 @@ describe('CatchShape', () => {
       1,
       111,
       [{ code: CODE_TYPE, input: 111, message: MESSAGE_STRING_TYPE, param: TYPE_STRING }],
-      { coerced: false, verbose: false }
+      { coerce: false, verbose: false }
     );
   });
 

--- a/src/test/shapes/StringShape.test.ts
+++ b/src/test/shapes/StringShape.test.ts
@@ -95,7 +95,7 @@ describe('StringShape', () => {
     expect(new StringShape().coerce().parse(111)).toBe('111');
     expect(new StringShape().coerce().parse(true)).toBe('true');
     expect(new StringShape().coerce().parse(['aaa'])).toBe('aaa');
-    expect(new StringShape().parse(['aaa'], { coerced: true })).toBe('aaa');
+    expect(new StringShape().parse(['aaa'], { coerce: true })).toBe('aaa');
   });
 
   test('raises an issue if coercion fails', () => {


### PR DESCRIPTION
Renamed `ApplyOptions.coerced` to `coerce` and `CoercibleShape.isCoerced` to `isCoercing` since the passive voice wasn't a good choice here after all.
