### PR TITLE
Operation tolerance

### DIFF
--- a/src/main/coerce/number.ts
+++ b/src/main/coerce/number.ts
@@ -2,8 +2,7 @@ import { freeze, getCanonicalValue, isArray } from '../internal/lang';
 import { TYPE_ARRAY, TYPE_BIGINT, TYPE_BOOLEAN, TYPE_DATE, TYPE_NUMBER, TYPE_OBJECT, TYPE_STRING } from '../types';
 import { NEVER } from './never';
 
-const MAX_SAFE_INTEGER = 0x1fffffffffffff;
-const MIN_SAFE_INTEGER = -MAX_SAFE_INTEGER;
+const { MIN_SAFE_INTEGER, MAX_SAFE_INTEGER } = Number;
 
 /**
  * The array of inputs that are coercible to a number with {@link coerceToNumber}.

--- a/src/main/plugin/bigint-essentials.ts
+++ b/src/main/plugin/bigint-essentials.ts
@@ -97,19 +97,19 @@ export default function enableBigIntEssentials(ctor: typeof BigIntShape): void {
   messages[CODE_BIGINT_MAX] = 'Must be less than or equal to %s';
 
   prototype.positive = function (options) {
-    return this.min(0, options);
+    return this.min(1, options);
   };
 
   prototype.negative = function (options) {
-    return this.max(0, options);
+    return this.max(-1, options);
   };
 
   prototype.nonPositive = function (options) {
-    return this.max(1, options);
+    return this.max(0, options);
   };
 
   prototype.nonNegative = function (options) {
-    return this.min(-1, options);
+    return this.min(0, options);
   };
 
   prototype.min = function (value, options) {

--- a/src/main/plugin/number-essentials.ts
+++ b/src/main/plugin/number-essentials.ts
@@ -26,6 +26,9 @@ import { createIssueFactory, extractOptions } from '../utils';
 
 export interface MultipleOfOptions extends IssueOptions {
   /**
+   * The non-negative integer, the number of decimal digits that are considered significant for floating number
+   * comparison.
+   *
    * By default, {@link core!NumberShape.multipleOf NumberShape.multipleOf} uses
    * [the modulo operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder) which
    * may produce unexpected results when used with floating point numbers. This happens because of
@@ -36,7 +39,7 @@ export interface MultipleOfOptions extends IssueOptions {
    * validated using this formula:
    *
    * ```
-   * Math.abs(Math.round(value / divisor) - value / divisor) < Math.pow(10, -precision)
+   * Math.abs(Math.round(value / divisor) - value / divisor) <= Math.pow(10, -precision)
    * ```
    */
   precision?: number;

--- a/src/main/shape/ObjectShape.ts
+++ b/src/main/shape/ObjectShape.ts
@@ -50,8 +50,8 @@ type DeepPartialObjectShape<PropShapes extends ReadonlyDict<AnyShape>, RestShape
 /**
  * Defines how unknown object keys are handled.
  *
- * - If `preserved` then unknown object keys are preserved as-is or checked with {@link ObjectShape.restShape};
- * - If `stripped` then the input object is cloned and unknown keys are removed from it;
+ * - If `preserved` then unknown object keys are preserved as-is or checked with {@link ObjectShape.restShape}.
+ * - If `stripped` then the input object is cloned and unknown keys are removed from it.
  * - If `exact` then an issue is raised if an unknown key is met.
  *
  * @see {@link ObjectShape.keysMode}

--- a/src/main/typings.ts
+++ b/src/main/typings.ts
@@ -182,10 +182,8 @@ export interface Operation {
   readonly type: any;
 
   /**
-   * The additional param associated with the operation. Usually contains a {@link type}-specific data is used in the
-   * {@link callback}.
-   *
-   * @see {@link Issue.param}
+   * The additional param associated with the operation. Usually contains a {@link Operation.type}-specific data is used
+   * in the {@link callback}.
    */
   readonly param: any;
 
@@ -195,15 +193,29 @@ export interface Operation {
   readonly isAsync: boolean;
 
   /**
-   * `true` if consequent operations must be omitted if this operation raises issues, of `false` otherwise.
+   * The operation tolerance for issues that are raised during validation.
    */
-  readonly isRequired: boolean;
+  readonly tolerance: OperationTolerance;
 
   /**
    * The callback that applies the logic of the operation to the shape output.
    */
   readonly callback: OperationCallback<Result> | OperationCallback<PromiseLike<Result>>;
 }
