### PR TITLE
Use Input and Output helper types in source code

### DIFF
--- a/src/main/dsl/lazy.ts
+++ b/src/main/dsl/lazy.ts
@@ -1,6 +1,5 @@
 import { identity } from '../internal';
-import { AnyShape, LazyShape } from '../shape';
-import { INPUT } from '../shape/Shape';
+import { AnyShape, Input, LazyShape } from '../shape';
 
 /**
  * Creates the shape that resolves the underlying shape on-demand.
@@ -11,6 +10,6 @@ import { INPUT } from '../shape/Shape';
  */
 export function lazy<ProvidedShape extends AnyShape>(
   shapeProvider: () => ProvidedShape
-): LazyShape<ProvidedShape, ProvidedShape[INPUT]> {
+): LazyShape<ProvidedShape, Input<ProvidedShape>> {
   return new LazyShape(shapeProvider, identity);
 }

--- a/src/main/shape/FunctionShape.ts
+++ b/src/main/shape/FunctionShape.ts
@@ -14,7 +14,7 @@ import { TYPE_FUNCTION } from '../Type';
 import { ApplyOptions, ConstraintOptions, Message, ParseOptions } from '../types';
 import { createIssueFactory } from '../utils';
 import { ValidationError } from '../ValidationError';
-import { AnyShape, defaultApplyOptions, INPUT, OUTPUT, Result, Shape } from './Shape';
+import { AnyShape, defaultApplyOptions, Input, INPUT, Output, OUTPUT, Result, Shape } from './Shape';
 
 type ShapeValue<
   Shape extends AnyShape | null | undefined,
@@ -37,8 +37,8 @@ export class FunctionShape<
   ReturnShape extends AnyShape | null,
   ThisShape extends AnyShape | null
 > extends Shape<
