### PR TITLE
Async operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Use [`tryAsync`](https://smikhalevski.github.io/doubter/next/classes/core.Shape.
 At the final stage of the parsing process, a shape applies operations that were added to it.
 
 ```ts
-const shape = d.string().withOperation(
+const shape = d.string().addOperation(
   next => (input, output, options, issues) => {
     return next(input, output.trim(), options, issues);
   }
@@ -2199,7 +2199,7 @@ class NumberLikeShape extends d.Shape<string, number> {
     }
 
     // 2️⃣ Apply operations to the output value
-    return this._applyOperations(input, parseFloat(input), options, null);
+    return this._applyOperations(input, parseFloat(input), options, null) as d.Result;
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Use [`tryAsync`](https://smikhalevski.github.io/doubter/next/classes/core.Shape.
 At the final stage of the parsing process, a shape applies operations that were added to it.
 
 ```ts
-const shape = d.string().addOperation(
+const shape = d.string().use(
   next => (input, output, options, issues) => {
     return next(input, output.trim(), options, issues);
   }

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Use [`tryAsync`](https://smikhalevski.github.io/doubter/next/classes/core.Shape.
 At the final stage of the parsing process, a shape applies operations that were added to it.
 
 ```ts
-const shape = d.string().use(
+const shape = d.string().withOperation(
   next => (input, output, options, issues) => {
     return next(input, output.trim(), options, issues);
   }

--- a/src/main/coerce/const.ts
+++ b/src/main/coerce/const.ts
@@ -10,7 +10,7 @@ import { coerceToString, stringCoercibleInputs } from './string';
 /**
  * The array of inputs that are coercible to `NaN` with {@link coerceToConst}.
  */
-export const nanCoercibleInputs = freeze<unknown[]>([
+const nanCoercibleInputs = freeze<unknown[]>([
   TYPE_ARRAY,
   TYPE_OBJECT, // new Number(NaN)
   NaN,

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -1,5 +1,4 @@
 export const ERR_SYNC_UNSUPPORTED = 'Shape is async, use tryAsync, parseAsync, or parseOrDefaultAsync.';
-export const ERR_SYNC_REQUIRED = 'Shape cannot be used because it is async.';
 export const ERR_SHAPE_EXPECTED = 'Provider must return a shape. Are you accessing a lazy shape prematurely?';
 export const ERR_ASYNC_FUNCTION = 'The function signature is constrained by async shapes, use ensureAsync.';
 

--- a/src/main/core.ts
+++ b/src/main/core.ts
@@ -67,10 +67,9 @@ export {
 export { StringShape } from './shape/StringShape';
 export { SymbolShape } from './shape/SymbolShape';
 export { UnionShape } from './shape/UnionShape';
-
-export * from './typings';
-export * from './ValidationError';
-
+export { ValidationError } from './ValidationError';
 export { Messages } from './messages';
 export { Type, TypeName } from './types';
 export { NEVER } from './coerce/never';
+
+export type * from './typings';

--- a/src/main/internal/arrays.ts
+++ b/src/main/internal/arrays.ts
@@ -1,11 +1,5 @@
-/**
- * Returns an array of unique values.
- */
 export function unique<T>(values: T[]): T[];
 
-/**
- * Returns an array of unique values.
- */
 export function unique<T>(values: readonly T[]): readonly T[];
 
 export function unique<T>(values: readonly T[]): T[] {

--- a/src/main/internal/lang.ts
+++ b/src/main/internal/lang.ts
@@ -59,8 +59,3 @@ export function getCanonicalValue(value: unknown): unknown {
 export function returnTrue(): boolean {
   return true;
 }
-
-export function defineProperty<T>(obj: object, key: PropertyKey, value: T, readOnly = false): T {
-  Object.defineProperty(obj, key, { configurable: true, writable: !readOnly, value });
-  return value;
-}

--- a/src/main/internal/objects.ts
+++ b/src/main/internal/objects.ts
@@ -6,8 +6,8 @@ export interface Dict<T = any> {
   [key: string]: T;
 }
 
-export function defineObjectProperty<T>(obj: object, key: PropertyKey, value: T, readOnly = false): T {
-  Object.defineProperty(obj, key, { configurable: true, writable: !readOnly, value });
+export function overrideProperty<T>(obj: object, key: PropertyKey, value: T): T {
+  Object.defineProperty(obj, key, { value, writable: false, configurable: true });
   return value;
 }
 

--- a/src/main/internal/objects.ts
+++ b/src/main/internal/objects.ts
@@ -6,10 +6,15 @@ export interface Dict<T = any> {
   [key: string]: T;
 }
 
+export function defineObjectProperty<T>(obj: object, key: PropertyKey, value: T, readOnly = false): T {
+  Object.defineProperty(obj, key, { configurable: true, writable: !readOnly, value });
+  return value;
+}
+
 /**
  * Updates object property value, prevents prototype pollution.
  */
-export function setObjectProperty<T>(obj: any, key: any, value: T): T {
+export function setObjectProperty<T>(obj: any, key: PropertyKey, value: T): T {
   if (key === '__proto__') {
     Object.defineProperty(obj, key, { value, writable: true, enumerable: true, configurable: true });
   } else {
@@ -51,7 +56,7 @@ export function cloneDictHead(dict: ReadonlyDict, count: number): Dict {
 /**
  * Clones known keys of a dictionary-like object.
  */
-export function cloneDictKeys(dict: ReadonlyDict, keys: readonly any[]): Dict {
+export function cloneDictKeys(dict: ReadonlyDict, keys: readonly string[]): Dict {
   const obj = {};
 
   for (const key of keys) {

--- a/src/main/internal/shapes.ts
+++ b/src/main/internal/shapes.ts
@@ -219,7 +219,7 @@ export function createApplyOperations(
   };
 }
 
-export function adoptCheckResult(result: CheckResult): Result {
+export function extractCheckResult(result: CheckResult): Result {
   if (!isObjectLike(result)) {
     return null;
   }
@@ -229,6 +229,6 @@ export function adoptCheckResult(result: CheckResult): Result {
   return [result];
 }
 
-export function dieAsync(): never {
+export function throwSyncUnsupported(): never {
   throw new Error(ERR_SYNC_UNSUPPORTED);
 }

--- a/src/main/internal/shapes.ts
+++ b/src/main/internal/shapes.ts
@@ -1,6 +1,16 @@
 import { ERR_SYNC_UNSUPPORTED } from '../constants';
 import type { AnyShape, DeepPartialProtocol, DeepPartialShape, Shape } from '../shape/Shape';
-import { ApplyOptions, CheckResult, Issue, Ok, Operation, OperationCallback, ParseOptions, Result } from '../typings';
+import {
+  ApplyOperationsCallback,
+  ApplyOptions,
+  CheckResult,
+  Issue,
+  Ok,
+  Operation,
+  OperationCallback,
+  ParseOptions,
+  Result,
+} from '../typings';
 import { ValidationError } from '../ValidationError';
 import { freeze, isArray, isEqual, isObjectLike } from './lang';
 
@@ -15,24 +25,6 @@ type Awaited<T> =
 export type Promisify<T> = Promise<Awaited<T>>;
 
 export type Awaitable<T> = Awaited<T> extends T ? Promise<T> | T : T;
-
-/**
- * A callback that applies operations to the shape output.
- *
- * @param input The input value to which the shape was applied.
- * @param output The shape output value to which the operation must be applied.
- * @param options Parsing options.
- * @param issues The mutable array of issues captured by a shape, or `null` if there were no issues raised yet.
- * @returns The result of the operation.
- * @template ReturnValue The cumulative result of applied operations.
- * @group Operations
- */
-type ApplyOperationsCallback = (
-  input: unknown,
-  output: unknown,
-  options: ApplyOptions,
-  issues: Issue[] | null
-) => Result | Promise<Result>;
 
 export const defaultApplyOptions = freeze<ApplyOptions>({ earlyReturn: false });
 
@@ -155,7 +147,10 @@ export function copyOperations<S extends Shape>(baseShape: Shape, shape: S): S {
   return shape;
 }
 
-export const universalApplyOperations: ApplyOperationsCallback = (input, output, options, issues) => {
+/**
+ * The callback that converts output and issues to a {@link Result}.
+ */
+export const applyOperations: ApplyOperationsCallback = (input, output, options, issues) => {
   if (issues !== null) {
     return issues;
   }

--- a/src/main/internal/shapes.ts
+++ b/src/main/internal/shapes.ts
@@ -42,6 +42,9 @@ export declare const OUTPUT: unique symbol;
 export type INPUT = typeof INPUT;
 export type OUTPUT = typeof OUTPUT;
 
+/**
+ * Nonce is required to distinguish parallel invocations of async parsing.
+ */
 let nonce = -1;
 
 export function nextNonce(): number {
@@ -50,7 +53,6 @@ export function nextNonce(): number {
 
 /**
  * For test purposes only!
- * @internal
  */
 export function resetNonce(): void {
   nonce = -1;
@@ -130,7 +132,11 @@ export function captureIssues(error: unknown): Issue[] {
 /**
  * Returns an error message that is composed of the captured issues and parsing options.
  */
-export function getMessage(issues: Issue[], input: unknown, options: ParseOptions | undefined): string | undefined {
+export function getErrorMessage(
+  issues: Issue[],
+  input: unknown,
+  options: ParseOptions | undefined
+): string | undefined {
   const message = options?.errorMessage;
 
   if (typeof message === 'function') {

--- a/src/main/internal/shapes.ts
+++ b/src/main/internal/shapes.ts
@@ -48,7 +48,10 @@ export function nextNonce(): number {
   return ++nonce;
 }
 
-// For test purposes only
+/**
+ * For test purposes only!
+ * @internal
+ */
 export function resetNonce(): void {
   nonce = -1;
 }

--- a/src/main/internal/shapes.ts
+++ b/src/main/internal/shapes.ts
@@ -1,3 +1,4 @@
+import { ERR_SYNC_UNSUPPORTED } from '../constants';
 import type { AnyShape, DeepPartialProtocol, DeepPartialShape, Shape } from '../shape/Shape';
 import { ApplyOptions, CheckResult, Issue, Ok, Operation, OperationCallback, ParseOptions, Result } from '../typings';
 import { ValidationError } from '../ValidationError';
@@ -26,12 +27,12 @@ export type Awaitable<T> = Awaited<T> extends T ? Promise<T> | T : T;
  * @template ReturnValue The cumulative result of applied operations.
  * @group Operations
  */
-export type ApplyOperationsCallback<ReturnValue = Result | Promise<Result>> = (
+type ApplyOperationsCallback = (
   input: unknown,
   output: unknown,
   options: ApplyOptions,
   issues: Issue[] | null
-) => ReturnValue;
+) => Result | Promise<Result>;
 
 export const defaultApplyOptions = freeze<ApplyOptions>({ earlyReturn: false });
 
@@ -223,4 +224,8 @@ export function adoptCheckResult(result: CheckResult): Result {
     return result.length === 0 ? null : result;
   }
   return [result];
+}
+
+export function dieAsync(): never {
+  throw new Error(ERR_SYNC_UNSUPPORTED);
 }

--- a/src/main/messages.ts
+++ b/src/main/messages.ts
@@ -29,7 +29,7 @@ export interface Messages {
   'type.union': Message | Any;
 }
 
-export const globalMessages = {
+export const defaultMessages = {
   'any.deny': 'Must not be equal to %s',
   'any.exclude': 'Must not conform the excluded shape',
   'any.refine': 'Must conform the predicate',

--- a/src/main/plugin/array-essentials.ts
+++ b/src/main/plugin/array-essentials.ts
@@ -98,7 +98,7 @@ export default function enableArrayEssentials(ctor: typeof ArrayShape<any, any>)
   prototype.min = function (length, options) {
     const issueFactory = createIssueFactory(CODE_ARRAY_MIN, ctor.messages[CODE_ARRAY_MIN], options, length);
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => (value.length < length ? [issueFactory(value, options)] : null),
       { type: CODE_ARRAY_MIN, param: length }
     );
@@ -107,7 +107,7 @@ export default function enableArrayEssentials(ctor: typeof ArrayShape<any, any>)
   prototype.max = function (length, options) {
     const issueFactory = createIssueFactory(CODE_ARRAY_MAX, ctor.messages[CODE_ARRAY_MAX], options, length);
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => (value.length > length ? [issueFactory(value, options)] : null),
       { type: CODE_ARRAY_MAX, param: length }
     );
@@ -121,14 +121,14 @@ export default function enableArrayEssentials(ctor: typeof ArrayShape<any, any>)
     const issueFactory = createIssueFactory(CODE_ARRAY_INCLUDES, ctor.messages[CODE_ARRAY_INCLUDES], options, value);
 
     if (!(value instanceof Shape)) {
-      return this.withOperation(
+      return this.addOperation(
         (value, param, options) => (value.includes(param) ? null : [issueFactory(value, options)]),
         { type: CODE_ARRAY_INCLUDES, param: value }
       );
     }
 
     if (value.isAsync) {
-      return this.withAsyncOperation(
+      return this.addAsyncOperation(
         (value, param, options) => {
           // TODO Implement me
           return Promise.resolve(null);
@@ -137,7 +137,7 @@ export default function enableArrayEssentials(ctor: typeof ArrayShape<any, any>)
       );
     }
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => {
         for (const item of value) {
           if (param.try(item, options).ok) {

--- a/src/main/plugin/array-essentials.ts
+++ b/src/main/plugin/array-essentials.ts
@@ -71,7 +71,7 @@ declare module '../core' {
      * Requires an array to contain at least one element that conforms the given shape.
      *
      * @param value The shape of the required element or its literal value. If a shape is provided, then it _must_
-     * support {@link Shape#isAsync the synchronous parsing}.
+     * support {@link Shape.isAsync the synchronous parsing}.
      * @param options The issue options or the issue message.
      * @returns The clone of the shape.
      * @group Plugin Methods

--- a/src/main/plugin/bigint-essentials.ts
+++ b/src/main/plugin/bigint-essentials.ts
@@ -116,7 +116,7 @@ export default function enableBigIntEssentials(ctor: typeof BigIntShape): void {
     const param = BigInt(value);
     const issueFactory = createIssueFactory(CODE_BIGINT_MIN, ctor.messages[CODE_BIGINT_MIN], options, param);
 
-    return this.withOperation((value, param, options) => (value < param ? [issueFactory(value, options)] : null), {
+    return this.addOperation((value, param, options) => (value < param ? [issueFactory(value, options)] : null), {
       type: CODE_BIGINT_MIN,
       param,
     });
@@ -126,7 +126,7 @@ export default function enableBigIntEssentials(ctor: typeof BigIntShape): void {
     const param = BigInt(value);
     const issueFactory = createIssueFactory(CODE_BIGINT_MAX, ctor.messages[CODE_BIGINT_MAX], options, param);
 
-    return this.withOperation((value, param, options) => (value > param ? [issueFactory(value, options)] : null), {
+    return this.addOperation((value, param, options) => (value > param ? [issueFactory(value, options)] : null), {
       type: CODE_BIGINT_MAX,
       param,
     });

--- a/src/main/plugin/bigint-essentials.ts
+++ b/src/main/plugin/bigint-essentials.ts
@@ -116,37 +116,19 @@ export default function enableBigIntEssentials(ctor: typeof BigIntShape): void {
     const param = BigInt(value);
     const issueFactory = createIssueFactory(CODE_BIGINT_MIN, ctor.messages[CODE_BIGINT_MIN], options, param);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (output < param) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
-      { type: CODE_BIGINT_MIN, param }
-    );
+    return this.withOperation((value, param, options) => (value < param ? [issueFactory(value, options)] : null), {
+      type: CODE_BIGINT_MIN,
+      param,
+    });
   };
 
   prototype.max = function (value, options) {
     const param = BigInt(value);
     const issueFactory = createIssueFactory(CODE_BIGINT_MAX, ctor.messages[CODE_BIGINT_MAX], options, param);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (output > param) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
-      { type: CODE_BIGINT_MAX, param }
-    );
+    return this.withOperation((value, param, options) => (value > param ? [issueFactory(value, options)] : null), {
+      type: CODE_BIGINT_MAX,
+      param,
+    });
   };
 }

--- a/src/main/plugin/bigint-essentials.ts
+++ b/src/main/plugin/bigint-essentials.ts
@@ -72,7 +72,7 @@ declare module '../core' {
      * @group Plugin Methods
      * @plugin {@link plugin/bigint-essentials! plugin/bigint-essentials}
      */
-    min(value: bigint | number, options?: IssueOptions | Message): this;
+    min(value: bigint | number | string, options?: IssueOptions | Message): this;
 
     /**
      * Constrains the number to be less than or equal to the value.
@@ -83,7 +83,7 @@ declare module '../core' {
      * @group Plugin Methods
      * @plugin {@link plugin/bigint-essentials! plugin/bigint-essentials}
      */
-    max(value: bigint | number, options?: IssueOptions | Message): this;
+    max(value: bigint | number | string, options?: IssueOptions | Message): this;
   }
 }
 
@@ -116,19 +116,29 @@ export default function enableBigIntEssentials(ctor: typeof BigIntShape): void {
     const param = BigInt(value);
     const issueFactory = createIssueFactory(CODE_BIGINT_MIN, ctor.messages[CODE_BIGINT_MIN], options, param);
 
-    return this.addOperation((value, param, options) => (value < param ? [issueFactory(value, options)] : null), {
-      type: CODE_BIGINT_MIN,
-      param,
-    });
+    return this.addOperation(
+      (value, param, options) => {
+        if (value >= param) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
+      { type: CODE_BIGINT_MIN, param }
+    );
   };
 
   prototype.max = function (value, options) {
     const param = BigInt(value);
     const issueFactory = createIssueFactory(CODE_BIGINT_MAX, ctor.messages[CODE_BIGINT_MAX], options, param);
 
-    return this.addOperation((value, param, options) => (value > param ? [issueFactory(value, options)] : null), {
-      type: CODE_BIGINT_MAX,
-      param,
-    });
+    return this.addOperation(
+      (value, param, options) => {
+        if (value <= param) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
+      { type: CODE_BIGINT_MAX, param }
+    );
   };
 }

--- a/src/main/plugin/date-essentials.ts
+++ b/src/main/plugin/date-essentials.ts
@@ -102,7 +102,12 @@ export default function enableDateEssentials(ctor: typeof DateShape): void {
     const issueFactory = createIssueFactory(CODE_DATE_MIN, ctor.messages[CODE_DATE_MIN], options, param);
 
     return this.addOperation(
-      (value, param, options) => (value.getTime() < timestamp ? [issueFactory(value, options)] : null),
+      (value, param, options) => {
+        if (value.getTime() >= timestamp) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
       { type: CODE_DATE_MIN, param }
     );
   };
@@ -113,7 +118,12 @@ export default function enableDateEssentials(ctor: typeof DateShape): void {
     const issueFactory = createIssueFactory(CODE_DATE_MAX, ctor.messages[CODE_DATE_MAX], options, param);
 
     return this.addOperation(
-      (value, param, options) => (value.getTime() > timestamp ? [issueFactory(value, options)] : null),
+      (value, param, options) => {
+        if (value.getTime() <= timestamp) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
       { type: CODE_DATE_MAX, param }
     );
   };

--- a/src/main/plugin/date-essentials.ts
+++ b/src/main/plugin/date-essentials.ts
@@ -101,7 +101,7 @@ export default function enableDateEssentials(ctor: typeof DateShape): void {
     const timestamp = param.getTime();
     const issueFactory = createIssueFactory(CODE_DATE_MIN, ctor.messages[CODE_DATE_MIN], options, param);
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => (value.getTime() < timestamp ? [issueFactory(value, options)] : null),
       { type: CODE_DATE_MIN, param }
     );
@@ -112,7 +112,7 @@ export default function enableDateEssentials(ctor: typeof DateShape): void {
     const timestamp = param.getTime();
     const issueFactory = createIssueFactory(CODE_DATE_MAX, ctor.messages[CODE_DATE_MAX], options, param);
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => (value.getTime() > timestamp ? [issueFactory(value, options)] : null),
       { type: CODE_DATE_MAX, param }
     );

--- a/src/main/plugin/date-essentials.ts
+++ b/src/main/plugin/date-essentials.ts
@@ -101,17 +101,8 @@ export default function enableDateEssentials(ctor: typeof DateShape): void {
     const timestamp = param.getTime();
     const issueFactory = createIssueFactory(CODE_DATE_MIN, ctor.messages[CODE_DATE_MIN], options, param);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (output.getTime() < timestamp) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
+    return this.withOperation(
+      (value, param, options) => (value.getTime() < timestamp ? [issueFactory(value, options)] : null),
       { type: CODE_DATE_MIN, param }
     );
   };
@@ -121,17 +112,8 @@ export default function enableDateEssentials(ctor: typeof DateShape): void {
     const timestamp = param.getTime();
     const issueFactory = createIssueFactory(CODE_DATE_MAX, ctor.messages[CODE_DATE_MAX], options, param);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (output.getTime() > timestamp) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
+    return this.withOperation(
+      (value, param, options) => (value.getTime() > timestamp ? [issueFactory(value, options)] : null),
       { type: CODE_DATE_MAX, param }
     );
   };

--- a/src/main/plugin/number-essentials.ts
+++ b/src/main/plugin/number-essentials.ts
@@ -222,7 +222,7 @@ export default function enableNumberEssentials(ctor: typeof NumberShape): void {
   prototype.finite = function (options) {
     const issueFactory = createIssueFactory(CODE_NUMBER_FINITE, ctor.messages[CODE_NUMBER_FINITE], options, undefined);
 
-    return this.withOperation((value, param, options) => (!isFinite(value) ? [issueFactory(value, options)] : null), {
+    return this.addOperation((value, param, options) => (!isFinite(value) ? [issueFactory(value, options)] : null), {
       type: CODE_NUMBER_FINITE,
     });
   };
@@ -231,7 +231,7 @@ export default function enableNumberEssentials(ctor: typeof NumberShape): void {
     const { isInteger } = Number;
     const issueFactory = createIssueFactory(CODE_NUMBER_INT, ctor.messages[CODE_NUMBER_INT], options, undefined);
 
-    return this.withOperation((value, param, options) => (!isInteger(value) ? [issueFactory(value, options)] : null), {
+    return this.addOperation((value, param, options) => (!isInteger(value) ? [issueFactory(value, options)] : null), {
       type: CODE_NUMBER_INT,
     });
   };
@@ -255,7 +255,7 @@ export default function enableNumberEssentials(ctor: typeof NumberShape): void {
   prototype.gt = function (value, options) {
     const issueFactory = createIssueFactory(CODE_NUMBER_GT, ctor.messages[CODE_NUMBER_GT], options, value);
 
-    return this.withOperation((value, param, options) => (value <= param ? [issueFactory(value, options)] : null), {
+    return this.addOperation((value, param, options) => (value <= param ? [issueFactory(value, options)] : null), {
       type: CODE_NUMBER_GT,
       param: value,
     });
@@ -264,7 +264,7 @@ export default function enableNumberEssentials(ctor: typeof NumberShape): void {
   prototype.lt = function (value, options) {
     const issueFactory = createIssueFactory(CODE_NUMBER_LT, ctor.messages[CODE_NUMBER_LT], options, value);
 
-    return this.withOperation((value, param, options) => (value >= param ? [issueFactory(value, options)] : null), {
+    return this.addOperation((value, param, options) => (value >= param ? [issueFactory(value, options)] : null), {
       type: CODE_NUMBER_LT,
       param: value,
     });
@@ -273,7 +273,7 @@ export default function enableNumberEssentials(ctor: typeof NumberShape): void {
   prototype.gte = function (value, options) {
     const issueFactory = createIssueFactory(CODE_NUMBER_GTE, ctor.messages[CODE_NUMBER_GTE], options, value);
 
-    return this.withOperation((value, param, options) => (value < param ? [issueFactory(value, options)] : null), {
+    return this.addOperation((value, param, options) => (value < param ? [issueFactory(value, options)] : null), {
       type: CODE_NUMBER_GTE,
       param: value,
     });
@@ -282,7 +282,7 @@ export default function enableNumberEssentials(ctor: typeof NumberShape): void {
   prototype.lte = function (value, options) {
     const issueFactory = createIssueFactory(CODE_NUMBER_LTE, ctor.messages[CODE_NUMBER_LTE], options, value);
 
-    return this.withOperation((value, param, options) => (value > param ? [issueFactory(value, options)] : null), {
+    return this.addOperation((value, param, options) => (value > param ? [issueFactory(value, options)] : null), {
       type: CODE_NUMBER_LTE,
       param: value,
     });
@@ -305,7 +305,7 @@ export default function enableNumberEssentials(ctor: typeof NumberShape): void {
       divisor
     );
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) =>
         (epsilon !== -1 ? abs(round(value / param) - value / param) > epsilon : value % param !== 0)
           ? [issueFactory(value, options)]

--- a/src/main/plugin/number-essentials.ts
+++ b/src/main/plugin/number-essentials.ts
@@ -220,41 +220,20 @@ export default function enableNumberEssentials(ctor: typeof NumberShape): void {
   messages[CODE_NUMBER_MULTIPLE_OF] = 'Must be a multiple of %s';
 
   prototype.finite = function (options) {
-    const { isFinite } = Number;
     const issueFactory = createIssueFactory(CODE_NUMBER_FINITE, ctor.messages[CODE_NUMBER_FINITE], options, undefined);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (!isFinite(output)) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
-      { type: CODE_NUMBER_FINITE }
-    );
+    return this.withOperation((value, param, options) => (!isFinite(value) ? [issueFactory(value, options)] : null), {
+      type: CODE_NUMBER_FINITE,
+    });
   };
 
   prototype.int = function (options) {
     const { isInteger } = Number;
     const issueFactory = createIssueFactory(CODE_NUMBER_INT, ctor.messages[CODE_NUMBER_INT], options, undefined);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (!isInteger(output)) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
-      { type: CODE_NUMBER_INT }
-    );
+    return this.withOperation((value, param, options) => (!isInteger(value) ? [issueFactory(value, options)] : null), {
+      type: CODE_NUMBER_INT,
+    });
   };
 
   prototype.positive = function (options) {
@@ -276,73 +255,37 @@ export default function enableNumberEssentials(ctor: typeof NumberShape): void {
   prototype.gt = function (value, options) {
     const issueFactory = createIssueFactory(CODE_NUMBER_GT, ctor.messages[CODE_NUMBER_GT], options, value);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (output <= value) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
-      { type: CODE_NUMBER_GT, param: value }
-    );
+    return this.withOperation((value, param, options) => (value <= param ? [issueFactory(value, options)] : null), {
+      type: CODE_NUMBER_GT,
+      param: value,
+    });
   };
 
   prototype.lt = function (value, options) {
     const issueFactory = createIssueFactory(CODE_NUMBER_LT, ctor.messages[CODE_NUMBER_LT], options, value);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (output >= value) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
-      { type: CODE_NUMBER_LT, param: value }
-    );
+    return this.withOperation((value, param, options) => (value >= param ? [issueFactory(value, options)] : null), {
+      type: CODE_NUMBER_LT,
+      param: value,
+    });
   };
 
   prototype.gte = function (value, options) {
     const issueFactory = createIssueFactory(CODE_NUMBER_GTE, ctor.messages[CODE_NUMBER_GTE], options, value);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (output < value) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
-      { type: CODE_NUMBER_GTE, param: value }
-    );
+    return this.withOperation((value, param, options) => (value < param ? [issueFactory(value, options)] : null), {
+      type: CODE_NUMBER_GTE,
+      param: value,
+    });
   };
 
   prototype.lte = function (value, options) {
     const issueFactory = createIssueFactory(CODE_NUMBER_LTE, ctor.messages[CODE_NUMBER_LTE], options, value);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (output > value) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
-      { type: CODE_NUMBER_LTE, param: value }
-    );
+    return this.withOperation((value, param, options) => (value > param ? [issueFactory(value, options)] : null), {
+      type: CODE_NUMBER_LTE,
+      param: value,
+    });
   };
 
   prototype.min = prototype.gte;
@@ -362,17 +305,11 @@ export default function enableNumberEssentials(ctor: typeof NumberShape): void {
       divisor
     );
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (epsilon !== -1 ? abs(round(output / divisor) - output / divisor) > epsilon : output % divisor !== 0) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
+    return this.withOperation(
+      (value, param, options) =>
+        (epsilon !== -1 ? abs(round(value / param) - value / param) > epsilon : value % param !== 0)
+          ? [issueFactory(value, options)]
+          : null,
       { type: CODE_NUMBER_MULTIPLE_OF, param: divisor }
     );
   };

--- a/src/main/plugin/number-essentials.ts
+++ b/src/main/plugin/number-essentials.ts
@@ -26,7 +26,7 @@ import { createIssueFactory, extractOptions } from '../utils';
 
 export interface MultipleOfOptions extends IssueOptions {
   /**
-   * By default, {@link core!NumberShape#multipleOf NumberShape.multipleOf} uses
+   * By default, {@link core!NumberShape.multipleOf NumberShape.multipleOf} uses
    * [the modulo operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder) which
    * may produce unexpected results when used with floating point numbers. This happens because of
    * [the way numbers are represented by IEEE 754](https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html).
@@ -222,18 +222,30 @@ export default function enableNumberEssentials(ctor: typeof NumberShape): void {
   prototype.finite = function (options) {
     const issueFactory = createIssueFactory(CODE_NUMBER_FINITE, ctor.messages[CODE_NUMBER_FINITE], options, undefined);
 
-    return this.addOperation((value, param, options) => (!isFinite(value) ? [issueFactory(value, options)] : null), {
-      type: CODE_NUMBER_FINITE,
-    });
+    return this.addOperation(
+      (value, param, options) => {
+        if (isFinite(value)) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
+      { type: CODE_NUMBER_FINITE }
+    );
   };
 
   prototype.int = function (options) {
     const { isInteger } = Number;
     const issueFactory = createIssueFactory(CODE_NUMBER_INT, ctor.messages[CODE_NUMBER_INT], options, undefined);
 
-    return this.addOperation((value, param, options) => (!isInteger(value) ? [issueFactory(value, options)] : null), {
-      type: CODE_NUMBER_INT,
-    });
+    return this.addOperation(
+      (value, param, options) => {
+        if (isInteger(value)) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
+      { type: CODE_NUMBER_INT }
+    );
   };
 
   prototype.positive = function (options) {
@@ -255,37 +267,57 @@ export default function enableNumberEssentials(ctor: typeof NumberShape): void {
   prototype.gt = function (value, options) {
     const issueFactory = createIssueFactory(CODE_NUMBER_GT, ctor.messages[CODE_NUMBER_GT], options, value);
 
-    return this.addOperation((value, param, options) => (value <= param ? [issueFactory(value, options)] : null), {
-      type: CODE_NUMBER_GT,
-      param: value,
-    });
+    return this.addOperation(
+      (value, param, options) => {
+        if (value > param) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
+      { type: CODE_NUMBER_GT, param: value }
+    );
   };
 
   prototype.lt = function (value, options) {
     const issueFactory = createIssueFactory(CODE_NUMBER_LT, ctor.messages[CODE_NUMBER_LT], options, value);
 
-    return this.addOperation((value, param, options) => (value >= param ? [issueFactory(value, options)] : null), {
-      type: CODE_NUMBER_LT,
-      param: value,
-    });
+    return this.addOperation(
+      (value, param, options) => {
+        if (value < param) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
+      { type: CODE_NUMBER_LT, param: value }
+    );
   };
 
   prototype.gte = function (value, options) {
     const issueFactory = createIssueFactory(CODE_NUMBER_GTE, ctor.messages[CODE_NUMBER_GTE], options, value);
 
-    return this.addOperation((value, param, options) => (value < param ? [issueFactory(value, options)] : null), {
-      type: CODE_NUMBER_GTE,
-      param: value,
-    });
+    return this.addOperation(
+      (value, param, options) => {
+        if (value >= param) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
+      { type: CODE_NUMBER_GTE, param: value }
+    );
   };
 
   prototype.lte = function (value, options) {
     const issueFactory = createIssueFactory(CODE_NUMBER_LTE, ctor.messages[CODE_NUMBER_LTE], options, value);
 
-    return this.addOperation((value, param, options) => (value > param ? [issueFactory(value, options)] : null), {
-      type: CODE_NUMBER_LTE,
-      param: value,
-    });
+    return this.addOperation(
+      (value, param, options) => {
+        if (value <= param) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
+      { type: CODE_NUMBER_LTE, param: value }
+    );
   };
 
   prototype.min = prototype.gte;
@@ -306,10 +338,12 @@ export default function enableNumberEssentials(ctor: typeof NumberShape): void {
     );
 
     return this.addOperation(
-      (value, param, options) =>
-        (epsilon !== -1 ? abs(round(value / param) - value / param) > epsilon : value % param !== 0)
-          ? [issueFactory(value, options)]
-          : null,
+      (value, param, options) => {
+        if (epsilon !== -1 ? abs(round(value / param) - value / param) <= epsilon : value % param === 0) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
       { type: CODE_NUMBER_MULTIPLE_OF, param: divisor }
     );
   };

--- a/src/main/plugin/object-essentials.ts
+++ b/src/main/plugin/object-essentials.ts
@@ -123,7 +123,11 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
     return this.addOperation(
       (value, param, options) => {
         const prototype = getPrototypeOf(value);
-        return prototype !== null && prototype.constructor !== Object ? [issueFactory(value, options)] : null;
+
+        if (prototype === null || prototype.constructor === Object) {
+          return null;
+        }
+        return [issueFactory(value, options)];
       },
       { type: CODE_OBJECT_PLAIN }
     );
@@ -135,7 +139,11 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
     return this.addOperation(
       (value, param, options) => {
         const keyCount = getKeyCount(value, keys, keys.length);
-        return keyCount > 0 && keyCount < keys.length ? [issueFactory(value, options)] : null;
+
+        if (keyCount === 0 || keyCount === keys.length) {
+          return null;
+        }
+        return [issueFactory(value, options)];
       },
       { type: CODE_OBJECT_ALL_KEYS, param: keys }
     );
@@ -151,8 +159,10 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
 
     return this.addOperation(
       (value, param, options) => {
-        const keyCount = getKeyCount(value, keys, keys.length);
-        return keyCount > 0 && keyCount <= keys.length ? [issueFactory(value, options)] : null;
+        if (getKeyCount(value, keys, keys.length) !== keys.length) {
+          return null;
+        }
+        return [issueFactory(value, options)];
       },
       { type: CODE_OBJECT_NOT_ALL_KEYS, param: keys }
     );
@@ -162,7 +172,12 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
     const issueFactory = createIssueFactory(CODE_OBJECT_OR_KEYS, ctor.messages[CODE_OBJECT_OR_KEYS], options, keys);
 
     return this.addOperation(
-      (value, param, options) => (getKeyCount(value, keys, 1) === 0 ? [issueFactory(value, options)] : null),
+      (value, param, options) => {
+        if (getKeyCount(value, keys, 1) !== 0) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
       { type: CODE_OBJECT_OR_KEYS, param: keys }
     );
   };
@@ -171,7 +186,12 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
     const issueFactory = createIssueFactory(CODE_OBJECT_XOR_KEYS, ctor.messages[CODE_OBJECT_XOR_KEYS], options, keys);
 
     return this.addOperation(
-      (value, param, options) => (getKeyCount(value, keys, 2) !== 1 ? [issueFactory(value, options)] : null),
+      (value, param, options) => {
+        if (getKeyCount(value, keys, 2) === 1) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
       { type: CODE_OBJECT_XOR_KEYS, param: keys }
     );
   };
@@ -180,7 +200,12 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
     const issueFactory = createIssueFactory(CODE_OBJECT_OXOR_KEYS, ctor.messages[CODE_OBJECT_OXOR_KEYS], options, keys);
 
     return this.addOperation(
-      (value, param, options) => (getKeyCount(value, keys, 2) > 1 ? [issueFactory(value, options)] : null),
+      (value, param, options) => {
+        if (getKeyCount(value, keys, 2) <= 1) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
       { type: CODE_OBJECT_OXOR_KEYS, param: keys }
     );
   };

--- a/src/main/plugin/object-essentials.ts
+++ b/src/main/plugin/object-essentials.ts
@@ -120,7 +120,7 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
     const { getPrototypeOf } = Object;
     const issueFactory = createIssueFactory(CODE_OBJECT_PLAIN, ctor.messages[CODE_OBJECT_PLAIN], options, undefined);
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => {
         const prototype = getPrototypeOf(value);
         return prototype !== null && prototype.constructor !== Object ? [issueFactory(value, options)] : null;
@@ -132,7 +132,7 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
   prototype.allKeys = function (keys, options) {
     const issueFactory = createIssueFactory(CODE_OBJECT_ALL_KEYS, ctor.messages[CODE_OBJECT_ALL_KEYS], options, keys);
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => {
         const keyCount = getKeyCount(value, keys, keys.length);
         return keyCount > 0 && keyCount < keys.length ? [issueFactory(value, options)] : null;
@@ -149,7 +149,7 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
       keys
     );
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => {
         const keyCount = getKeyCount(value, keys, keys.length);
         return keyCount > 0 && keyCount <= keys.length ? [issueFactory(value, options)] : null;
@@ -161,7 +161,7 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
   prototype.orKeys = function (keys, options) {
     const issueFactory = createIssueFactory(CODE_OBJECT_OR_KEYS, ctor.messages[CODE_OBJECT_OR_KEYS], options, keys);
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => (getKeyCount(value, keys, 1) === 0 ? [issueFactory(value, options)] : null),
       { type: CODE_OBJECT_OR_KEYS, param: keys }
     );
@@ -170,7 +170,7 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
   prototype.xorKeys = function (keys, options) {
     const issueFactory = createIssueFactory(CODE_OBJECT_XOR_KEYS, ctor.messages[CODE_OBJECT_XOR_KEYS], options, keys);
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => (getKeyCount(value, keys, 2) !== 1 ? [issueFactory(value, options)] : null),
       { type: CODE_OBJECT_XOR_KEYS, param: keys }
     );
@@ -179,7 +179,7 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
   prototype.oxorKeys = function (keys, options) {
     const issueFactory = createIssueFactory(CODE_OBJECT_OXOR_KEYS, ctor.messages[CODE_OBJECT_OXOR_KEYS], options, keys);
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => (getKeyCount(value, keys, 2) > 1 ? [issueFactory(value, options)] : null),
       { type: CODE_OBJECT_OXOR_KEYS, param: keys }
     );

--- a/src/main/plugin/object-essentials.ts
+++ b/src/main/plugin/object-essentials.ts
@@ -120,18 +120,10 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
     const { getPrototypeOf } = Object;
     const issueFactory = createIssueFactory(CODE_OBJECT_PLAIN, ctor.messages[CODE_OBJECT_PLAIN], options, undefined);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        const prototype = getPrototypeOf(output);
-
-        if (prototype !== null && prototype.constructor !== Object) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
+    return this.withOperation(
+      (value, param, options) => {
+        const prototype = getPrototypeOf(value);
+        return prototype !== null && prototype.constructor !== Object ? [issueFactory(value, options)] : null;
       },
       { type: CODE_OBJECT_PLAIN }
     );
@@ -140,18 +132,10 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
   prototype.allKeys = function (keys, options) {
     const issueFactory = createIssueFactory(CODE_OBJECT_ALL_KEYS, ctor.messages[CODE_OBJECT_ALL_KEYS], options, keys);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        const keyCount = getKeyCount(output, keys, keys.length);
-
-        if (keyCount > 0 && keyCount < keys.length) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
+    return this.withOperation(
+      (value, param, options) => {
+        const keyCount = getKeyCount(value, keys, keys.length);
+        return keyCount > 0 && keyCount < keys.length ? [issueFactory(value, options)] : null;
       },
       { type: CODE_OBJECT_ALL_KEYS, param: keys }
     );
@@ -165,18 +149,10 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
       keys
     );
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        const keyCount = getKeyCount(output, keys, keys.length);
-
-        if (keyCount > 0 && keyCount <= keys.length) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
+    return this.withOperation(
+      (value, param, options) => {
+        const keyCount = getKeyCount(value, keys, keys.length);
+        return keyCount > 0 && keyCount <= keys.length ? [issueFactory(value, options)] : null;
       },
       { type: CODE_OBJECT_NOT_ALL_KEYS, param: keys }
     );
@@ -185,17 +161,8 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
   prototype.orKeys = function (keys, options) {
     const issueFactory = createIssueFactory(CODE_OBJECT_OR_KEYS, ctor.messages[CODE_OBJECT_OR_KEYS], options, keys);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (getKeyCount(output, keys, 1) === 0) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
+    return this.withOperation(
+      (value, param, options) => (getKeyCount(value, keys, 1) === 0 ? [issueFactory(value, options)] : null),
       { type: CODE_OBJECT_OR_KEYS, param: keys }
     );
   };
@@ -203,17 +170,8 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
   prototype.xorKeys = function (keys, options) {
     const issueFactory = createIssueFactory(CODE_OBJECT_XOR_KEYS, ctor.messages[CODE_OBJECT_XOR_KEYS], options, keys);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (getKeyCount(output, keys, 2) !== 1) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
+    return this.withOperation(
+      (value, param, options) => (getKeyCount(value, keys, 2) !== 1 ? [issueFactory(value, options)] : null),
       { type: CODE_OBJECT_XOR_KEYS, param: keys }
     );
   };
@@ -221,17 +179,8 @@ export default function enableObjectEssentials(ctor: typeof ObjectShape<any, any
   prototype.oxorKeys = function (keys, options) {
     const issueFactory = createIssueFactory(CODE_OBJECT_OXOR_KEYS, ctor.messages[CODE_OBJECT_OXOR_KEYS], options, keys);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (getKeyCount(output, keys, 2) > 1) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
+    return this.withOperation(
+      (value, param, options) => (getKeyCount(value, keys, 2) > 1 ? [issueFactory(value, options)] : null),
       { type: CODE_OBJECT_OXOR_KEYS, param: keys }
     );
   };

--- a/src/main/plugin/set-essentials.ts
+++ b/src/main/plugin/set-essentials.ts
@@ -83,37 +83,19 @@ export default function enableSetEssentials(ctor: typeof SetShape<any>): void {
   prototype.min = function (size, options) {
     const issueFactory = createIssueFactory(CODE_SET_MIN, ctor.messages[CODE_SET_MIN], options, size);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (output.size < size) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
-      { type: CODE_SET_MIN, param: size }
-    );
+    return this.withOperation((value, param, options) => (value.size < param ? [issueFactory(value, options)] : null), {
+      type: CODE_SET_MIN,
+      param: size,
+    });
   };
 
   prototype.max = function (size, options) {
     const issueFactory = createIssueFactory(CODE_SET_MAX, ctor.messages[CODE_SET_MAX], options, size);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (output.size > size) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
-      { type: CODE_SET_MAX, param: size }
-    );
+    return this.withOperation((value, param, options) => (value.size > param ? [issueFactory(value, options)] : null), {
+      type: CODE_SET_MAX,
+      param: size,
+    });
   };
 
   prototype.nonEmpty = function (options) {

--- a/src/main/plugin/set-essentials.ts
+++ b/src/main/plugin/set-essentials.ts
@@ -83,7 +83,7 @@ export default function enableSetEssentials(ctor: typeof SetShape<any>): void {
   prototype.min = function (size, options) {
     const issueFactory = createIssueFactory(CODE_SET_MIN, ctor.messages[CODE_SET_MIN], options, size);
 
-    return this.withOperation((value, param, options) => (value.size < param ? [issueFactory(value, options)] : null), {
+    return this.addOperation((value, param, options) => (value.size < param ? [issueFactory(value, options)] : null), {
       type: CODE_SET_MIN,
       param: size,
     });
@@ -92,7 +92,7 @@ export default function enableSetEssentials(ctor: typeof SetShape<any>): void {
   prototype.max = function (size, options) {
     const issueFactory = createIssueFactory(CODE_SET_MAX, ctor.messages[CODE_SET_MAX], options, size);
 
-    return this.withOperation((value, param, options) => (value.size > param ? [issueFactory(value, options)] : null), {
+    return this.addOperation((value, param, options) => (value.size > param ? [issueFactory(value, options)] : null), {
       type: CODE_SET_MAX,
       param: size,
     });

--- a/src/main/plugin/set-essentials.ts
+++ b/src/main/plugin/set-essentials.ts
@@ -83,19 +83,29 @@ export default function enableSetEssentials(ctor: typeof SetShape<any>): void {
   prototype.min = function (size, options) {
     const issueFactory = createIssueFactory(CODE_SET_MIN, ctor.messages[CODE_SET_MIN], options, size);
 
-    return this.addOperation((value, param, options) => (value.size < param ? [issueFactory(value, options)] : null), {
-      type: CODE_SET_MIN,
-      param: size,
-    });
+    return this.addOperation(
+      (value, param, options) => {
+        if (value.size >= param) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
+      { type: CODE_SET_MIN, param: size }
+    );
   };
 
   prototype.max = function (size, options) {
     const issueFactory = createIssueFactory(CODE_SET_MAX, ctor.messages[CODE_SET_MAX], options, size);
 
-    return this.addOperation((value, param, options) => (value.size > param ? [issueFactory(value, options)] : null), {
-      type: CODE_SET_MAX,
-      param: size,
-    });
+    return this.addOperation(
+      (value, param, options) => {
+        if (value.size <= param) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
+      { type: CODE_SET_MAX, param: size }
+    );
   };
 
   prototype.nonEmpty = function (options) {

--- a/src/main/plugin/string-essentials.ts
+++ b/src/main/plugin/string-essentials.ts
@@ -181,17 +181,8 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
   prototype.min = function (length, options) {
     const issueFactory = createIssueFactory(CODE_STRING_MIN, ctor.messages[CODE_STRING_MIN], options, length);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (output.length < length) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
+    return this.withOperation(
+      (value, param, options) => (value.length < param ? [issueFactory(value, options)] : null),
       { type: CODE_STRING_MIN, param: length }
     );
   };
@@ -199,17 +190,8 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
   prototype.max = function (length, options) {
     const issueFactory = createIssueFactory(CODE_STRING_MAX, ctor.messages[CODE_STRING_MAX], options, length);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (output.length > length) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
+    return this.withOperation(
+      (value, param, options) => (value.length > param ? [issueFactory(value, options)] : null),
       { type: CODE_STRING_MAX, param: length }
     );
   };
@@ -217,35 +199,17 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
   prototype.regex = function (re, options) {
     const issueFactory = createIssueFactory(CODE_STRING_REGEX, ctor.messages[CODE_STRING_REGEX], options, re);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (!re.test(output)) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
-      { type: CODE_STRING_REGEX, param: re }
-    );
+    return this.withOperation((value, param, options) => (!re.test(value) ? [issueFactory(value, options)] : null), {
+      type: CODE_STRING_REGEX,
+      param: re,
+    });
   };
 
   prototype.includes = function (value, options) {
     const issueFactory = createIssueFactory(CODE_STRING_INCLUDES, ctor.messages[CODE_STRING_INCLUDES], options, value);
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (output.indexOf(value) === -1) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
+    return this.withOperation(
+      (value, param, options) => (value.indexOf(param) === -1 ? [issueFactory(value, options)] : null),
       { type: CODE_STRING_INCLUDES, param: value }
     );
   };
@@ -258,17 +222,8 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
       value
     );
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (!output.startsWith(value)) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
+    return this.withOperation(
+      (value, param, options) => (!value.startsWith(param) ? [issueFactory(value, options)] : null),
       { type: CODE_STRING_STARTS_WITH, param: value }
     );
   };
@@ -281,17 +236,8 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
       value
     );
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (!output.endsWith(value)) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
+    return this.withOperation(
+      (value, param, options) => (!value.endsWith(param) ? [issueFactory(value, options)] : null),
       { type: CODE_STRING_ENDS_WITH, param: value }
     );
   };
@@ -304,17 +250,8 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
       undefined
     );
 
-    return this.use(
-      next => (input, output, options, issues) => {
-        if (output.trim().length === 0) {
-          (issues ||= []).push(issueFactory(output, options));
-
-          if (options.earlyReturn) {
-            return issues;
-          }
-        }
-        return next(input, output, options, issues);
-      },
+    return this.withOperation(
+      (value, param, options) => (value.trim().length === 0 ? [issueFactory(value, options)] : null),
       { type: CODE_STRING_NON_BLANK }
     );
   };
@@ -324,19 +261,19 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
   };
 
   prototype.trim = function () {
-    return this.use(next => (input, output, options, issues) => next(input, output.trim(), options, issues), {
+    return this.withOperation((value, param, options) => ({ ok: true, value: value.trim() }), {
       type: 'string.trim',
     });
   };
 
   prototype.toLowerCase = function () {
-    return this.use(next => (input, output, options, issues) => next(input, output.toLowerCase(), options, issues), {
+    return this.withOperation((value, param, options) => ({ ok: true, value: value.toLowerCase() }), {
       type: 'string.toLowerCase',
     });
   };
 
   prototype.toUpperCase = function () {
-    return this.use(next => (input, output, options, issues) => next(input, output.toUpperCase(), options, issues), {
+    return this.withOperation((value, param, options) => ({ ok: true, value: value.toUpperCase() }), {
       type: 'string.toUpperCase',
     });
   };

--- a/src/main/plugin/string-essentials.ts
+++ b/src/main/plugin/string-essentials.ts
@@ -181,7 +181,7 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
   prototype.min = function (length, options) {
     const issueFactory = createIssueFactory(CODE_STRING_MIN, ctor.messages[CODE_STRING_MIN], options, length);
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => (value.length < param ? [issueFactory(value, options)] : null),
       { type: CODE_STRING_MIN, param: length }
     );
@@ -190,7 +190,7 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
   prototype.max = function (length, options) {
     const issueFactory = createIssueFactory(CODE_STRING_MAX, ctor.messages[CODE_STRING_MAX], options, length);
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => (value.length > param ? [issueFactory(value, options)] : null),
       { type: CODE_STRING_MAX, param: length }
     );
@@ -199,7 +199,7 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
   prototype.regex = function (re, options) {
     const issueFactory = createIssueFactory(CODE_STRING_REGEX, ctor.messages[CODE_STRING_REGEX], options, re);
 
-    return this.withOperation((value, param, options) => (!re.test(value) ? [issueFactory(value, options)] : null), {
+    return this.addOperation((value, param, options) => (!re.test(value) ? [issueFactory(value, options)] : null), {
       type: CODE_STRING_REGEX,
       param: re,
     });
@@ -208,7 +208,7 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
   prototype.includes = function (value, options) {
     const issueFactory = createIssueFactory(CODE_STRING_INCLUDES, ctor.messages[CODE_STRING_INCLUDES], options, value);
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => (value.indexOf(param) === -1 ? [issueFactory(value, options)] : null),
       { type: CODE_STRING_INCLUDES, param: value }
     );
@@ -222,7 +222,7 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
       value
     );
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => (!value.startsWith(param) ? [issueFactory(value, options)] : null),
       { type: CODE_STRING_STARTS_WITH, param: value }
     );
@@ -236,7 +236,7 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
       value
     );
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => (!value.endsWith(param) ? [issueFactory(value, options)] : null),
       { type: CODE_STRING_ENDS_WITH, param: value }
     );
@@ -250,7 +250,7 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
       undefined
     );
 
-    return this.withOperation(
+    return this.addOperation(
       (value, param, options) => (value.trim().length === 0 ? [issueFactory(value, options)] : null),
       { type: CODE_STRING_NON_BLANK }
     );
@@ -261,19 +261,19 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
   };
 
   prototype.trim = function () {
-    return this.withOperation((value, param, options) => ({ ok: true, value: value.trim() }), {
+    return this.addOperation((value, param, options) => ({ ok: true, value: value.trim() }), {
       type: 'string.trim',
     });
   };
 
   prototype.toLowerCase = function () {
-    return this.withOperation((value, param, options) => ({ ok: true, value: value.toLowerCase() }), {
+    return this.addOperation((value, param, options) => ({ ok: true, value: value.toLowerCase() }), {
       type: 'string.toLowerCase',
     });
   };
 
   prototype.toUpperCase = function () {
-    return this.withOperation((value, param, options) => ({ ok: true, value: value.toUpperCase() }), {
+    return this.addOperation((value, param, options) => ({ ok: true, value: value.toUpperCase() }), {
       type: 'string.toUpperCase',
     });
   };

--- a/src/main/plugin/string-essentials.ts
+++ b/src/main/plugin/string-essentials.ts
@@ -182,7 +182,12 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
     const issueFactory = createIssueFactory(CODE_STRING_MIN, ctor.messages[CODE_STRING_MIN], options, length);
 
     return this.addOperation(
-      (value, param, options) => (value.length < param ? [issueFactory(value, options)] : null),
+      (value, param, options) => {
+        if (value.length >= param) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
       { type: CODE_STRING_MIN, param: length }
     );
   };
@@ -191,7 +196,12 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
     const issueFactory = createIssueFactory(CODE_STRING_MAX, ctor.messages[CODE_STRING_MAX], options, length);
 
     return this.addOperation(
-      (value, param, options) => (value.length > param ? [issueFactory(value, options)] : null),
+      (value, param, options) => {
+        if (value.length <= param) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
       { type: CODE_STRING_MAX, param: length }
     );
   };
@@ -199,17 +209,27 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
   prototype.regex = function (re, options) {
     const issueFactory = createIssueFactory(CODE_STRING_REGEX, ctor.messages[CODE_STRING_REGEX], options, re);
 
-    return this.addOperation((value, param, options) => (!re.test(value) ? [issueFactory(value, options)] : null), {
-      type: CODE_STRING_REGEX,
-      param: re,
-    });
+    return this.addOperation(
+      (value, param, options) => {
+        if (param.test(value)) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
+      { type: CODE_STRING_REGEX, param: re }
+    );
   };
 
   prototype.includes = function (value, options) {
     const issueFactory = createIssueFactory(CODE_STRING_INCLUDES, ctor.messages[CODE_STRING_INCLUDES], options, value);
 
     return this.addOperation(
-      (value, param, options) => (value.indexOf(param) === -1 ? [issueFactory(value, options)] : null),
+      (value, param, options) => {
+        if (value.includes(param)) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
       { type: CODE_STRING_INCLUDES, param: value }
     );
   };
@@ -223,7 +243,12 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
     );
 
     return this.addOperation(
-      (value, param, options) => (!value.startsWith(param) ? [issueFactory(value, options)] : null),
+      (value, param, options) => {
+        if (value.startsWith(param)) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
       { type: CODE_STRING_STARTS_WITH, param: value }
     );
   };
@@ -237,7 +262,12 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
     );
 
     return this.addOperation(
-      (value, param, options) => (!value.endsWith(param) ? [issueFactory(value, options)] : null),
+      (value, param, options) => {
+        if (value.endsWith(param)) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
       { type: CODE_STRING_ENDS_WITH, param: value }
     );
   };
@@ -251,7 +281,12 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
     );
 
     return this.addOperation(
-      (value, param, options) => (value.trim().length === 0 ? [issueFactory(value, options)] : null),
+      (value, param, options) => {
+        if (value.trim().length !== 0) {
+          return null;
+        }
+        return [issueFactory(value, options)];
+      },
       { type: CODE_STRING_NON_BLANK }
     );
   };
@@ -261,20 +296,29 @@ export default function enableStringEssentials(ctor: typeof StringShape): void {
   };
 
   prototype.trim = function () {
-    return this.addOperation((value, param, options) => ({ ok: true, value: value.trim() }), {
-      type: 'string.trim',
-    });
+    return this.addOperation(
+      (value, param, options) => {
+        return { ok: true, value: value.trim() };
+      },
+      { type: 'string.trim' }
+    );
   };
 
   prototype.toLowerCase = function () {
-    return this.addOperation((value, param, options) => ({ ok: true, value: value.toLowerCase() }), {
-      type: 'string.toLowerCase',
-    });
+    return this.addOperation(
+      (value, param, options) => {
+        return { ok: true, value: value.toLowerCase() };
+      },
+      { type: 'string.toLowerCase' }
+    );
   };
 
   prototype.toUpperCase = function () {
-    return this.addOperation((value, param, options) => ({ ok: true, value: value.toUpperCase() }), {
-      type: 'string.toUpperCase',
-    });
+    return this.addOperation(
+      (value, param, options) => {
+        return { ok: true, value: value.toUpperCase() };
+      },
+      { type: 'string.toUpperCase' }
+    );
   };
 }

--- a/src/main/shape/ArrayShape.ts
+++ b/src/main/shape/ArrayShape.ts
@@ -272,7 +272,7 @@ export class ArrayShape<HeadShapes extends readonly AnyShape[], RestShape extend
           );
         }
 
-        return this._applyOperations(input, output, options, issues);
+        return this._applyOperationsAsync(input, output, options, issues);
       };
 
       resolve(next());

--- a/src/main/shape/ArrayShape.ts
+++ b/src/main/shape/ArrayShape.ts
@@ -211,7 +211,7 @@ export class ArrayShape<HeadShapes extends readonly AnyShape[], RestShape extend
         }
       }
     }
-    return this._applyOperations(input, output, options, issues);
+    return this._applyOperations(input, output, options, issues) as Result;
   }
 
   protected _applyAsync(

--- a/src/main/shape/ArrayShape.ts
+++ b/src/main/shape/ArrayShape.ts
@@ -272,7 +272,7 @@ export class ArrayShape<HeadShapes extends readonly AnyShape[], RestShape extend
           );
         }
 
-        return this._applyOperationsAsync(input, output, options, issues);
+        return this._applyOperations(input, output, options, issues);
       };
 
       resolve(next());

--- a/src/main/shape/BigIntShape.ts
+++ b/src/main/shape/BigIntShape.ts
@@ -39,7 +39,7 @@ export class BigIntShape extends CoercibleShape<bigint> {
     if (typeof output !== 'bigint' && (output = this._applyCoerce(input)) === NEVER) {
       return [this._typeIssueFactory(input, options)];
     }
-    return this._applyOperations(input, output, options, null);
+    return this._applyOperations(input, output, options, null) as Result;
   }
 }
 

--- a/src/main/shape/BooleanShape.ts
+++ b/src/main/shape/BooleanShape.ts
@@ -39,7 +39,7 @@ export class BooleanShape extends CoercibleShape<boolean> {
     if (typeof output !== 'boolean' && (output = this._applyCoerce(input)) === NEVER) {
       return [this._typeIssueFactory(input, options)];
     }
-    return this._applyOperations(input, output, options, null);
+    return this._applyOperations(input, output, options, null) as Result;
   }
 }
 

--- a/src/main/shape/BooleanShape.ts
+++ b/src/main/shape/BooleanShape.ts
@@ -5,7 +5,6 @@ import { booleanInputs, TYPE_BOOLEAN } from '../types';
 import { ApplyOptions, IssueOptions, Message, Result } from '../typings';
 import { createIssueFactory } from '../utils';
 import { CoercibleShape } from './CoercibleShape';
-import { Shape } from './Shape';
 
 /**
  * The shape of a boolean value.
@@ -26,7 +25,7 @@ export class BooleanShape extends CoercibleShape<boolean> {
   constructor(options?: IssueOptions | Message) {
     super();
 
-    this._typeIssueFactory = createIssueFactory(CODE_TYPE, Shape.messages['type.boolean'], options, TYPE_BOOLEAN);
+    this._typeIssueFactory = createIssueFactory(CODE_TYPE, new.target.messages['type.boolean'], options, TYPE_BOOLEAN);
   }
 
   protected _getInputs(): readonly unknown[] {

--- a/src/main/shape/BooleanShape.ts
+++ b/src/main/shape/BooleanShape.ts
@@ -5,6 +5,7 @@ import { booleanInputs, TYPE_BOOLEAN } from '../types';
 import { ApplyOptions, IssueOptions, Message, Result } from '../typings';
 import { createIssueFactory } from '../utils';
 import { CoercibleShape } from './CoercibleShape';
+import { Shape } from './Shape';
 
 /**
  * The shape of a boolean value.
@@ -25,7 +26,7 @@ export class BooleanShape extends CoercibleShape<boolean> {
   constructor(options?: IssueOptions | Message) {
     super();
 
-    this._typeIssueFactory = createIssueFactory(CODE_TYPE, new.target.messages['type.boolean'], options, TYPE_BOOLEAN);
+    this._typeIssueFactory = createIssueFactory(CODE_TYPE, Shape.messages['type.boolean'], options, TYPE_BOOLEAN);
   }
 
   protected _getInputs(): readonly unknown[] {

--- a/src/main/shape/CoercibleShape.ts
+++ b/src/main/shape/CoercibleShape.ts
@@ -24,7 +24,7 @@ export class CoercibleShape<InputValue = any, OutputValue = InputValue, CoercedV
    * Applies coercion rules to the given value. Call this method in {@link Shape._apply} and {@link Shape._applyAsync}
    * to coerce the input.
    *
-   * Override {@link _coerce} and {@link _getInputs} methods to implement custom type coercion.
+   * Override {@link CoercibleShape._coerce} and {@link Shape._getInputs} methods to implement custom type coercion.
    *
    * @param input The input value to coerce.
    * @returns The coerced value, or {@link NEVER} if coercion isn't possible.
@@ -45,7 +45,7 @@ export class CoercibleShape<InputValue = any, OutputValue = InputValue, CoercedV
   /**
    * Coerces an input value to another type.
    *
-   * Override this method along with {@link _getInputs} to implement custom type coercion.
+   * Override this method along with {@link Shape._getInputs} to implement custom type coercion.
    *
    * @param input The input value to coerce.
    * @returns The coerced value, or {@link NEVER} if coercion isn't possible.

--- a/src/main/shape/ConstShape.ts
+++ b/src/main/shape/ConstShape.ts
@@ -69,6 +69,6 @@ export class ConstShape<Value> extends CoercibleShape<Value> {
     if (!this._typePredicate(input) && (output = this._applyCoerce(input)) === NEVER) {
       return [this._typeIssueFactory(input, options)];
     }
-    return this._applyOperations(input, output, options, null);
+    return this._applyOperations(input, output, options, null) as Result;
   }
 }

--- a/src/main/shape/DateShape.ts
+++ b/src/main/shape/DateShape.ts
@@ -39,7 +39,7 @@ export class DateShape extends CoercibleShape<Date> {
     if (!isValidDate(input) && (output = this._applyCoerce(input)) === NEVER) {
       return [this._typeIssueFactory(input, options)];
     }
-    return this._applyOperations(input, output, options, null);
+    return this._applyOperations(input, output, options, null) as Result;
   }
 }
 

--- a/src/main/shape/EnumShape.ts
+++ b/src/main/shape/EnumShape.ts
@@ -87,7 +87,7 @@ export class EnumShape<Value> extends CoercibleShape<Value> {
     if (!this.values.includes(output) && (output = this._applyCoerce(input)) === NEVER) {
       return [this._typeIssueFactory(input, options)];
     }
-    return this._applyOperations(input, output, options, null);
+    return this._applyOperations(input, output, options, null) as Result;
   }
 }
 

--- a/src/main/shape/FunctionShape.ts
+++ b/src/main/shape/FunctionShape.ts
@@ -5,7 +5,7 @@ import {
   Awaitable,
   copyOperations,
   defaultApplyOptions,
-  getMessage,
+  getErrorMessage,
   INPUT,
   nextNonce,
   ok,
@@ -308,7 +308,7 @@ function getValue(key: string, result: Result, input: unknown, options: ParseOpt
   }
   if (isArray(result)) {
     unshiftIssuesPath(result, key);
-    throw new ValidationError(result, getMessage(result, input, options));
+    throw new ValidationError(result, getErrorMessage(result, input, options));
   }
   return result.value;
 }

--- a/src/main/shape/FunctionShape.ts
+++ b/src/main/shape/FunctionShape.ts
@@ -95,7 +95,7 @@ export class FunctionShape<
   }
 
   /**
-   * `true` if some shapes that describe the function signature are {@link Shape#isAsync async}, or `false` otherwise.
+   * `true` if some shapes that describe the function signature are {@link Shape.isAsync async}, or `false` otherwise.
    */
   get isAsyncFunction(): boolean {
     return this.returnShape?.isAsync || this.thisShape?.isAsync || this.argsShape.isAsync;
@@ -191,8 +191,8 @@ export class FunctionShape<
    * {@linkcode FunctionShape.argsShape} and the {@linkcode FunctionShape.thisShape} respectively, and _asynchronously_
    * returns the value that conforms the {@linkcode FunctionShape.returnShape}.
    *
-   * Use this method if {@link FunctionShape#isAsyncFunction some shapes that describe the function signature} are
-   * {@link Shape#isAsync async}.
+   * Use this method if {@link FunctionShape.isAsyncFunction some shapes that describe the function signature} are
+   * {@link Shape.isAsync async}.
    *
    * @param fn The underlying function.
    * @param options Parsing options. By default, options provided to {@linkcode FunctionShape.strict} are used.

--- a/src/main/shape/InstanceShape.ts
+++ b/src/main/shape/InstanceShape.ts
@@ -66,6 +66,6 @@ export class InstanceShape<Ctor extends new (...args: any) => any> extends Shape
     if (!(input instanceof this.ctor)) {
       return [this._typeIssueFactory(input, options)];
     }
-    return this._applyOperations(input, input, options, null);
+    return this._applyOperations(input, input, options, null) as Result;
   }
 }

--- a/src/main/shape/IntersectionShape.ts
+++ b/src/main/shape/IntersectionShape.ts
@@ -214,7 +214,7 @@ export class IntersectionShape<Shapes extends readonly AnyShape[]>
         return [this._typeIssueFactory(input, options)];
       }
     }
-    return this._applyOperations(input, output, options, null);
+    return this._applyOperations(input, output, options, null) as Result;
   }
 }
 

--- a/src/main/shape/LazyShape.ts
+++ b/src/main/shape/LazyShape.ts
@@ -112,6 +112,8 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
   protected _apply(input: unknown, options: ApplyOptions, nonce: number): Result<Output<ProvidedShape> | Pointer> {
     const { _stackMap } = this;
 
+    let output = input;
+    let result;
     let stack = _stackMap.get(nonce);
 
     const leading = stack === undefined;
@@ -120,7 +122,6 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
       stack = [input];
       _stackMap.set(nonce, stack);
     } else if (stack.includes(input)) {
-      let output;
       try {
         output = this.pointerProvider(input, options);
       } catch (error) {
@@ -132,12 +133,20 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
     }
 
     try {
-      return this._handleResult(this.providedShape['_apply'](input, options, nonce), input, options);
+      result = this.providedShape['_apply'](input, options, nonce);
     } finally {
       if (leading) {
         _stackMap.delete(nonce);
       }
     }
+
+    if (result !== null) {
+      if (isArray(result)) {
+        return result;
+      }
+      output = result.value;
+    }
+    return this._applyOperations(input, output, options, null) as Result;
   }
 
   protected _applyAsync(
@@ -147,6 +156,7 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
   ): Promise<Result<Output<ProvidedShape> | Pointer>> {
     const { _stackMap } = this;
 
+    let output = input;
     let stack = _stackMap.get(nonce);
 
     const leading = stack === undefined;
@@ -156,7 +166,6 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
       _stackMap.set(nonce, stack);
     } else if (stack.includes(input)) {
       return new Promise(resolve => {
-        let output;
         try {
           output = this.pointerProvider(input, options);
         } catch (error) {
@@ -174,7 +183,13 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
         if (leading) {
           _stackMap.delete(nonce);
         }
-        return this._handleResult(result, input, options);
+        if (result !== null) {
+          if (isArray(result)) {
+            return result;
+          }
+          output = result.value;
+        }
+        return this._applyOperations(input, output, options, null);
       },
       error => {
         if (leading) {
@@ -183,21 +198,5 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
         throw error;
       }
     );
-  }
-
-  private _handleResult(
-    result: Result,
-    input: unknown,
-    options: ApplyOptions
-  ): Result<Output<ProvidedShape> | Pointer> {
-    let output = input;
-
-    if (result !== null) {
-      if (isArray(result)) {
-        return result;
-      }
-      output = result.value;
-    }
-    return this._applyOperations(input, output, options, null) as Result;
   }
 }

--- a/src/main/shape/LazyShape.ts
+++ b/src/main/shape/LazyShape.ts
@@ -1,5 +1,6 @@
 import { ERR_SHAPE_EXPECTED } from '../constants';
-import { defineProperty, identity, isArray } from '../internal/lang';
+import { identity, isArray } from '../internal/lang';
+import { defineObjectProperty } from '../internal/objects';
 import { captureIssues, copyOperations, ok, toDeepPartialShape } from '../internal/shapes';
 import { Any, ApplyOptions, Result } from '../typings';
 import { AnyShape, DeepPartialProtocol, DeepPartialShape, Input, Output, Shape } from './Shape';
@@ -64,7 +65,7 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
    * The lazy-loaded shape.
    */
   get providedShape(): ProvidedShape {
-    return defineProperty(this, 'providedShape', this._cachingShapeProvider(), true);
+    return defineObjectProperty(this, 'providedShape', this._cachingShapeProvider(), true);
   }
 
   at(key: unknown): AnyShape | null {

--- a/src/main/shape/LazyShape.ts
+++ b/src/main/shape/LazyShape.ts
@@ -198,6 +198,6 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
       }
       output = result.value;
     }
-    return this._applyOperations(input, output, options, null);
+    return this._applyOperations(input, output, options, null) as Result;
   }
 }

--- a/src/main/shape/LazyShape.ts
+++ b/src/main/shape/LazyShape.ts
@@ -1,6 +1,6 @@
 import { ERR_SHAPE_EXPECTED } from '../constants';
 import { identity, isArray } from '../internal/lang';
-import { defineObjectProperty } from '../internal/objects';
+import { overrideProperty } from '../internal/objects';
 import { captureIssues, copyOperations, ok, toDeepPartialShape } from '../internal/shapes';
 import { Any, ApplyOptions, Result } from '../typings';
 import { AnyShape, DeepPartialProtocol, DeepPartialShape, Input, Output, Shape } from './Shape';
@@ -65,7 +65,7 @@ export class LazyShape<ProvidedShape extends AnyShape, Pointer>
    * The lazy-loaded shape.
    */
   get providedShape(): ProvidedShape {
-    return defineObjectProperty(this, 'providedShape', this._cachingShapeProvider(), true);
+    return overrideProperty(this, 'providedShape', this._cachingShapeProvider());
   }
 
   at(key: unknown): AnyShape | null {

--- a/src/main/shape/MapShape.ts
+++ b/src/main/shape/MapShape.ts
@@ -175,7 +175,7 @@ export class MapShape<KeyShape extends AnyShape, ValueShape extends AnyShape>
       }
     }
 
-    return this._applyOperations(input, changed ? new Map(entries) : input, options, issues);
+    return this._applyOperations(input, changed ? new Map(entries) : input, options, issues) as Result;
   }
 
   protected _applyAsync(

--- a/src/main/shape/NumberShape.ts
+++ b/src/main/shape/NumberShape.ts
@@ -55,7 +55,7 @@ export class NumberShape extends CoercibleShape<number> {
     if ((typeof output !== 'number' || output !== output) && (output = this._applyCoerce(input)) === NEVER) {
       return [this._typeIssueFactory(input, options)];
     }
-    return this._applyOperations(input, output, options, null);
+    return this._applyOperations(input, output, options, null) as Result;
   }
 }
 

--- a/src/main/shape/ObjectShape.ts
+++ b/src/main/shape/ObjectShape.ts
@@ -1,7 +1,14 @@
 import { CODE_OBJECT_EXACT, CODE_TYPE } from '../constants';
 import { Bitmask, getBit, toggleBit } from '../internal/bitmasks';
-import { defineProperty, isArray, isObject } from '../internal/lang';
-import { cloneDict, cloneDictKeys, Dict, ReadonlyDict, setObjectProperty } from '../internal/objects';
+import { isArray, isObject } from '../internal/lang';
+import {
+  cloneDict,
+  cloneDictKeys,
+  defineObjectProperty,
+  Dict,
+  ReadonlyDict,
+  setObjectProperty,
+} from '../internal/objects';
 import {
   applyShape,
   concatIssues,
@@ -141,7 +148,7 @@ export class ObjectShape<PropShapes extends ReadonlyDict<AnyShape>, RestShape ex
    * The enum shape that describes object keys.
    */
   get keysShape(): EnumShape<keyof PropShapes> {
-    return defineProperty(this, 'keysShape', new EnumShape(this.keys), true);
+    return defineObjectProperty(this, 'keysShape', new EnumShape(this.keys), true);
   }
 
   at(key: any): AnyShape | null {

--- a/src/main/shape/ObjectShape.ts
+++ b/src/main/shape/ObjectShape.ts
@@ -525,7 +525,7 @@ export class ObjectShape<PropShapes extends ReadonlyDict<AnyShape>, RestShape ex
         setObjectProperty(output, key, result.value);
       }
     }
-    return this._applyOperations(input, output, options, issues);
+    return this._applyOperations(input, output, options, issues) as Result;
   }
 
   /**
@@ -645,6 +645,6 @@ export class ObjectShape<PropShapes extends ReadonlyDict<AnyShape>, RestShape ex
         }
       }
     }
-    return this._applyOperations(input, output, options, issues);
+    return this._applyOperations(input, output, options, issues) as Result;
   }
 }

--- a/src/main/shape/ObjectShape.ts
+++ b/src/main/shape/ObjectShape.ts
@@ -1,14 +1,7 @@
 import { CODE_OBJECT_EXACT, CODE_TYPE } from '../constants';
 import { Bitmask, getBit, toggleBit } from '../internal/bitmasks';
 import { isArray, isObject } from '../internal/lang';
-import {
-  cloneDict,
-  cloneDictKeys,
-  defineObjectProperty,
-  Dict,
-  ReadonlyDict,
-  setObjectProperty,
-} from '../internal/objects';
+import { cloneDict, cloneDictKeys, Dict, overrideProperty, ReadonlyDict, setObjectProperty } from '../internal/objects';
 import {
   applyShape,
   concatIssues,
@@ -148,7 +141,7 @@ export class ObjectShape<PropShapes extends ReadonlyDict<AnyShape>, RestShape ex
    * The enum shape that describes object keys.
    */
   get keysShape(): EnumShape<keyof PropShapes> {
-    return defineObjectProperty(this, 'keysShape', new EnumShape(this.keys), true);
+    return overrideProperty(this, 'keysShape', new EnumShape(this.keys));
   }
 
   at(key: any): AnyShape | null {

--- a/src/main/shape/PromiseShape.ts
+++ b/src/main/shape/PromiseShape.ts
@@ -83,7 +83,7 @@ export class PromiseShape<ValueShape extends AnyShape | null>
     if (!(input instanceof Promise) && (output = this._applyCoerce(input)) === NEVER) {
       return [this._typeIssueFactory(input, options)];
     }
-    return this._applyOperations(input, output, options, null);
+    return this._applyOperations(input, output, options, null) as Result;
   }
 
   protected _applyAsync(

--- a/src/main/shape/RecordShape.ts
+++ b/src/main/shape/RecordShape.ts
@@ -141,7 +141,7 @@ export class RecordShape<KeyShape extends Shape<string, PropertyKey> | null, Val
         setObjectProperty(output, key, value);
       }
     }
-    return this._applyOperations(input, output, options, issues);
+    return this._applyOperations(input, output, options, issues) as Result;
   }
 
   protected _applyAsync(

--- a/src/main/shape/SetShape.ts
+++ b/src/main/shape/SetShape.ts
@@ -118,7 +118,7 @@ export class SetShape<ValueShape extends AnyShape>
       values[i] = result.value;
     }
 
-    return this._applyOperations(input, changed ? new Set(values) : input, options, issues);
+    return this._applyOperations(input, changed ? new Set(values) : input, options, issues) as Result;
   }
 
   protected _applyAsync(input: any, options: ApplyOptions, nonce: number): Promise<Result<Set<Output<ValueShape>>>> {

--- a/src/main/shape/Shape.ts
+++ b/src/main/shape/Shape.ts
@@ -1003,16 +1003,10 @@ Object.defineProperties(Shape.prototype, {
     get(this: Shape) {
       defineObjectProperty(this, 'isAsync', false);
 
-      let async = false;
+      let async = this._isAsync();
 
       for (let i = 0; !async && i < this.operations.length; ++i) {
         async ||= this.operations[i].isAsync;
-      }
-
-      async ||= this._isAsync();
-
-      if (!async && this._applyAsync !== Shape.prototype._applyAsync) {
-        this._applyAsync = Shape.prototype._applyAsync;
       }
 
       return defineObjectProperty(this, 'isAsync', async, true);
@@ -1047,9 +1041,6 @@ Object.defineProperties(Shape.prototype, {
     configurable: true,
 
     get(this: Shape) {
-      // Ensure _applyAsync is configured
-      this.isAsync;
-
       return defineObjectProperty<Shape['tryAsync']>(this, 'tryAsync', (input, options) => {
         return this._applyAsync(input, options || defaultApplyOptions, nextNonce()).then(result => {
           if (result === null) {
@@ -1092,9 +1083,6 @@ Object.defineProperties(Shape.prototype, {
     configurable: true,
 
     get(this: Shape) {
-      // Ensure _applyAsync is configured
-      this.isAsync;
-
       return defineObjectProperty<Shape['parseAsync']>(this, 'parseAsync', (input, options) => {
         return this._applyAsync(input, options || defaultApplyOptions, nextNonce()).then(result => {
           if (result === null) {
@@ -1137,9 +1125,6 @@ Object.defineProperties(Shape.prototype, {
     configurable: true,
 
     get(this: Shape) {
-      // Ensure _applyAsync is configured
-      this.isAsync;
-
       return defineObjectProperty(
         this,
         'parseOrDefaultAsync',

--- a/src/main/shape/Shape.ts
+++ b/src/main/shape/Shape.ts
@@ -8,7 +8,7 @@ import {
   createApplyOperations,
   defaultApplyOptions,
   extractCheckResult,
-  getMessage,
+  getErrorMessage,
   nextNonce,
   ok,
   Promisify,
@@ -1071,7 +1071,7 @@ Object.defineProperties(Shape.prototype, {
                 return input;
               }
               if (isArray(result)) {
-                throw new ValidationError(result, getMessage(result, input, options));
+                throw new ValidationError(result, getErrorMessage(result, input, options));
               }
               return result.value;
             }
@@ -1089,7 +1089,7 @@ Object.defineProperties(Shape.prototype, {
             return input;
           }
           if (isArray(result)) {
-            throw new ValidationError(result, getMessage(result, input, options));
+            throw new ValidationError(result, getErrorMessage(result, input, options));
           }
           return result.value;
         });

--- a/src/main/shape/Shape.ts
+++ b/src/main/shape/Shape.ts
@@ -1,18 +1,18 @@
 import { CODE_ANY_DENY, CODE_ANY_EXCLUDE, CODE_ANY_REFINE } from '../constants';
 import { freeze, isArray, isEqual, returnTrue } from '../internal/lang';
-import { defineObjectProperty, Dict, ReadonlyDict } from '../internal/objects';
+import { Dict, overrideProperty, ReadonlyDict } from '../internal/objects';
 import type { INPUT, OUTPUT } from '../internal/shapes';
 import {
-  extractCheckResult,
   applyShape,
   captureIssues,
   createApplyOperations,
   defaultApplyOptions,
-  throwSyncUnsupported,
+  extractCheckResult,
   getMessage,
   nextNonce,
   ok,
   Promisify,
+  throwSyncUnsupported,
   toDeepPartialShape,
   universalApplyOperations,
 } from '../internal/shapes';
@@ -983,7 +983,7 @@ Object.defineProperties(Shape.prototype, {
         cb = createApplyOperations(operation, cb, async);
       }
 
-      return defineObjectProperty(this, '_applyOperations', cb);
+      return overrideProperty(this, '_applyOperations', cb);
     },
   },
 
@@ -991,9 +991,9 @@ Object.defineProperties(Shape.prototype, {
     configurable: true,
 
     get(this: Shape) {
-      defineObjectProperty(this, 'inputs', []);
+      overrideProperty(this, 'inputs', []);
 
-      return defineObjectProperty(this, 'inputs', freeze(unionTypes(this._getInputs())), true);
+      return overrideProperty(this, 'inputs', freeze(unionTypes(this._getInputs())));
     },
   },
 
@@ -1001,7 +1001,7 @@ Object.defineProperties(Shape.prototype, {
     configurable: true,
 
     get(this: Shape) {
-      defineObjectProperty(this, 'isAsync', false);
+      overrideProperty(this, 'isAsync', false);
 
       let async = this._isAsync();
 
@@ -1009,7 +1009,7 @@ Object.defineProperties(Shape.prototype, {
         async ||= this.operations[i].isAsync;
       }
 
-      return defineObjectProperty(this, 'isAsync', async, true);
+      return overrideProperty(this, 'isAsync', async);
     },
   },
 
@@ -1017,7 +1017,7 @@ Object.defineProperties(Shape.prototype, {
     configurable: true,
 
     get(this: Shape) {
-      return defineObjectProperty<Shape['try']>(
+      return overrideProperty<Shape['try']>(
         this,
         'try',
         this.isAsync
@@ -1041,7 +1041,7 @@ Object.defineProperties(Shape.prototype, {
     configurable: true,
 
     get(this: Shape) {
-      return defineObjectProperty<Shape['tryAsync']>(this, 'tryAsync', (input, options) => {
+      return overrideProperty<Shape['tryAsync']>(this, 'tryAsync', (input, options) => {
         return this._applyAsync(input, options || defaultApplyOptions, nextNonce()).then(result => {
           if (result === null) {
             return ok(input);
@@ -1059,7 +1059,7 @@ Object.defineProperties(Shape.prototype, {
     configurable: true,
 
     get(this: Shape) {
-      return defineObjectProperty<Shape['parse']>(
+      return overrideProperty<Shape['parse']>(
         this,
         'parse',
         this.isAsync
@@ -1083,7 +1083,7 @@ Object.defineProperties(Shape.prototype, {
     configurable: true,
 
     get(this: Shape) {
-      return defineObjectProperty<Shape['parseAsync']>(this, 'parseAsync', (input, options) => {
+      return overrideProperty<Shape['parseAsync']>(this, 'parseAsync', (input, options) => {
         return this._applyAsync(input, options || defaultApplyOptions, nextNonce()).then(result => {
           if (result === null) {
             return input;
@@ -1101,7 +1101,7 @@ Object.defineProperties(Shape.prototype, {
     configurable: true,
 
     get(this: Shape) {
-      return defineObjectProperty(
+      return overrideProperty(
         this,
         'parseOrDefault',
         this.isAsync
@@ -1125,7 +1125,7 @@ Object.defineProperties(Shape.prototype, {
     configurable: true,
 
     get(this: Shape) {
-      return defineObjectProperty(
+      return overrideProperty(
         this,
         'parseOrDefaultAsync',
         (input: unknown, defaultValue?: unknown, options?: ParseOptions) => {

--- a/src/main/shape/Shape.ts
+++ b/src/main/shape/Shape.ts
@@ -199,7 +199,8 @@ export class Shape<InputValue = any, OutputValue = InputValue> {
    * This method returns a promise if there are async {@link Shape.operations}.
    *
    * If the shape overrides only {@link Shape._apply} and doesn't override {@link Shape._applyAsync} then it's only safe
-   * to call this method _as the last statement_ in {@link Shape._apply}. Otherwise, it may return unexpected promise.
+   * to call this method _as the last statement_ in {@link Shape._apply}. Otherwise, it may return an unexpected
+   * promise.
    *
    * If the shape overrides both {@link Shape._apply} and {@link Shape._applyAsync} then this method would always
    * synchronously return a {@link Result} inside {@link Shape._apply}.

--- a/src/main/shape/Shape.ts
+++ b/src/main/shape/Shape.ts
@@ -3,6 +3,7 @@ import { freeze, isArray, isEqual, returnTrue } from '../internal/lang';
 import { Dict, overrideProperty, ReadonlyDict } from '../internal/objects';
 import type { INPUT, OUTPUT } from '../internal/shapes';
 import {
+  applyOperations,
   applyShape,
   captureIssues,
   createApplyOperations,
@@ -14,13 +15,13 @@ import {
   Promisify,
   throwSyncUnsupported,
   toDeepPartialShape,
-  universalApplyOperations,
 } from '../internal/shapes';
 import { isType, unionTypes } from '../internal/types';
 import { globalMessages } from '../messages';
 import { getTypeOf, TYPE_UNKNOWN, unknownInputs } from '../types';
 import {
   Any,
+  ApplyOperationsCallback,
   ApplyOptions,
   CheckResult,
   Err,
@@ -200,12 +201,7 @@ export class Shape<InputValue = any, OutputValue = InputValue> {
    * It's only safe to call this method _as the last statement_ in {@link Shape._apply}, otherwise it may return an
    * unexpected promise.
    */
-  protected declare _applyOperations: (
-    input: unknown,
-    output: unknown,
-    options: ApplyOptions,
-    issues: Issue[] | null
-  ) => Result | Promise<Result>;
+  protected declare _applyOperations: ApplyOperationsCallback;
 
   /**
    * Returns a sub-shape that describes a value associated with the given property name, or `null` if there's no such
@@ -974,7 +970,7 @@ Object.defineProperties(Shape.prototype, {
     configurable: true,
 
     get(this: Shape) {
-      let cb = universalApplyOperations;
+      let cb = applyOperations;
 
       for (let i = this.operations.length - 1, async = false; i >= 0; --i) {
         const operation = this.operations[i];

--- a/src/main/shape/StringShape.ts
+++ b/src/main/shape/StringShape.ts
@@ -39,7 +39,7 @@ export class StringShape extends CoercibleShape<string> {
     if (typeof output !== 'string' && (output = this._applyCoerce(input)) === NEVER) {
       return [this._typeIssueFactory(input, options)];
     }
-    return this._applyOperations(input, output, options, null);
+    return this._applyOperations(input, output, options, null) as Result;
   }
 }
 

--- a/src/main/shape/SymbolShape.ts
+++ b/src/main/shape/SymbolShape.ts
@@ -34,6 +34,6 @@ export class SymbolShape extends Shape<symbol> {
     if (typeof input !== 'symbol') {
       return [this._typeIssueFactory(input, options)];
     }
-    return this._applyOperations(input, input, options, null);
+    return this._applyOperations(input, input, options, null) as Result;
   }
 }

--- a/src/main/shape/UnionShape.ts
+++ b/src/main/shape/UnionShape.ts
@@ -1,7 +1,7 @@
 import { CODE_TYPE_UNION } from '../constants';
 import { unique } from '../internal/arrays';
-import { defineProperty, isArray, isObject } from '../internal/lang';
-import { ReadonlyDict } from '../internal/objects';
+import { isArray, isObject } from '../internal/lang';
+import { defineObjectProperty, ReadonlyDict } from '../internal/objects';
 import { applyShape, isAsyncShapes, toDeepPartialShape } from '../internal/shapes';
 import { isType } from '../internal/types';
 import { getTypeOf, TYPE_UNKNOWN } from '../types';
@@ -81,7 +81,7 @@ export class UnionShape<Shapes extends readonly AnyShape[]>
    * Returns an array of shapes that should be applied to the input.
    */
   private get _lookup(): LookupCallback {
-    return defineProperty(this, '_lookup', createLookup(unique(this.shapes)));
+    return defineObjectProperty(this, '_lookup', createLookup(unique(this.shapes)));
   }
 
   protected _isAsync(): boolean {

--- a/src/main/shape/UnionShape.ts
+++ b/src/main/shape/UnionShape.ts
@@ -1,7 +1,7 @@
 import { CODE_TYPE_UNION } from '../constants';
 import { unique } from '../internal/arrays';
 import { isArray, isObject } from '../internal/lang';
-import { defineObjectProperty, ReadonlyDict } from '../internal/objects';
+import { overrideProperty, ReadonlyDict } from '../internal/objects';
 import { applyShape, isAsyncShapes, toDeepPartialShape } from '../internal/shapes';
 import { isType } from '../internal/types';
 import { getTypeOf, TYPE_UNKNOWN } from '../types';
@@ -81,7 +81,7 @@ export class UnionShape<Shapes extends readonly AnyShape[]>
    * Returns an array of shapes that should be applied to the input.
    */
   private get _lookup(): LookupCallback {
-    return defineObjectProperty(this, '_lookup', createLookup(unique(this.shapes)));
+    return overrideProperty(this, '_lookup', createLookup(unique(this.shapes)));
   }
 
   protected _isAsync(): boolean {

--- a/src/main/shape/UnionShape.ts
+++ b/src/main/shape/UnionShape.ts
@@ -132,7 +132,7 @@ export class UnionShape<Shapes extends readonly AnyShape[]>
       }
       return [this._typeIssueFactory(input, options, { inputs: this.inputs, issueGroups })];
     }
-    return this._applyOperations(input, output, options, null);
+    return this._applyOperations(input, output, options, null) as Result;
   }
 
   protected _applyAsync(input: unknown, options: ApplyOptions, nonce: number): Promise<Result<Output<Shapes[number]>>> {

--- a/src/main/typings.ts
+++ b/src/main/typings.ts
@@ -150,9 +150,13 @@ export type MessageCallback = (issue: Issue, options: ApplyOptions) => any;
  * @see {@link Shape.alter}
  * @see {@link Shape.refine}
  * @see {@link Shape.withOperation}
+ * @see {@link Shape.checkAsync}
+ * @see {@link Shape.alterAsync}
+ * @see {@link Shape.refineAsync}
+ * @see {@link Shape.withAsyncOperation}
  * @group Operations
  */
-export interface Operation<Value = any> {
+export interface Operation {
   /**
    * The type of the operation such as {@link StringShape#regex "string.regex"} or
    * {@link ArrayShape#includes "array.includes"}.
@@ -180,7 +184,7 @@ export interface Operation<Value = any> {
   /**
    * The callback that applies the logic of the operation to the shape output.
    */
-  readonly callback: OperationCallback<Value, Result<Value>> | OperationCallback<Value, Promise<Result<Value>>>;
+  readonly callback: OperationCallback<Result> | OperationCallback<PromiseLike<Result>>;
 }
 
 /**
@@ -191,25 +195,25 @@ export interface Operation<Value = any> {
  * @param value The shape output value to which the operation must be applied.
  * @param param The {@link Operation.param additional param} that was associated with the operation.
  * @param options Parsing options.
+ * @template ReturnValue The value returned by the operation.
  * @template Value The shape output value to which the operation must be applied.
  * @template Param The {@link Operation.param additional param} that was associated with the operation.
- * @template ReturnValue The value returned by the operation.
  * @group Operations
  */
-export type OperationCallback<Value = any, Param = any, ReturnValue = any> = (
+export type OperationCallback<ReturnValue = any, Value = any, Param = any> = (
   value: Value,
   param: Param,
   options: ApplyOptions
 ) => ReturnValue;
 
 /**
- * Options of a generic {@link Operation operation}.
+ * Options of an {@link Operation operation}.
  *
  * @group Operations
  */
 export interface OperationOptions {
   /**
-   * The type of the operation.
+   * The type of the operation. If omitted then operation callback is used as its type.
    *
    * @see {@link Operation.type}
    */
@@ -226,28 +230,11 @@ export interface OperationOptions {
   /**
    * If `true` then consequent operations are omitted if this operation raises issues.
    *
+   * @see {@link Operation.isRequired}
    * @default false
    */
   required?: boolean;
 }
-
-/**
- * A callback that synchronously applies an operation to the shape output.
- *
- * @param input The input value to which the shape was applied.
- * @param output The shape output value to which the operation must be applied.
- * @param options Parsing options.
- * @param issues The mutable array of issues captured by a shape, or `null` if there were no issues raised yet.
- * @returns The result of the operation.
- * @template ReturnValue The cumulative result of applied operations.
- * @group Operations
- */
-export type ApplyOperationsCallback<ReturnValue extends Result | Promise<Result>> = (
-  input: any,
-  output: any,
-  options: ApplyOptions,
-  issues: Issue[] | null
-) => ReturnValue;
 
 /**
  * @inheritDoc
@@ -267,7 +254,7 @@ export interface ParameterizedOperationOptions<Param> extends OperationOptions {
  * @param value The value to refine.
  * @param param The additional param that was associated with the operation.
  * @param options Parsing options.
- * @return `true` if value matches the predicate, or `false` otherwise.
+ * @returns `true` if value matches the predicate, or `false` otherwise.
  * @template Value The value to refine.
  * @template RefinedValue The refined value.
  * @template Param The additional param that was associated with the operation.
@@ -353,3 +340,5 @@ export interface ParseOptions extends ApplyOptions {
  * @group Other
  */
 export type Any = object | string | number | bigint | boolean | symbol | null | undefined;
+
+export type CheckResult = Issue[] | Issue | null | undefined | void;

--- a/src/main/typings.ts
+++ b/src/main/typings.ts
@@ -108,14 +108,14 @@ export interface IssueOptions {
    * The custom issue message.
    *
    * @see {@link Message}
-   * @see {@link core!Issue#message Issue.message}
+   * @see {@link Issue.message}
    */
   message?: Message | Any;
 
   /**
    * An arbitrary metadata that is added to an issue.
    *
-   * @see {@link core!Issue#meta Issue.meta}
+   * @see {@link Issue.meta}
    */
   meta?: any;
 }

--- a/src/main/typings.ts
+++ b/src/main/typings.ts
@@ -158,8 +158,8 @@ export type MessageCallback = (issue: Issue, options: ApplyOptions) => any;
  */
 export interface Operation {
   /**
-   * The type of the operation such as {@link StringShape#regex "string.regex"} or
-   * {@link ArrayShape#includes "array.includes"}.
+   * The type of the operation such as {@link StringShape.regex "string.regex"} or
+   * {@link ArrayShape.includes "array.includes"}.
    */
   readonly type: any;
 

--- a/src/main/typings.ts
+++ b/src/main/typings.ts
@@ -149,11 +149,11 @@ export type MessageCallback = (issue: Issue, options: ApplyOptions) => any;
  * @see {@link Shape.check}
  * @see {@link Shape.alter}
  * @see {@link Shape.refine}
- * @see {@link Shape.withOperation}
+ * @see {@link Shape.addOperation}
  * @see {@link Shape.checkAsync}
  * @see {@link Shape.alterAsync}
  * @see {@link Shape.refineAsync}
- * @see {@link Shape.withAsyncOperation}
+ * @see {@link Shape.addAsyncOperation}
  * @group Operations
  */
 export interface Operation {

--- a/src/main/typings.ts
+++ b/src/main/typings.ts
@@ -186,6 +186,8 @@ export interface Operation<Value = any> {
 /**
  * A callback that applies an operation to the shape output value.
  *
+ * If a {@link ValidationError} is thrown, its issues are captured and incorporated into a parsing result.
+ *
  * @param value The shape output value to which the operation must be applied.
  * @param param The {@link Operation.param additional param} that was associated with the operation.
  * @param options Parsing options.
@@ -256,44 +258,6 @@ export interface ParameterizedOperationOptions<Param> extends OperationOptions {
   param: Param;
 }
 
-// /**
-//  * Checks that a value satisfies a requirement and returns issues if it doesn't.
-//  *
-//  * If a {@link ValidationError} is thrown, its issues are captured and incorporated into a parsing result.
-//  *
-//  * @param value The value to check.
-//  * @param param The additional param that was associated with the operation.
-//  * @param options Parsing options.
-//  * @returns `null` or `undefined` if the value satisfies a requirement; an issue or an array of issues if a value
-//  * doesn't satisfy a requirement.
-//  * @template Value The value to check.
-//  * @template Param The additional param that was associated with the check operation.
-//  * @see {@link Shape.check}
-//  * @group Operations
-//  */
-// export type CheckCallback<Value = any, Param = any> = (
-//   value: Value,
-//   param: Param,
-//   options: ApplyOptions
-// ) => Issue[] | Issue | null | undefined | void;
-//
-// /**
-//  * Checks that a value matches a predicate.
-//  *
-//  * If a {@link ValidationError} is thrown, its issues are captured and incorporated into a parsing result. Throw if
-//  * refinement cannot be performed, and you want to abort the operation.
-//  *
-//  * @param value The value to refine.
-//  * @param param The additional param that was associated with the operation.
-//  * @param options Parsing options.
-//  * @return Truthy if value matches the predicate, or falsy if it doesn't.
-//  * @template Value The value to refine.
-//  * @template Param The additional param that was associated with the operation.
-//  * @see {@link Shape.refine}
-//  * @group Operations
-//  */
-// export type RefineCallback<Value = any, Param = any> = (value: Value, param: Param, options: ApplyOptions) => any;
-
 /**
  * A [narrowing predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html) that refines the value type.
  *
@@ -339,26 +303,6 @@ export interface RefineOptions extends OperationOptions, IssueOptions {
 export interface ParameterizedRefineOptions<Param> extends RefineOptions {
   param: Param;
 }
-
-// /**
-//  * Alters the value without changing its base type.
-//  *
-//  * If you want to change the base type, consider using {@link Shape.convert}.
-//  *
-//  * If a {@link ValidationError} is thrown, its issues are captured and incorporated into a parsing result. Throw if
-//  * alteration cannot be performed, and you want to abort the operation.
-//  *
-//  * @param value The value to alter.
-//  * @param param The additional param that was associated with the operation.
-//  * @param options Parsing options.
-//  * @returns The altered value.
-//  * @template Value The value to alter.
-//  * @template Param The additional param that was associated with the operation.
-//  * @see {@link Shape.alter}
-//  * @see {@link Shape.convert}
-//  * @group Operations
-//  */
-// export type AlterCallback<Value = any, Param = any> = (value: Value, param: Param, options: ApplyOptions) => Value;
 
 /**
  * Options used when a shape is applied to an input value.
@@ -408,4 +352,4 @@ export interface ParseOptions extends ApplyOptions {
  *
  * @group Other
  */
-export type Any = {} | null | undefined;
+export type Any = object | string | number | bigint | boolean | symbol | null | undefined;

--- a/src/main/typings.ts
+++ b/src/main/typings.ts
@@ -143,6 +143,24 @@ export type Message = MessageCallback | string;
 export type MessageCallback = (issue: Issue, options: ApplyOptions) => any;
 
 /**
+ * A callback that applies operations to the shape output.
+ *
+ * @param input The input value to which the shape was applied.
+ * @param output The shape output value to which the operation must be applied.
+ * @param options Parsing options.
+ * @param issues The mutable array of issues captured by a shape, or `null` if there were no issues raised yet.
+ * @returns The result of the operation.
+ * @template ReturnValue The cumulative result of applied operations.
+ * @group Operations
+ */
+export type ApplyOperationsCallback = (
+  input: unknown,
+  output: unknown,
+  options: ApplyOptions,
+  issues: Issue[] | null
+) => Result | Promise<Result>;
+
+/**
  * An operation that a shape applies to its output.
  *
  * @template Value The shape output value to which the operation must be applied.

--- a/src/main/typings.ts
+++ b/src/main/typings.ts
@@ -359,4 +359,9 @@ export interface ParseOptions extends ApplyOptions {
  */
 export type Any = object | string | number | bigint | boolean | symbol | null | undefined;
 
+/**
+ * The result returned by a {@link Shape.check check operation}.
+ *
+ * @group Other
+ */
 export type CheckResult = Issue[] | Issue | null | undefined | void;

--- a/src/test/README.test.ts
+++ b/src/test/README.test.ts
@@ -1,6 +1,6 @@
 import qs from 'qs';
 import * as d from '../main';
-import { Shape } from '../main';
+import { Result, Shape } from '../main';
 import { CODE_TYPE_UNION } from '../main/constants';
 import { TYPE_ARRAY, TYPE_BOOLEAN, TYPE_NUMBER, TYPE_OBJECT, TYPE_STRING } from '../main/types';
 
@@ -215,7 +215,7 @@ describe('Advanced shapes', () => {
         }
 
         // 2️⃣ Apply operations to the output value
-        return this._applyOperations(input, parseFloat(input), options, null);
+        return this._applyOperations(input, parseFloat(input), options, null) as Result;
       }
     }
 

--- a/src/test/dsl/any.test.ts
+++ b/src/test/dsl/any.test.ts
@@ -17,7 +17,9 @@ describe('any', () => {
     expect(d.any(cb).operations[0]).toEqual({
       type: cb,
       param: undefined,
-      factory: expect.any(Function),
+      isAsync: false,
+      isRequired: false,
+      callback: expect.any(Function),
     });
   });
 });

--- a/src/test/plugins/array-essentials.test.ts
+++ b/src/test/plugins/array-essentials.test.ts
@@ -78,7 +78,7 @@ describe('includes', () => {
     });
   });
 
-  test('throws if shape is async', () => {
+  test.skip('throws if shape is async', () => {
     expect(() => new ArrayShape([], new Shape()).includes(new AsyncMockShape())).toThrow();
   });
 });

--- a/src/test/shapes/ArrayShape.test.ts
+++ b/src/test/shapes/ArrayShape.test.ts
@@ -2,7 +2,7 @@ import { ArrayShape, Err, NumberShape, ObjectShape, Ok, Shape, StringShape } fro
 import { CODE_TYPE, CODE_TYPE_TUPLE } from '../../main/constants';
 import { resetNonce } from '../../main/internal/shapes';
 import { TYPE_ARRAY, TYPE_NUMBER, TYPE_OBJECT, TYPE_STRING, TYPE_UNKNOWN } from '../../main/types';
-import { AsyncMockShape, MockShape, spyOnShape } from './mocks';
+import { AsyncMockShape, MockShape } from './mocks';
 
 describe('ArrayShape', () => {
   beforeEach(() => {
@@ -423,14 +423,6 @@ describe('ArrayShape', () => {
         ok: false,
         issues: [{ code: CODE_TYPE, input: 'aaa', message: Shape.messages['type.array'], param: TYPE_ARRAY }],
       });
-    });
-
-    test('downgrades to sync implementation if there are no async element shapes', async () => {
-      const shape = spyOnShape(new ArrayShape([], new MockShape()));
-
-      await expect(shape.tryAsync([])).resolves.toEqual({ ok: true, value: [] });
-      expect(shape._apply).toHaveBeenCalledTimes(1);
-      expect(shape._apply).toHaveBeenNthCalledWith(1, [], { earlyReturn: false }, 0);
     });
 
     test('parses head elements', async () => {

--- a/src/test/shapes/BooleanShape.test.ts
+++ b/src/test/shapes/BooleanShape.test.ts
@@ -48,4 +48,19 @@ describe('BooleanShape', () => {
       });
     });
   });
+
+  describe('async', () => {
+    test('invokes async check', async () => {
+      const checkMock = jest.fn(() => Promise.resolve([{ code: 'xxx' }]));
+
+      const shape = new BooleanShape().checkAsync(checkMock);
+
+      expect(shape.isAsync).toBe(true);
+
+      await expect(shape.tryAsync(true)).resolves.toEqual({
+        ok: false,
+        issues: [{ code: 'xxx' }],
+      });
+    });
+  });
 });

--- a/src/test/shapes/FunctionShape.test.ts
+++ b/src/test/shapes/FunctionShape.test.ts
@@ -316,4 +316,19 @@ describe('FunctionShape', () => {
       );
     });
   });
+
+  describe('async', () => {
+    test('invokes async check', async () => {
+      const checkMock = jest.fn(() => Promise.resolve([{ code: 'xxx' }]));
+
+      const shape = new FunctionShape(new ArrayShape([], null), new StringShape(), null).checkAsync(checkMock);
+
+      expect(shape.isAsync).toBe(true);
+
+      await expect(shape.tryAsync(() => undefined)).resolves.toEqual({
+        ok: false,
+        issues: [{ code: 'xxx' }],
+      });
+    });
+  });
 });

--- a/src/test/shapes/IntersectionShape.test.ts
+++ b/src/test/shapes/IntersectionShape.test.ts
@@ -116,7 +116,7 @@ describe('IntersectionShape', () => {
     const shape1 = new Shape();
     const shape2 = new Shape().check(() => [{ code: 'xxx' }]);
 
-    const shape = new IntersectionShape([shape1, shape2]).check(() => [{ code: 'yyy' }], { force: true });
+    const shape = new IntersectionShape([shape1, shape2]).check(() => [{ code: 'yyy' }]);
 
     expect(shape.try({}, { earlyReturn: true })).toEqual({
       ok: false,

--- a/src/test/shapes/LazyShape.test.ts
+++ b/src/test/shapes/LazyShape.test.ts
@@ -44,7 +44,7 @@ describe('LazyShape', () => {
 
   test('does not apply operations if the provided shape raises an issue', () => {
     const providedShape = new Shape().check(() => [{ code: 'xxx' }]);
-    const shape = new LazyShape(() => providedShape, identity).check(() => [{ code: 'yyy' }], { force: true });
+    const shape = new LazyShape(() => providedShape, identity).check(() => [{ code: 'yyy' }]);
 
     expect(shape.try('aaa', { earlyReturn: true })).toEqual({
       ok: false,

--- a/src/test/shapes/PromiseShape.test.ts
+++ b/src/test/shapes/PromiseShape.test.ts
@@ -129,17 +129,6 @@ describe('PromiseShape', () => {
       expect(checkMock).toHaveBeenNthCalledWith(1, input, undefined, { earlyReturn: false });
     });
 
-    test('applies forced operations if value shape raised issues', async () => {
-      const valueShape = new Shape().check(() => [{ code: 'xxx' }]);
-
-      const shape = new PromiseShape(valueShape).check(() => [{ code: 'yyy' }]);
-
-      await expect(shape.tryAsync(Promise.resolve(111))).resolves.toEqual({
-        ok: false,
-        issues: [{ code: 'xxx' }, { code: 'yyy' }],
-      });
-    });
-
     test('returns the same promise if the resolved value did not change', async () => {
       const input = Promise.resolve('aaa');
 

--- a/src/test/shapes/PromiseShape.test.ts
+++ b/src/test/shapes/PromiseShape.test.ts
@@ -132,7 +132,7 @@ describe('PromiseShape', () => {
     test('applies forced operations if value shape raised issues', async () => {
       const valueShape = new Shape().check(() => [{ code: 'xxx' }]);
 
-      const shape = new PromiseShape(valueShape).check(() => [{ code: 'yyy' }], { force: true });
+      const shape = new PromiseShape(valueShape).check(() => [{ code: 'yyy' }]);
 
       await expect(shape.tryAsync(Promise.resolve(111))).resolves.toEqual({
         ok: false,

--- a/src/test/shapes/SetShape.test.ts
+++ b/src/test/shapes/SetShape.test.ts
@@ -2,7 +2,7 @@ import { ObjectShape, Ok, SetShape, Shape, StringShape } from '../../main';
 import { CODE_TYPE } from '../../main/constants';
 import { resetNonce } from '../../main/internal/shapes';
 import { TYPE_ARRAY, TYPE_OBJECT, TYPE_SET, TYPE_STRING } from '../../main/types';
-import { AsyncMockShape, MockShape, spyOnShape } from './mocks';
+import { AsyncMockShape, MockShape } from './mocks';
 
 describe('SetShape', () => {
   beforeEach(() => {
@@ -181,14 +181,6 @@ describe('SetShape', () => {
         ok: false,
         issues: [{ code: CODE_TYPE, input: 'aaa', message: Shape.messages['type.set'], param: TYPE_SET }],
       });
-    });
-
-    test('downgrades to sync implementation if value shape is sync', async () => {
-      const shape = spyOnShape(new SetShape(new Shape()));
-
-      await expect(shape.tryAsync(new Set())).resolves.toEqual({ ok: true, value: new Set() });
-      expect(shape._apply).toHaveBeenCalledTimes(1);
-      expect(shape._apply).toHaveBeenNthCalledWith(1, new Set(), { earlyReturn: false }, 0);
     });
 
     test('parses values in a Set', async () => {

--- a/src/test/shapes/Shape.test.ts
+++ b/src/test/shapes/Shape.test.ts
@@ -37,22 +37,28 @@ describe('Shape', () => {
     expect(shape.inputs).toEqual([TYPE_UNKNOWN]);
   });
 
-  describe('use', () => {
+  describe('withOperation', () => {
     test('clones the shape', () => {
       const shape1 = new Shape();
-      const shape2 = shape1.use(next => (input, output, options, issues) => next(input, output, options, issues), {
-        type: 'aaa',
-        param: undefined,
-      });
+      const shape2 = shape1.withOperation(
+        next => (input, output, options, issues) => next(input, output, options, issues),
+        {
+          type: 'aaa',
+          param: undefined,
+        }
+      );
 
       expect(shape1).not.toBe(shape2);
     });
 
     test('returns the shape clone', () => {
-      const shape = new Shape().use(next => (input, output, options, issues) => next(input, output, options, issues), {
-        type: 'aaa',
-        param: undefined,
-      });
+      const shape = new Shape().withOperation(
+        next => (input, output, options, issues) => next(input, output, options, issues),
+        {
+          type: 'aaa',
+          param: undefined,
+        }
+      );
 
       expect(shape.operations.length).toBe(1);
     });

--- a/src/test/shapes/Shape.test.ts
+++ b/src/test/shapes/Shape.test.ts
@@ -37,10 +37,10 @@ describe('Shape', () => {
     expect(shape.inputs).toEqual([TYPE_UNKNOWN]);
   });
 
-  describe('withOperation', () => {
+  describe('addOperation', () => {
     test('clones the shape', () => {
       const shape1 = new Shape();
-      const shape2 = shape1.withOperation(() => null, { type: 'aaa', param: undefined });
+      const shape2 = shape1.addOperation(() => null, { type: 'aaa', param: undefined });
 
       expect(shape1).not.toBe(shape2);
       expect(shape1.operations.length).toBe(0);

--- a/src/test/shapes/UnionShape.test.ts
+++ b/src/test/shapes/UnionShape.test.ts
@@ -279,7 +279,7 @@ describe('UnionShape', () => {
           key1: new AsyncMockShape().check(() => [{ code: 'zzz' }]),
         },
         null
-      ).check(() => [{ code: 'yyy' }], { force: true });
+      ).check(() => [{ code: 'yyy' }]);
 
       const shape = new UnionShape([shape1, shape2]);
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -62,7 +62,6 @@
     "InferPromise",
     "InferRecord",
     "Intersect",
-    "LookupCallback",
     "OptionalDeepPartialShape",
     "OptionalKeys",
     "OptionalPropShapes",


### PR DESCRIPTION
- Renamed `use` to `addOperation` and added `addAsyncOperation`, so now async operations can be added to any shape. For example, this allowed to enable support of async shapes in `ArrayShape.includes` check:

```ts
const shape1 = d.string().checkAsync(async () => …);

const shape2 = d.array().includes(shape1);

shape2.isAsync;
// ⮕ true
```

- Added `checkAsync`, `refineAsync`, and `alterAsync`;

- Removed async to sync auto downgrade optimization, so if `parseAsync` is called on a sync shape it would use the async path instead of wrapping a sync path in a promise.

### New semantics

`_applyOperations` now returns a promise if there are async operations.

If the shape overrides only `_apply` and doesn't override `_applyAsync` then it's only safe
to call this method _as the last statement_ in `_apply`. Otherwise, it may return an unexpected promise.

If the shape overrides both `_apply` and `_applyAsync` then this method would always
synchronously return a `Result` inside `_apply`.