+
+/**
+ * Defines the operation tolerance for issues that are raised during validation.
+ *
+ * - If `skip` then if preceding operations have raised issues, then this operation is skipped but consequent operations
+ * are still applied.
+ * - If `abort` then if preceding operations have raised issues, then this operation is skipped and consequent operations
+ * aren't applied. Also, if this operation itself raises issues then consequent operations aren't applied.
+ * - If `auto` then the operation is applied regardless of previously raised issues.
+ *
+ * @see {@link Operation.tolerance}
+ * @group Operations
+ */
+export type OperationTolerance = 'skip' | 'abort' | 'auto';
 
 /**
  * A callback that applies an operation to the shape output value.
@@ -231,14 +243,16 @@ export type OperationCallback<ReturnValue = any, Value = any, Param = any> = (
  */
 export interface OperationOptions {
   /**
-   * The type of the operation. If omitted then operation callback is used as its type.
+   * The type of the operation such as {@link StringShape.regex "string.regex"} or
+   * {@link ArrayShape.includes "array.includes"}.  If omitted then operation callback is used as its type.
    *
    * @see {@link Operation.type}
    */
   type?: any;
 
   /**
-   * The additional param associated with the operation.
+   * The additional param associated with the operation. Usually contains a {@link OperationOptions.type type}-specific
+   * data is used in the {@link callback}.
    *
    * @see {@link Operation.param}
    * @default undefined
@@ -246,12 +260,12 @@ export interface OperationOptions {
   param?: any;
 
   /**
-   * If `true` then consequent operations are omitted if this operation raises issues.
+   * The operation tolerance for issues that are raised during validation.
    *
-   * @see {@link Operation.isRequired}
-   * @default false
+   * @see {@link Operation.tolerance}
+   * @default 'auto'
    */
-  required?: boolean;
+  tolerance?: OperationTolerance;
 }
 
 /**

--- a/src/test/dsl/any.test.ts
+++ b/src/test/dsl/any.test.ts
@@ -18,7 +18,7 @@ describe('any', () => {
       type: cb,
       param: undefined,
       isAsync: false,
-      isRequired: false,
+      tolerance: 'auto',
       callback: expect.any(Function),
     });
   });

--- a/src/test/shapes/Shape.test.ts
+++ b/src/test/shapes/Shape.test.ts
@@ -63,23 +63,23 @@ describe('Shape', () => {
           type: 'aaa',
           callback: cb,
           isAsync: false,
-          isRequired: false,
+          tolerance: 'auto',
           param: 111,
         },
       ]);
     });
 
-    test('adds a required operation', () => {
+    test('adds a non-tolerant operation', () => {
       const cb = () => null;
 
-      const shape = new Shape().addOperation(cb, { required: true });
+      const shape = new Shape().addOperation(cb, { tolerance: 'abort' });
 
       expect(shape.operations).toEqual([
         {
           type: cb,
           callback: cb,
           isAsync: false,
-          isRequired: true,
+          tolerance: 'abort',
         },
       ]);
     });
@@ -113,11 +113,11 @@ describe('Shape', () => {
       expect(cb2).toHaveBeenCalledTimes(1);
     });
 
-    test('if required operation fails then consequent operations are skipped', () => {
+    test('if a non-tolerant operation fails then consequent operations are skipped', () => {
       const cb1 = jest.fn().mockReturnValue([{ code: 'xxx' }]);
       const cb2 = jest.fn().mockReturnValue(null);
 
-      const shape = new Shape().addOperation(cb1, { required: true }).addOperation(cb2);
+      const shape = new Shape().addOperation(cb1, { tolerance: 'abort' }).addOperation(cb2);
 
       expect(shape.try('aaa')).toEqual({
         issues: [{ code: 'xxx' }],
@@ -162,23 +162,23 @@ describe('Shape', () => {
           type: 'aaa',
           callback: cb,
           isAsync: true,
-          isRequired: false,
+          tolerance: 'auto',
           param: 111,
         },
       ]);
     });
 
-    test('adds a required operation', () => {
+    test('adds a non-tolerant operation', () => {
       const cb = () => Promise.resolve(null);
 
-      const shape = new Shape().addAsyncOperation(cb, { required: true });
+      const shape = new Shape().addAsyncOperation(cb, { tolerance: 'abort' });
 
       expect(shape.operations).toEqual([
         {
           type: cb,
           callback: cb,
           isAsync: true,
-          isRequired: true,
+          tolerance: 'abort',
         },
       ]);
     });
@@ -212,11 +212,11 @@ describe('Shape', () => {
       expect(cb2).toHaveBeenCalledTimes(1);
     });
 
-    test('if required operation fails then consequent operations are skipped', async () => {
+    test('if a non-tolerant operation fails then consequent operations are skipped', async () => {
       const cb1 = jest.fn().mockReturnValue(Promise.resolve([{ code: 'xxx' }]));
       const cb2 = jest.fn().mockReturnValue(Promise.resolve(null));
 
-      const shape = new Shape().addAsyncOperation(cb1, { required: true }).addAsyncOperation(cb2);
+      const shape = new Shape().addAsyncOperation(cb1, { tolerance: 'abort' }).addAsyncOperation(cb2);
 
       await expect(shape.tryAsync('aaa')).resolves.toEqual({
         issues: [{ code: 'xxx' }],
@@ -975,11 +975,11 @@ describe('Shape', () => {
       expect(() => shape.try('aaa')).toThrow(new Error('expected'));
     });
 
-    test('check is not called if the preceding required operation has failed', () => {
+    test('check is not called if the preceding non-tolerant operation has failed', () => {
       const cbMock1 = jest.fn(() => [{ code: 'xxx' }]);
       const cbMock2 = jest.fn();
 
-      const shape = new Shape().check(cbMock1, { required: true }).check(cbMock2);
+      const shape = new Shape().check(cbMock1, { tolerance: 'abort' }).check(cbMock2);
 
       expect(shape.try('aaa')).toEqual({
         ok: false,


### PR DESCRIPTION
Tolerance setting changes the operation behavior depending on the validation issues are raised by the shape and preceding operations:
- If `skip` then if preceding operations have raised issues, then this operation is skipped but consequent operations are still applied.
- If `abort` then if preceding operations have raised issues, then this operation is skipped and consequent operations aren't applied. Also, if this operation itself raises issues then consequent operations aren't applied.
- If `auto` then the operation is applied regardless of previously raised issues.

For example, this skips alter operation if string length is insufficient:
```ts
d.string().min(10).alter(
  value => value.substring(5),
  { tolerance: 'skip' }
);
```