-  (this: ShapeValue<ThisShape, OUTPUT>, ...args: ArgsShape[OUTPUT]) => ShapeValue<ReturnShape, INPUT>,
-  (this: ShapeValue<ThisShape, INPUT>, ...args: ArgsShape[INPUT]) => ShapeValue<ReturnShape, OUTPUT>
+  (this: ShapeValue<ThisShape, OUTPUT>, ...args: Output<ArgsShape>) => ShapeValue<ReturnShape, INPUT>,
+  (this: ShapeValue<ThisShape, INPUT>, ...args: Input<ArgsShape>) => ShapeValue<ReturnShape, OUTPUT>
 > {
   /**
    * `true` if input functions are wrapped during parsing to ensure runtime signature type-safety, or `false` otherwise.
@@ -142,13 +142,13 @@ export class FunctionShape<
    * @template F The function to wrap.
    */
   ensureSignature<
-    F extends (this: ShapeValue<ThisShape, OUTPUT>, ...args: ArgsShape[OUTPUT]) => ShapeValue<ReturnShape, INPUT>
+    F extends (this: ShapeValue<ThisShape, OUTPUT>, ...args: Output<ArgsShape>) => ShapeValue<ReturnShape, INPUT>
   >(
     fn: F,
     options?: Readonly<ParseOptions>
   ): (
     this: ShapeValue<ThisShape, INPUT, ThisType<F>>,
-    ...args: ArgsShape[INPUT]
+    ...args: Input<ArgsShape>
   ) => ShapeValue<ReturnShape, OUTPUT, ReturnType<F>>;
 
   ensureSignature(fn: Function, options = this._parseOptions || defaultApplyOptions) {
@@ -188,14 +188,14 @@ export class FunctionShape<
   ensureAsyncSignature<
     F extends (
       this: ShapeValue<ThisShape, OUTPUT>,
-      ...args: ArgsShape[OUTPUT]
+      ...args: Output<ArgsShape>
     ) => Awaitable<ShapeValue<ReturnShape, INPUT>>
   >(
     fn: F,
     options?: Readonly<ParseOptions>
   ): (
     this: ShapeValue<ThisShape, INPUT, ThisType<F>>,
-    ...args: ArgsShape[INPUT]
+    ...args: Input<ArgsShape>
   ) => Promisify<ShapeValue<ReturnShape, OUTPUT, ReturnType<F>>>;
 
   ensureAsyncSignature(fn: Function, options = this._parseOptions || defaultApplyOptions) {
@@ -240,7 +240,7 @@ export class FunctionShape<
     input: any,
     options: ApplyOptions,
     nonce: number
-  ): Result<(this: ShapeValue<ThisShape, INPUT>, ...args: ArgsShape[INPUT]) => ShapeValue<ReturnShape, OUTPUT>> {
+  ): Result<(this: ShapeValue<ThisShape, INPUT>, ...args: Input<ArgsShape>) => ShapeValue<ReturnShape, OUTPUT>> {
     const { _applyChecks } = this;
 
     let issues = null;

--- a/src/main/shape/IntersectionShape.ts
+++ b/src/main/shape/IntersectionShape.ts
@@ -15,7 +15,7 @@ import {
 import { getTypeOf, TYPE_ARRAY, TYPE_DATE, TYPE_OBJECT } from '../Type';
 import { ApplyOptions, ConstraintOptions, Issue, Message } from '../types';
 import { createIssueFactory } from '../utils';
-import { AnyShape, DeepPartialProtocol, DeepPartialShape, INPUT, NEVER, OUTPUT, Result, Shape } from './Shape';
+import { AnyShape, DeepPartialProtocol, DeepPartialShape, Input, NEVER, Output, Result, Shape } from './Shape';
 
 // prettier-ignore
 /**
@@ -35,7 +35,7 @@ type DeepPartialIntersectionShape<Shapes extends readonly AnyShape[]> = Intersec
  * @group Shapes
  */
 export class IntersectionShape<Shapes extends readonly AnyShape[]>
-  extends Shape<Intersect<Shapes[number]>[INPUT], Intersect<Shapes[number]>[OUTPUT]>
+  extends Shape<Input<Intersect<Shapes[number]>>, Output<Intersect<Shapes[number]>>>
   implements DeepPartialProtocol<DeepPartialIntersectionShape<Shapes>>
 {
   /**
@@ -99,7 +99,7 @@ export class IntersectionShape<Shapes extends readonly AnyShape[]>
     return distributeTypes(this.shapes.map(getShapeInputs));
   }
 
-  protected _apply(input: any, options: ApplyOptions, nonce: number): Result<Intersect<Shapes[number]>[OUTPUT]> {
+  protected _apply(input: any, options: ApplyOptions, nonce: number): Result<Output<Intersect<Shapes[number]>>> {
     const { shapes } = this;
     const shapesLength = shapes.length;
 
@@ -141,7 +141,7 @@ export class IntersectionShape<Shapes extends readonly AnyShape[]>
     input: any,
     options: ApplyOptions,
     nonce: number
-  ): Promise<Result<Intersect<Shapes[number]>[OUTPUT]>> {
+  ): Promise<Result<Output<Intersect<Shapes[number]>>>> {
     return new Promise(resolve => {
       const { shapes } = this;
       const shapesLength = shapes.length;
@@ -193,7 +193,7 @@ export class IntersectionShape<Shapes extends readonly AnyShape[]>
     input: any,
     outputs: any[] | null,
     options: ApplyOptions
-  ): Result<Intersect<Shapes[number]>[OUTPUT]> {
+  ): Result<Output<Intersect<Shapes[number]>>> {
     const { shapes, _applyChecks } = this;
 
     let output = input;

--- a/src/main/shape/LazyShape.ts
+++ b/src/main/shape/LazyShape.ts
@@ -1,7 +1,7 @@
 import { ERROR_SHAPE_EXPECTED } from '../constants';
 import { captureIssues, copyUnsafeChecks, identity, isArray, ok, toDeepPartialShape } from '../internal';
 import { ApplyOptions, Literal } from '../types';
-import { AnyShape, DeepPartialProtocol, DeepPartialShape, INPUT, OUTPUT, Result, Shape } from './Shape';
+import { AnyShape, DeepPartialProtocol, DeepPartialShape, Input, Output, Result, Shape } from './Shape';
 
 /**
  * Lazily loads a shape using the provider callback.
@@ -11,7 +11,7 @@ import { AnyShape, DeepPartialProtocol, DeepPartialShape, INPUT, OUTPUT, Result,
  * @group Shapes
  */
 export class LazyShape<ProvidedShape extends AnyShape, Pointer>
-  extends Shape<ProvidedShape[INPUT], ProvidedShape[OUTPUT] | Pointer>
+  extends Shape<Input<ProvidedShape>, Output<ProvidedShape> | Pointer>
   implements DeepPartialProtocol<LazyShape<DeepPartialShape<ProvidedShape>, Pointer>>
 {
   /**
@@ -42,7 +42,7 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
     /**
      * The provider callback that returns the value that is used instead of a circular reference.
      */
-    readonly pointerProvider: (value: ProvidedShape[INPUT], options: Readonly<ApplyOptions>) => Pointer
+    readonly pointerProvider: (value: Input<ProvidedShape>, options: Readonly<ApplyOptions>) => Pointer
   ) {
     super();
 
@@ -76,7 +76,7 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
     return this.shape.at(key);
   }
 
-  deepPartial(): LazyShape<DeepPartialShape<ProvidedShape>, DeepPartialShape<ProvidedShape>[INPUT]> {
+  deepPartial(): LazyShape<DeepPartialShape<ProvidedShape>, Input<DeepPartialShape<ProvidedShape>>> {
     const { _cachingShapeProvider } = this;
 
     return copyUnsafeChecks(this, new LazyShape(() => toDeepPartialShape(_cachingShapeProvider()), identity));
@@ -91,7 +91,7 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
    * @returns The clone of the shape.
    */
   circular<Pointer extends Literal>(
-    pointer: Pointer | ((value: ProvidedShape[INPUT], options: Readonly<ApplyOptions>) => Pointer)
+    pointer: Pointer | ((value: Input<ProvidedShape>, options: Readonly<ApplyOptions>) => Pointer)
   ): LazyShape<ProvidedShape, Pointer> {
     return copyUnsafeChecks(
       this,
@@ -113,7 +113,7 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
     return shape;
   }
 
-  protected _apply(input: unknown, options: ApplyOptions, nonce: number): Result<ProvidedShape[OUTPUT] | Pointer> {
+  protected _apply(input: unknown, options: ApplyOptions, nonce: number): Result<Output<ProvidedShape> | Pointer> {
     const { _stackMap } = this;
 
     let stack = _stackMap.get(nonce);
@@ -148,7 +148,7 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
     input: unknown,
     options: ApplyOptions,
     nonce: number
-  ): Promise<Result<ProvidedShape[OUTPUT] | Pointer>> {
+  ): Promise<Result<Output<ProvidedShape> | Pointer>> {
     const { _stackMap } = this;
 
     let stack = _stackMap.get(nonce);
@@ -193,7 +193,7 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
     result: Result,
     input: unknown,
     options: ApplyOptions
-  ): Result<ProvidedShape[OUTPUT] | Pointer> {
+  ): Result<Output<ProvidedShape> | Pointer> {
     const { _applyChecks } = this;
 
     let output = input;

--- a/src/main/shape/MapShape.ts
+++ b/src/main/shape/MapShape.ts
@@ -20,10 +20,10 @@ import {
   AnyShape,
   DeepPartialProtocol,
   DeepPartialShape,
-  INPUT,
+  Input,
   NEVER,
   OptionalDeepPartialShape,
-  OUTPUT,
+  Output,
   Result,
 } from './Shape';
 
@@ -36,8 +36,8 @@ import {
  */
 export class MapShape<KeyShape extends AnyShape, ValueShape extends AnyShape>
   extends CoercibleShape<
-    Map<KeyShape[INPUT], ValueShape[INPUT]>,
-    Map<KeyShape[OUTPUT], ValueShape[OUTPUT]>,
+    Map<Input<KeyShape>, Input<ValueShape>>,
+    Map<Output<KeyShape>, Output<ValueShape>>,
     [unknown, unknown][]
   >
   implements DeepPartialProtocol<MapShape<DeepPartialShape<KeyShape>, OptionalDeepPartialShape<ValueShape>>>
@@ -105,7 +105,7 @@ export class MapShape<KeyShape extends AnyShape, ValueShape extends AnyShape>
     input: any,
     options: ApplyOptions,
     nonce: number
-  ): Result<Map<KeyShape[OUTPUT], ValueShape[OUTPUT]>> {
+  ): Result<Map<Output<KeyShape>, Output<ValueShape>>> {
     let changed = false;
     let entries;
 
@@ -182,7 +182,7 @@ export class MapShape<KeyShape extends AnyShape, ValueShape extends AnyShape>
     input: any,
     options: ApplyOptions,
     nonce: number
-  ): Promise<Result<Map<KeyShape[OUTPUT], ValueShape[OUTPUT]>>> {
+  ): Promise<Result<Map<Output<KeyShape>, Output<ValueShape>>>> {
     return new Promise(resolve => {
       let changed = false;
       let entries: [unknown, unknown][];

--- a/src/main/shape/SetShape.ts
+++ b/src/main/shape/SetShape.ts
@@ -14,7 +14,7 @@ import { TYPE_ARRAY, TYPE_OBJECT, TYPE_SET } from '../Type';
 import { ApplyOptions, ConstraintOptions, Issue, Message } from '../types';
 import { createIssueFactory } from '../utils';
 import { CoercibleShape } from './CoercibleShape';
-import { AnyShape, DeepPartialProtocol, INPUT, NEVER, OptionalDeepPartialShape, OUTPUT, Result } from './Shape';
+import { AnyShape, DeepPartialProtocol, Input, NEVER, OptionalDeepPartialShape, Output, Result } from './Shape';
 
 /**
  * The shape of a `Set` instance.
@@ -23,7 +23,7 @@ import { AnyShape, DeepPartialProtocol, INPUT, NEVER, OptionalDeepPartialShape, 
  * @group Shapes
  */
 export class SetShape<ValueShape extends AnyShape>
-  extends CoercibleShape<Set<ValueShape[INPUT]>, Set<ValueShape[OUTPUT]>, unknown[]>
+  extends CoercibleShape<Set<Input<ValueShape>>, Set<Output<ValueShape>>, unknown[]>
   implements DeepPartialProtocol<SetShape<OptionalDeepPartialShape<ValueShape>>>
 {
   /**
@@ -76,7 +76,7 @@ export class SetShape<ValueShape extends AnyShape>
     }
   }
 
-  protected _apply(input: any, options: ApplyOptions, nonce: number): Result<Set<ValueShape[OUTPUT]>> {
+  protected _apply(input: any, options: ApplyOptions, nonce: number): Result<Set<Output<ValueShape>>> {
     let changed = false;
     let values;
     let issues = null;
@@ -124,7 +124,7 @@ export class SetShape<ValueShape extends AnyShape>
     return issues;
   }
 
-  protected _applyAsync(input: any, options: ApplyOptions, nonce: number): Promise<Result<Set<ValueShape[OUTPUT]>>> {
+  protected _applyAsync(input: any, options: ApplyOptions, nonce: number): Promise<Result<Set<Output<ValueShape>>>> {
     return new Promise(resolve => {
       let changed = false;
       let values: unknown[];

--- a/src/main/shape/UnionShape.ts
+++ b/src/main/shape/UnionShape.ts
@@ -15,7 +15,7 @@ import { getTypeOf, TYPE_UNKNOWN } from '../Type';
 import { ApplyOptions, ConstraintOptions, Issue, Message } from '../types';
 import { createIssueFactory } from '../utils';
 import { ObjectShape } from './ObjectShape';
-import { AnyShape, DeepPartialProtocol, DeepPartialShape, INPUT, OUTPUT, Result, Shape } from './Shape';
+import { AnyShape, DeepPartialProtocol, DeepPartialShape, Input, Output, Result, Shape } from './Shape';
 
 /**
  * Returns the array of shapes that are applicable to the input.
@@ -33,7 +33,7 @@ type DeepPartialUnionShape<Shapes extends readonly AnyShape[]> = UnionShape<{
  * @group Shapes
  */
 export class UnionShape<Shapes extends readonly AnyShape[]>
-  extends Shape<Shapes[number][INPUT], Shapes[number][OUTPUT]>
+  extends Shape<Input<Shapes[number]>, Output<Shapes[number]>>
   implements DeepPartialProtocol<DeepPartialUnionShape<Shapes>>
 {
   /**
@@ -107,7 +107,7 @@ export class UnionShape<Shapes extends readonly AnyShape[]>
     return Array.prototype.concat.apply([], this.shapes.map(getShapeInputs));
   }
 
-  protected _apply(input: unknown, options: ApplyOptions, nonce: number): Result<Shapes[number][OUTPUT]> {
+  protected _apply(input: unknown, options: ApplyOptions, nonce: number): Result<Output<Shapes[number]>> {
     const { _applyChecks } = this;
 
     let result = null;
@@ -151,7 +151,7 @@ export class UnionShape<Shapes extends readonly AnyShape[]>
     return issues;
   }
 
-  protected _applyAsync(input: unknown, options: ApplyOptions, nonce: number): Promise<Result<Shapes[number][OUTPUT]>> {
+  protected _applyAsync(input: unknown, options: ApplyOptions, nonce: number): Promise<Result<Output<Shapes[number]>>> {
     return new Promise(resolve => {
       const { _applyChecks } = this;
 

--- a/src/main/shape/index.ts
+++ b/src/main/shape/index.ts
@@ -35,6 +35,8 @@ export {
   Result,
   Shape,
   TransformShape,
+  INPUT,
+  OUTPUT,
 } from './Shape';
 export { StringShape } from './StringShape';
 export { SymbolShape } from './SymbolShape';

--- a/src/test/dsl/and.test-d.ts
+++ b/src/test/dsl/and.test-d.ts
@@ -1,8 +1,9 @@
 import * as d from 'doubter';
+import { OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
 expectType<{ key1: string } & { key2: number }>(
-  d.and([d.object({ key1: d.string() }), d.object({ key2: d.number() })]).__output
+  d.and([d.object({ key1: d.string() }), d.object({ key2: d.number() })])[OUTPUT]
 );
 
 expectType<{ aaa?: string } & { bbb?: number }>(
@@ -15,7 +16,7 @@ expectType<{ aaa?: string } & { bbb?: number }>(
         bbb: d.number(),
       }),
     ])
-    .deepPartial().__output
+    .deepPartial()[OUTPUT]
 );
 
 expectType<{ aaa?: Array<string | undefined> } & { bbb?: number }>(
@@ -28,5 +29,5 @@ expectType<{ aaa?: Array<string | undefined> } & { bbb?: number }>(
         bbb: d.number(),
       }),
     ])
-    .deepPartial().__output
+    .deepPartial()[OUTPUT]
 );

--- a/src/test/dsl/any.test-d.ts
+++ b/src/test/dsl/any.test-d.ts
@@ -1,37 +1,38 @@
 import * as d from 'doubter';
+import { INPUT, OUTPUT } from 'doubter';
 import { expectNotType, expectType } from 'tsd';
 
-expectType<111>(d.any((value): value is 111 => true).__input);
+expectType<111>(d.any((value): value is 111 => true)[INPUT]);
 
-expectType<111>(d.any((value): value is 111 => true).__output);
+expectType<111>(d.any((value): value is 111 => true)[OUTPUT]);
 
-expectType<string>(d.any<string>().__input);
+expectType<string>(d.any<string>()[INPUT]);
 
-expectType<string>(d.any<string>().__output);
+expectType<string>(d.any<string>()[OUTPUT]);
 
-expectType<string>(d.any<string>(() => true).__input);
+expectType<string>(d.any<string>(() => true)[INPUT]);
 
-expectType<string>(d.any<string>(() => true).__output);
+expectType<string>(d.any<string>(() => true)[OUTPUT]);
 
 // refine()
 
-expectType<any>(d.any().refine((value: unknown): value is number => true).__input);
+expectType<any>(d.any().refine((value: unknown): value is number => true)[INPUT]);
 
-expectType<number>(d.any().refine((value: unknown): value is number => true).__output);
+expectType<number>(d.any().refine((value: unknown): value is number => true)[OUTPUT]);
 
 // ReplaceLiteralShape
 
-expectType<string | null>(d.any<string>().nullable().__output);
+expectType<string | null>(d.any<string>().nullable()[OUTPUT]);
 
-expectType<string | 111>(d.any<string>().nullable(111).__output);
+expectType<string | 111>(d.any<string>().nullable(111)[OUTPUT]);
 
-expectType<111 | 333>(d.any<111 | 222>().replace(222, 333).__output);
+expectType<111 | 333>(d.any<111 | 222>().replace(222, 333)[OUTPUT]);
 
-expectType<111 | 222 | 333>(d.any<111 | 222>().replace(222 as number, 333).__output);
+expectType<111 | 222 | 333>(d.any<111 | 222>().replace(222 as number, 333)[OUTPUT]);
 
-expectType<number>(d.any<111 | 222>().replace(NaN, 333).__input);
+expectType<number>(d.any<111 | 222>().replace(NaN, 333)[INPUT]);
 
-expectType<111 | 222 | 333>(d.any<111 | 222>().replace(NaN, 333).__output);
+expectType<111 | 222 | 333>(d.any<111 | 222>().replace(NaN, 333)[OUTPUT]);
 
 // parse()
 
@@ -41,83 +42,83 @@ expectType<string | true>(d.any<string>().parseOrDefault(111, true));
 
 // CatchShape
 
-expectType<number | undefined>(d.number().catch().__output);
+expectType<number | undefined>(d.number().catch()[OUTPUT]);
 
-expectType<number | 'aaa'>(d.number().catch('aaa').__output);
+expectType<number | 'aaa'>(d.number().catch('aaa')[OUTPUT]);
 
-expectType<number | 'aaa'>(d.number().catch(() => 'aaa').__output);
+expectType<number | 'aaa'>(d.number().catch(() => 'aaa')[OUTPUT]);
 
 // deepPartial()
 
 // TransformShape is opaque for deepPartial
 expectType<{ aaa?: { bbb: number } }>(
-  d.object({ aaa: d.object({ bbb: d.number() }).transform(value => value) }).deepPartial().__output
+  d.object({ aaa: d.object({ bbb: d.number() }).transform(value => value) }).deepPartial()[OUTPUT]
 );
 
 expectType<{ aaa?: string }>(
   d
     .object({ aaa: d.string().transform(parseFloat) })
     .to(d.object({ aaa: d.number() }))
-    .deepPartial().__input
+    .deepPartial()[INPUT]
 );
 
 expectType<{ aaa?: number }>(
   d
     .object({ aaa: d.string().transform(parseFloat) })
     .to(d.object({ aaa: d.number() }))
-    .deepPartial().__output
+    .deepPartial()[OUTPUT]
 );
 
 expectType<{ aaa?: string }>(
   d
     .or([d.object({ aaa: d.string() }), d.const(111)])
     .deny(111)
-    .deepPartial().__output
+    .deepPartial()[OUTPUT]
 );
 
-expectType<{ aaa?: string } | undefined>(d.object({ aaa: d.string() }).catch().deepPartial().__output);
+expectType<{ aaa?: string } | undefined>(d.object({ aaa: d.string() }).catch().deepPartial()[OUTPUT]);
 
-expectType<{ aaa?: string } | 111>(d.object({ aaa: d.string() }).catch(111).deepPartial().__output);
+expectType<{ aaa?: string } | 111>(d.object({ aaa: d.string() }).catch(111).deepPartial()[OUTPUT]);
 
 // BrandShape
 
-expectType<d.Branded<string, 'foo'>>(d.string().brand<'foo'>().__output);
+expectType<d.Branded<string, 'foo'>>(d.string().brand<'foo'>()[OUTPUT]);
 
 const brandShape = d.any<string>().brand();
 
-expectType<d.Output<typeof brandShape>>(brandShape.__output);
+expectType<d.Output<typeof brandShape>>(brandShape[OUTPUT]);
 
 expectType<d.Output<typeof brandShape>>(brandShape.parse('aaa'));
 
 expectNotType<d.Output<typeof brandShape>>('aaa');
 
-expectNotType<d.Output<typeof brandShape>>(d.any<string>().brand<'bbb'>().__output);
+expectNotType<d.Output<typeof brandShape>>(d.any<string>().brand<'bbb'>()[OUTPUT]);
 
 // deepPartial is visible on branded shapes
-expectType<{ aaa?: string }>(d.object({ aaa: d.string() }).brand().deepPartial().__output);
+expectType<{ aaa?: string }>(d.object({ aaa: d.string() }).brand().deepPartial()[OUTPUT]);
 
 // Branded shapes are transparent for deepPartial
-expectType<{ aaa?: { bbb?: string } }>(d.object({ aaa: d.object({ bbb: d.string() }).brand() }).deepPartial().__output);
+expectType<{ aaa?: { bbb?: string } }>(d.object({ aaa: d.object({ bbb: d.string() }).brand() }).deepPartial()[OUTPUT]);
 
 // not()
 
-expectType<111 | 222>(d.enum([111, 222]).not(d.number()).__input);
+expectType<111 | 222>(d.enum([111, 222]).not(d.number())[INPUT]);
 
-expectType<111 | 222>(d.enum([111, 222]).not(d.number()).__output);
+expectType<111 | 222>(d.enum([111, 222]).not(d.number())[OUTPUT]);
 
-expectType<111 | 222>(d.enum([111, 222]).not(d.const(222)).__input);
+expectType<111 | 222>(d.enum([111, 222]).not(d.const(222))[INPUT]);
 
-expectType<111 | 222>(d.enum([111, 222]).not(d.const(222)).__output);
+expectType<111 | 222>(d.enum([111, 222]).not(d.const(222))[OUTPUT]);
 
 // exclude()
 
-expectType<111 | 222>(d.enum([111, 222]).exclude(d.number()).__input);
+expectType<111 | 222>(d.enum([111, 222]).exclude(d.number())[INPUT]);
 
-expectType<never>(d.enum([111, 222]).exclude(d.number()).__output);
+expectType<never>(d.enum([111, 222]).exclude(d.number())[OUTPUT]);
 
-expectType<111 | 222>(d.enum([111, 222]).exclude(d.const(222)).__input);
+expectType<111 | 222>(d.enum([111, 222]).exclude(d.const(222))[INPUT]);
 
-expectType<111>(d.enum([111, 222]).exclude(d.const(222)).__output);
+expectType<111>(d.enum([111, 222]).exclude(d.const(222))[OUTPUT]);
 
 // parseOrDefault()
 

--- a/src/test/dsl/array.test-d.ts
+++ b/src/test/dsl/array.test-d.ts
@@ -1,14 +1,15 @@
 import * as d from 'doubter';
+import { INPUT, OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
-expectType<any[]>(d.array().__input);
+expectType<any[]>(d.array()[INPUT]);
 
-expectType<any[]>(d.array().__output);
+expectType<any[]>(d.array()[OUTPUT]);
 
-expectType<111[]>(d.array(d.const(111)).__input);
+expectType<111[]>(d.array(d.const(111))[INPUT]);
 
-expectType<111[]>(d.array(d.const(111)).__output);
+expectType<111[]>(d.array(d.const(111))[OUTPUT]);
 
-expectType<Array<number | undefined>>(d.array(d.number()).deepPartial().__output);
+expectType<Array<number | undefined>>(d.array(d.number()).deepPartial()[OUTPUT]);
 
-expectType<Array<{ aaa?: number } | undefined>>(d.array(d.object({ aaa: d.number() })).deepPartial().__output);
+expectType<Array<{ aaa?: number } | undefined>>(d.array(d.object({ aaa: d.number() })).deepPartial()[OUTPUT]);

--- a/src/test/dsl/const.test-d.ts
+++ b/src/test/dsl/const.test-d.ts
@@ -1,4 +1,5 @@
 import * as d from 'doubter';
+import { OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
-expectType<111>(d.const(111).__output);
+expectType<111>(d.const(111)[OUTPUT]);

--- a/src/test/dsl/enum.test-d.ts
+++ b/src/test/dsl/enum.test-d.ts
@@ -1,17 +1,18 @@
 import * as d from 'doubter';
+import { OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
-expectType<111 | 'aaa'>(d.enum([111, 'aaa']).__output);
+expectType<111 | 'aaa'>(d.enum([111, 'aaa'])[OUTPUT]);
 
 enum FooEnum {
   AAA,
   BBB,
 }
 
-expectType<FooEnum.AAA | FooEnum.BBB>(d.enum(FooEnum).__output);
+expectType<FooEnum.AAA | FooEnum.BBB>(d.enum(FooEnum)[OUTPUT]);
 
-expectType<'aaa' | 'bbb'>(d.enum({ AAA: 'aaa', BBB: 'bbb' } as const).__output);
+expectType<'aaa' | 'bbb'>(d.enum({ AAA: 'aaa', BBB: 'bbb' } as const)[OUTPUT]);
 
-expectType<111 | 'aaa' | 333>(d.enum([111, 222, 333]).replace(222, 'aaa').__output);
+expectType<111 | 'aaa' | 333>(d.enum([111, 222, 333]).replace(222, 'aaa')[OUTPUT]);
 
-expectType<111 | 333>(d.enum([111, 222, 333]).deny(222).__output);
+expectType<111 | 333>(d.enum([111, 222, 333]).deny(222)[OUTPUT]);

--- a/src/test/dsl/finite.test-d.ts
+++ b/src/test/dsl/finite.test-d.ts
@@ -1,6 +1,7 @@
 import * as d from 'doubter';
+import { OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
-expectType<number>(d.finite().__output);
+expectType<number>(d.finite()[OUTPUT]);
 
-expectType<number>(d.finite().nan().__output);
+expectType<number>(d.finite().nan()[OUTPUT]);

--- a/src/test/dsl/function.test-d.ts
+++ b/src/test/dsl/function.test-d.ts
@@ -1,59 +1,60 @@
 import * as d from 'doubter';
+import { INPUT, OUTPUT } from 'doubter';
 import { expectNotType, expectType } from 'tsd';
 
 // Alias
 
-expectType<() => any>(d.function().__output);
+expectType<() => any>(d.function()[OUTPUT]);
 
 // Arguments
 
-expectType<() => any>(d.fn().__output);
+expectType<() => any>(d.fn()[OUTPUT]);
 
-expectType<(arg: string) => any>(d.fn([d.string()]).__output);
+expectType<(arg: string) => any>(d.fn([d.string()])[OUTPUT]);
 
-expectType<(arg1: string, arg2: number) => any>(d.fn([d.string(), d.number()]).__output);
+expectType<(arg1: string, arg2: number) => any>(d.fn([d.string(), d.number()])[OUTPUT]);
 
-expectType<(arg: string) => any>(d.fn(d.tuple([d.string()])).__output);
+expectType<(arg: string) => any>(d.fn(d.tuple([d.string()]))[OUTPUT]);
 
-expectType<(arg1: string, arg2: number) => any>(d.fn(d.tuple([d.string(), d.number()])).__output);
+expectType<(arg1: string, arg2: number) => any>(d.fn(d.tuple([d.string(), d.number()]))[OUTPUT]);
 
 expectType<(arg1: string, arg2: number, ...args: boolean[]) => any>(
-  d.fn(d.tuple([d.string(), d.number()]).rest(d.boolean())).__output
+  d.fn(d.tuple([d.string(), d.number()]).rest(d.boolean()))[OUTPUT]
 );
 
-expectType<(...args: any[]) => any>(d.fn(d.array()).__output);
+expectType<(...args: any[]) => any>(d.fn(d.array())[OUTPUT]);
 
-expectType<(...args: string[]) => any>(d.fn(d.array(d.string())).__output);
+expectType<(...args: string[]) => any>(d.fn(d.array(d.string()))[OUTPUT]);
 
 expectType<(...args: string[] | [string, number]) => any>(
-  d.fn(d.or([d.array(d.string()), d.tuple([d.string(), d.number()])])).__output
+  d.fn(d.or([d.array(d.string()), d.tuple([d.string(), d.number()])]))[OUTPUT]
 );
 
-expectType<(arg: string) => any>(d.fn([d.string().transform(parseFloat)]).__output);
+expectType<(arg: string) => any>(d.fn([d.string().transform(parseFloat)])[OUTPUT]);
 
-expectType<(arg: number) => any>(d.fn([d.string().transform(parseFloat)]).__input);
+expectType<(arg: number) => any>(d.fn([d.string().transform(parseFloat)])[INPUT]);
 
-expectType<(arg: number) => any>(d.fn([d.string().transform(parseFloat)]).__input);
+expectType<(arg: number) => any>(d.fn([d.string().transform(parseFloat)])[INPUT]);
 
-expectType<(arg: string) => any>(d.fn([d.string().transform(parseFloat)]).__output);
+expectType<(arg: string) => any>(d.fn([d.string().transform(parseFloat)])[OUTPUT]);
 
 // Return
 
-expectType<() => string>(d.fn().return(d.string()).__output);
+expectType<() => string>(d.fn().return(d.string())[OUTPUT]);
 
-expectType<() => Promise<string>>(d.fn().return(d.promise(d.string())).__output);
+expectType<() => Promise<string>>(d.fn().return(d.promise(d.string()))[OUTPUT]);
 
-expectType<() => string>(d.fn().return(d.string().transform(parseFloat)).__input);
+expectType<() => string>(d.fn().return(d.string().transform(parseFloat))[INPUT]);
 
-expectType<() => number>(d.fn().return(d.string().transform(parseFloat)).__output);
+expectType<() => number>(d.fn().return(d.string().transform(parseFloat))[OUTPUT]);
 
 // This
 
-expectType<(this: string) => any>(d.fn().this(d.string()).__output);
+expectType<(this: string) => any>(d.fn().this(d.string())[OUTPUT]);
 
-expectType<(this: number) => any>(d.fn().this(d.string().transform(parseFloat)).__input);
+expectType<(this: number) => any>(d.fn().this(d.string().transform(parseFloat))[INPUT]);
 
-expectType<(this: string) => any>(d.fn().this(d.string().transform(parseFloat)).__output);
+expectType<(this: string) => any>(d.fn().this(d.string().transform(parseFloat))[OUTPUT]);
 
 // ensureSignature
 

--- a/src/test/dsl/instanceOf.test-d.ts
+++ b/src/test/dsl/instanceOf.test-d.ts
@@ -1,8 +1,9 @@
 import * as d from 'doubter';
+import { OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
 class TestClass {
   aaa = 111;
 }
 
-expectType<TestClass>(d.instanceOf(TestClass).__output);
+expectType<TestClass>(d.instanceOf(TestClass)[OUTPUT]);

--- a/src/test/dsl/intersection.test-d.ts
+++ b/src/test/dsl/intersection.test-d.ts
@@ -1,22 +1,23 @@
 import * as d from 'doubter';
+import { OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
 expectType<{ key1: string } & { key2: number }>(
-  d.and([d.object({ key1: d.string() }), d.object({ key2: d.number() })]).__output
+  d.and([d.object({ key1: d.string() }), d.object({ key2: d.number() })])[OUTPUT]
 );
 
-expectType<string>(d.and([d.string(), d.string()]).__output);
+expectType<string>(d.and([d.string(), d.string()])[OUTPUT]);
 
-expectType<string>(d.and([d.or([d.string(), d.number()]), d.string()]).__output);
+expectType<string>(d.and([d.or([d.string(), d.number()]), d.string()])[OUTPUT]);
 
 expectType<string | number>(
-  d.and([d.or([d.string(), d.number(), d.boolean()]), d.or([d.string(), d.number()])]).__output
+  d.and([d.or([d.string(), d.number(), d.boolean()]), d.or([d.string(), d.number()])])[OUTPUT]
 );
 
-expectType<never>(d.and([d.or([d.string(), d.never()]), d.number()]).__output);
+expectType<never>(d.and([d.or([d.string(), d.never()]), d.number()])[OUTPUT]);
 
-expectType<any>(d.and([d.any(), d.string()]).__output);
+expectType<any>(d.and([d.any(), d.string()])[OUTPUT]);
 
-expectType<never>(d.and([d.never(), d.string()]).__output);
+expectType<never>(d.and([d.never(), d.string()])[OUTPUT]);
 
-expectType<never>(d.and([d.never(), d.any()]).__output);
+expectType<never>(d.and([d.never(), d.any()])[OUTPUT]);

--- a/src/test/dsl/lazy.test-d.ts
+++ b/src/test/dsl/lazy.test-d.ts
@@ -1,25 +1,26 @@
 import * as d from 'doubter';
+import { INPUT, OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
-expectType<string>(d.lazy(() => d.string()).__output);
+expectType<string>(d.lazy(() => d.string())[OUTPUT]);
 
-expectType<string | number>(d.lazy(() => d.string().transform(parseFloat)).__output);
+expectType<string | number>(d.lazy(() => d.string().transform(parseFloat))[OUTPUT]);
 
-expectType<{ aaa?: string }>(d.lazy(() => d.object({ aaa: d.string().transform(parseFloat) })).deepPartial().__input);
+expectType<{ aaa?: string }>(d.lazy(() => d.object({ aaa: d.string().transform(parseFloat) })).deepPartial()[INPUT]);
 
 expectType<{ aaa?: string } | { aaa?: number }>(
-  d.lazy(() => d.object({ aaa: d.string().transform(parseFloat) })).deepPartial().__output
+  d.lazy(() => d.object({ aaa: d.string().transform(parseFloat) })).deepPartial()[OUTPUT]
 );
 
-expectType<string | 111>(d.lazy(() => d.string()).circular(111).__output);
+expectType<string | 111>(d.lazy(() => d.string()).circular(111)[OUTPUT]);
 
 expectType<{ aaa: number } | 111>(
-  d.lazy(() => d.object({ aaa: d.string().transform(parseFloat) })).circular(111).__output
+  d.lazy(() => d.object({ aaa: d.string().transform(parseFloat) })).circular(111)[OUTPUT]
 );
 
 expectType<{ aaa?: string } | { aaa?: number }>(
   d
     .lazy(() => d.object({ aaa: d.string().transform(parseFloat) }))
     .circular(111)
-    .deepPartial().__output
+    .deepPartial()[OUTPUT]
 );

--- a/src/test/dsl/map.test-d.ts
+++ b/src/test/dsl/map.test-d.ts
@@ -1,17 +1,18 @@
 import * as d from 'doubter';
+import { OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
-expectType<Map<string, number>>(d.map(d.string(), d.number()).__output);
+expectType<Map<string, number>>(d.map(d.string(), d.number())[OUTPUT]);
 
 expectType<Map<'bbb', number>>(
   d.map(
     d.string().transform((): 'bbb' => 'bbb'),
     d.number()
-  ).__output
+  )[OUTPUT]
 );
 
-expectType<Map<string, number | undefined>>(d.map(d.string(), d.number()).deepPartial().__output);
+expectType<Map<string, number | undefined>>(d.map(d.string(), d.number()).deepPartial()[OUTPUT]);
 
 expectType<Map<{ aaa?: string }, { bbb?: number } | undefined>>(
-  d.map(d.object({ aaa: d.string() }), d.object({ bbb: d.number() })).deepPartial().__output
+  d.map(d.object({ aaa: d.string() }), d.object({ bbb: d.number() })).deepPartial()[OUTPUT]
 );

--- a/src/test/dsl/not.test-d.ts
+++ b/src/test/dsl/not.test-d.ts
@@ -1,4 +1,5 @@
 import * as d from 'doubter';
+import { OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
-expectType<any>(d.not(d.string()).__output);
+expectType<any>(d.not(d.string())[OUTPUT]);

--- a/src/test/dsl/number.test-d.ts
+++ b/src/test/dsl/number.test-d.ts
@@ -1,32 +1,33 @@
 import * as d from 'doubter';
+import { INPUT, OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
-expectType<number | 'aaa'>(d.number().replace('aaa', true).__input);
+expectType<number | 'aaa'>(d.number().replace('aaa', true)[INPUT]);
 
-expectType<number | true>(d.number().replace('aaa', true).__output);
+expectType<number | true>(d.number().replace('aaa', true)[OUTPUT]);
 
-expectType<number>(d.number().replace(222, 'aaa').__input);
+expectType<number>(d.number().replace(222, 'aaa')[INPUT]);
 
-expectType<number | 'aaa'>(d.number().replace(222, 'aaa').__output);
+expectType<number | 'aaa'>(d.number().replace(222, 'aaa')[OUTPUT]);
 
-expectType<number>(d.number().replace(NaN, 0).__input);
+expectType<number>(d.number().replace(NaN, 0)[INPUT]);
 
-expectType<number>(d.number().replace(NaN, 0).__output);
+expectType<number>(d.number().replace(NaN, 0)[OUTPUT]);
 
-expectType<number>(d.number().nan().__input);
+expectType<number>(d.number().nan()[INPUT]);
 
-expectType<number>(d.number().nan().__output);
+expectType<number>(d.number().nan()[OUTPUT]);
 
-expectType<number>(d.number().nan(111).__input);
+expectType<number>(d.number().nan(111)[INPUT]);
 
-expectType<number>(d.number().nan(111).__output);
+expectType<number>(d.number().nan(111)[OUTPUT]);
 
-expectType<number>(d.number().nan('aaa').__input);
+expectType<number>(d.number().nan('aaa')[INPUT]);
 
-expectType<number | 'aaa'>(d.number().nan('aaa').__output);
+expectType<number | 'aaa'>(d.number().nan('aaa')[OUTPUT]);
 
-expectType<number>(d.number().allow(Infinity).__output);
+expectType<number>(d.number().allow(Infinity)[OUTPUT]);
 
-expectType<number>(d.number().deny(111).__input);
+expectType<number>(d.number().deny(111)[INPUT]);
 
-expectType<number>(d.number().deny(111).__output);
+expectType<number>(d.number().deny(111)[OUTPUT]);

--- a/src/test/dsl/object.test-d.ts
+++ b/src/test/dsl/object.test-d.ts
@@ -1,23 +1,24 @@
 import * as d from 'doubter';
+import { OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
 expectType<{ aaa?: string }>(
   d.object({
     aaa: d.string().optional(),
-  }).__output
+  })[OUTPUT]
 );
 
 expectType<{ aaa?: any }>(
   d.object({
     aaa: d.any(),
-  }).__output
+  })[OUTPUT]
 );
 
 expectType<{ aaa: string; bbb: number }>(
   d.object({
     aaa: d.string(),
     bbb: d.number(),
-  }).__output
+  })[OUTPUT]
 );
 
 expectType<{ aaa: string }>(
@@ -26,7 +27,7 @@ expectType<{ aaa: string }>(
       aaa: d.string(),
       bbb: d.number(),
     })
-    .pick(['aaa']).__output
+    .pick(['aaa'])[OUTPUT]
 );
 
 expectType<{ bbb: number }>(
@@ -35,12 +36,12 @@ expectType<{ bbb: number }>(
       aaa: d.string(),
       bbb: d.number(),
     })
-    .omit(['aaa']).__output
+    .omit(['aaa'])[OUTPUT]
 );
 
-expectType<{ aaa: string; bbb: number }>(d.object({ aaa: d.string() }).extend({ bbb: d.number() }).__output);
+expectType<{ aaa: string; bbb: number }>(d.object({ aaa: d.string() }).extend({ bbb: d.number() })[OUTPUT]);
 
-expectType<{ aaa: string; bbb: number }>(d.object({ aaa: d.string() }).extend(d.object({ bbb: d.number() })).__output);
+expectType<{ aaa: string; bbb: number }>(d.object({ aaa: d.string() }).extend(d.object({ bbb: d.number() }))[OUTPUT]);
 
 expectType<{ aaa?: string; bbb?: number }>(
   d
@@ -48,7 +49,7 @@ expectType<{ aaa?: string; bbb?: number }>(
       aaa: d.string(),
       bbb: d.number(),
     })
-    .partial().__output
+    .partial()[OUTPUT]
 );
 
 expectType<{ aaa?: string; bbb?: number }>(
@@ -57,7 +58,7 @@ expectType<{ aaa?: string; bbb?: number }>(
       aaa: d.string(),
       bbb: d.number(),
     })
-    .deepPartial().__output
+    .deepPartial()[OUTPUT]
 );
 
 expectType<{ aaa?: string; bbb?: { ccc?: number } }>(
@@ -66,7 +67,7 @@ expectType<{ aaa?: string; bbb?: { ccc?: number } }>(
       aaa: d.string(),
       bbb: d.object({ ccc: d.number() }),
     })
-    .deepPartial().__output
+    .deepPartial()[OUTPUT]
 );
 
 expectType<{ aaa?: string; bbb?: Array<number | undefined> }>(
@@ -75,14 +76,14 @@ expectType<{ aaa?: string; bbb?: Array<number | undefined> }>(
       aaa: d.string(),
       bbb: d.array(d.number()),
     })
-    .deepPartial().__output
+    .deepPartial()[OUTPUT]
 );
 
 const keys = ['aaa'] as const;
 
-expectType<{ aaa: string }>(d.object({ aaa: d.string(), bbb: d.number() }).pick(keys).__output);
+expectType<{ aaa: string }>(d.object({ aaa: d.string(), bbb: d.number() }).pick(keys)[OUTPUT]);
 
-expectType<{ bbb: number }>(d.object({ aaa: d.string(), bbb: d.number() }).omit(keys).__output);
+expectType<{ bbb: number }>(d.object({ aaa: d.string(), bbb: d.number() }).omit(keys)[OUTPUT]);
 
 expectType<{ aaa?: string | undefined; bbb: number }>(
   d
@@ -90,7 +91,7 @@ expectType<{ aaa?: string | undefined; bbb: number }>(
       aaa: d.string(),
       bbb: d.number(),
     })
-    .partial(keys).__output
+    .partial(keys)[OUTPUT]
 );
 
 expectType<{ aaa: string; bbb: number }>(
@@ -99,5 +100,5 @@ expectType<{ aaa: string; bbb: number }>(
       aaa: d.string().optional(),
       bbb: d.number(),
     })
-    .required(keys).__output
+    .required(keys)[OUTPUT]
 );

--- a/src/test/dsl/or.test-d.ts
+++ b/src/test/dsl/or.test-d.ts
@@ -1,10 +1,11 @@
 import * as d from 'doubter';
+import { OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
-expectType<number | string>(d.or([d.number(), d.string()]).__output);
+expectType<number | string>(d.or([d.number(), d.string()])[OUTPUT]);
 
 expectType<{ key1: string } | { key2: number }>(
-  d.or([d.object({ key1: d.string() }), d.object({ key2: d.number() })]).__output
+  d.or([d.object({ key1: d.string() }), d.object({ key2: d.number() })])[OUTPUT]
 );
 
 expectType<{ aaa?: string } | { bbb?: number }>(
@@ -17,7 +18,7 @@ expectType<{ aaa?: string } | { bbb?: number }>(
         bbb: d.number(),
       }),
     ])
-    .deepPartial().__output
+    .deepPartial()[OUTPUT]
 );
 
 expectType<{ aaa?: Array<string | undefined> } | { bbb?: number }>(
@@ -30,5 +31,5 @@ expectType<{ aaa?: Array<string | undefined> } | { bbb?: number }>(
         bbb: d.number(),
       }),
     ])
-    .deepPartial().__output
+    .deepPartial()[OUTPUT]
 );

--- a/src/test/dsl/record.test-d.ts
+++ b/src/test/dsl/record.test-d.ts
@@ -1,13 +1,14 @@
 import * as d from 'doubter';
+import { OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
-expectType<Record<string, number>>(d.record(d.number()).__output);
+expectType<Record<string, number>>(d.record(d.number())[OUTPUT]);
 
 expectType<{ bbb: number }>(
   d.record(
     d.string().transform((): 'bbb' => 'bbb'),
     d.number()
-  ).__output
+  )[OUTPUT]
 );
 
-expectType<Record<string, boolean | undefined>>(d.record(d.string(), d.boolean().optional()).__output);
+expectType<Record<string, boolean | undefined>>(d.record(d.string(), d.boolean().optional())[OUTPUT]);

--- a/src/test/dsl/set.test-d.ts
+++ b/src/test/dsl/set.test-d.ts
@@ -1,6 +1,7 @@
 import * as d from 'doubter';
+import { OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
-expectType<Set<string | number>>(d.set(d.or([d.string(), d.number()])).__output);
+expectType<Set<string | number>>(d.set(d.or([d.string(), d.number()]))[OUTPUT]);
 
-expectType<Set<111>>(d.set(d.const(111)).__output);
+expectType<Set<111>>(d.set(d.const(111))[OUTPUT]);

--- a/src/test/dsl/tuple.test-d.ts
+++ b/src/test/dsl/tuple.test-d.ts
@@ -1,10 +1,11 @@
 import * as d from 'doubter';
+import { OUTPUT } from 'doubter';
 import { expectNotType, expectType } from 'tsd';
 
-expectType<[string, number]>(d.tuple([d.string(), d.number()]).__output);
+expectType<[string, number]>(d.tuple([d.string(), d.number()])[OUTPUT]);
 
-expectNotType<[string, number, ...unknown[]]>(d.tuple([d.string(), d.number()]).__output);
+expectNotType<[string, number, ...unknown[]]>(d.tuple([d.string(), d.number()])[OUTPUT]);
 
-expectType<number>(d.tuple([d.string(), d.number()]).headShapes[1].__output);
+expectType<number>(d.tuple([d.string(), d.number()]).headShapes[1][OUTPUT]);
 
-expectType<[string, number, ...boolean[]]>(d.tuple([d.string(), d.number()], d.boolean()).__output);
+expectType<[string, number, ...boolean[]]>(d.tuple([d.string(), d.number()], d.boolean())[OUTPUT]);

--- a/src/test/dsl/union.test-d.ts
+++ b/src/test/dsl/union.test-d.ts
@@ -1,10 +1,11 @@
 import * as d from 'doubter';
+import { OUTPUT } from 'doubter';
 import { expectType } from 'tsd';
 
-expectType<string | number | boolean>(d.or([d.string(), d.number(), d.boolean()]).__output);
+expectType<string | number | boolean>(d.or([d.string(), d.number(), d.boolean()])[OUTPUT]);
 
-expectType<string>(d.or([d.string(), d.never()]).__output);
+expectType<string>(d.or([d.string(), d.never()])[OUTPUT]);
 
-expectType<any>(d.or([d.string(), d.any()]).__output);
+expectType<any>(d.or([d.string(), d.any()])[OUTPUT]);
 
-expectType<unknown>(d.or([d.string(), d.unknown()]).__output);
+expectType<unknown>(d.or([d.string(), d.unknown()])[OUTPUT]);


### PR DESCRIPTION
Switched to using `Input` and `Output` helper types instead of INPUT and OUTPUT property keys. This results in cleaner docs, and autocomplete doesn't show type-only keys inherited from the `Shape` class.