### PR TITLE
Readonly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1921,7 +1921,7 @@ const userShape = d.object({
 // ⮕ Shape<{ name: string, age: number }>
 
 userShape.propShapes.name;
-// ⮕ Shape<number>
+// ⮕ Shape<string>
 
 const userOrNameShape = d.or([userShape, d.string()]);
 // ⮕ Shape<{ name: string, age: number } | string>
@@ -1931,7 +1931,7 @@ userOrNameShape.shapes[0];
 ```
 
 [`Shape.at`](https://smikhalevski.github.io/doubter/next/classes/core.Shape.html#at) method derives a sub-shape at the
-given type, and if there's no such type then `null` is returned:
+given key, and if there's no such key then `null` is returned:
 
 ```ts
 userShape.at('age');
@@ -2447,7 +2447,7 @@ The table below highlights features that are unique to Doubter and its peers.
 2. Zod schemas are class instances so introspection is possible, but there's no way to get
    [a list of types accepted by a schema](#introspection).
 
-3. Zod supports only deep partial on objects. Doubter allows any shape to implement
+3. Zod supports [`deepPartial`](https://zod.dev/?id=deeppartial) for objects only. Doubter allows any shape to implement
    [`DeepPartialProtocol`](#implementing-deep-partial-support) and all shapes (except for primitives) support it
    out-of-the-box.
 
@@ -2517,6 +2517,13 @@ Convert array values during parsing:
 ```ts
 d.array(d.string().convert(parseFloat));
 // ⮕ Shape<string[], number[]>
+```
+
+Make an array readonly:
+
+```ts
+d.array(d.string()).readonly();
+// ⮕ Shape<string[], readonly string[]>
 ```
 
 ## Coerce to an array
@@ -3285,6 +3292,16 @@ d.map(d.string(), d.number());
 // ⮕ Shape<Map<string, number>>
 ```
 
+Mark a `Map` as readonly:
+
+```ts
+d.map(d.string(), d.number()).readonly();
+// ⮕ Shape<Map<string, number>, ReadonlyMap<string, number>>
+```
+
+> [!NOTE]\
+> Marking a `Map` as readonly, only affects type checking. At runtime, you would still be able to set and delete items.
+
 ## Coerce to a `Map`
 
 Arrays, iterables and array-like objects that withhold entry-like elements (a tuple with two elements) are converted to
@@ -3473,6 +3490,15 @@ d.object({
   age: d.number()
 });
 // ⮕ Shape<{ name: string, age: number }>
+```
+
+Make an object readonly:
+
+```ts
+d.object({
+  name: d.string()
+}).readonly();
+// ⮕ Shape<{ name: string }, { readonly name: string }>
 ```
 
 ## Optional properties
@@ -3769,6 +3795,13 @@ d.record(keysShape, d.number());
 // ⮕ Shape<Record<'foo' | 'bar', number>>
 ```
 
+Make a record readonly:
+
+```ts
+d.record(d.number()).readonly();
+// ⮕ Shape<Record<string, number>, Readonly<Record<string, number>>>
+```
+
 # `set`
 
 [`d.set`](https://smikhalevski.github.io/doubter/next/functions/core.set.html) returns a
@@ -3792,6 +3825,16 @@ Limit both minimum and maximum size at the same time:
 ```ts
 d.set(d.string()).size(5);
 ```
+
+Mark a `Set` as readonly:
+
+```ts
+d.set(d.string()).readonly();
+// ⮕ Shape<Set<string>, ReadonlySet<string>>
+```
+
+> [!NOTE]\
+> Marking a `Set` as readonly, only affects type checking. At runtime, you would still be able to add and delete items.
 
 ## Coerce to a `Set`
 
@@ -3937,6 +3980,13 @@ d.tuple([d.string(), d.number()], d.boolean());
 // Or
 d.tuple([d.string(), d.number()]).rest(d.boolean());
 // ⮕ Shape<[string, number, ...boolean]>
+```
+
+Make a tuple readonly:
+
+```ts
+d.tuple([d.string()]).readonly();
+// ⮕ Shape<[string], readonly [string]>
 ```
 
 Tuples follow [array type coercion rules](#coerce-to-an-array).

--- a/src/main/core.ts
+++ b/src/main/core.ts
@@ -44,6 +44,7 @@ export { NeverShape } from './shape/NeverShape';
 export { NumberShape } from './shape/NumberShape';
 export { ObjectShape } from './shape/ObjectShape';
 export { PromiseShape } from './shape/PromiseShape';
+export { ReadonlyShape } from './shape/ReadonlyShape';
 export { RecordShape } from './shape/RecordShape';
 export { SetShape } from './shape/SetShape';
 export { CatchShape, DenyShape, ExcludeShape, PipeShape, ReplaceShape, Shape, ConvertShape } from './shape/Shape';

--- a/src/main/internal/lang.ts
+++ b/src/main/internal/lang.ts
@@ -19,6 +19,10 @@ export function isObject(value: unknown): boolean {
   return isObjectLike(value) && !isArray(value);
 }
 
+export function isPlainObject(value: unknown): value is object {
+  return isObjectLike(value) && ((value = Object.getPrototypeOf(value)) === null || value === Object.prototype);
+}
+
 export function isIterableObject(value: any): value is Iterable<any> {
   return isObjectLike(value) && ((typeof Symbol !== 'undefined' && Symbol.iterator in value) || !isNaN(value.length));
 }

--- a/src/main/plugin/object-essentials.ts
+++ b/src/main/plugin/object-essentials.ts
@@ -28,6 +28,7 @@ import {
   MESSAGE_OBJECT_PLAIN,
   MESSAGE_OBJECT_XOR_KEYS,
 } from '../constants';
+import { isPlainObject } from '../internal/lang';
 import { ReadonlyDict } from '../internal/objects';
 import { OUTPUT } from '../internal/shapes';
 import { ObjectShape } from '../shape/ObjectShape';
@@ -177,9 +178,7 @@ declare module '../core' {
 ObjectShape.prototype.plain = RecordShape.prototype.plain = function (issueOptions): any {
   return this.addOperation(
     (value, param, options) => {
-      const prototype = Object.getPrototypeOf(value);
-
-      if (prototype === null || prototype.constructor === Object) {
+      if (isPlainObject(value)) {
         return null;
       }
       return [createIssue(CODE_OBJECT_PLAIN, value, MESSAGE_OBJECT_PLAIN, param, options, issueOptions)];

--- a/src/main/shape/ArrayShape.ts
+++ b/src/main/shape/ArrayShape.ts
@@ -15,6 +15,7 @@ import { Type } from '../Type';
 import { Issue, IssueOptions, Message, ParseOptions, Result } from '../types';
 import { createIssue } from '../utils';
 import { CoercibleShape } from './CoercibleShape';
+import { ReadonlyShape } from './ReadonlyShape';
 import { AnyShape, DeepPartialProtocol, OptionalDeepPartialShape, Shape, unknownInputs } from './Shape';
 
 const arrayInputs = Object.freeze([Type.ARRAY]);
@@ -118,8 +119,8 @@ export class ArrayShape<HeadShapes extends readonly AnyShape[], RestShape extend
   /**
    * Makes an array readonly: array elements cannot be added, removed or updated at runtime.
    */
-  readonly(): Shape<InferArray<HeadShapes, RestShape, INPUT>, Readonly<InferArray<HeadShapes, RestShape, OUTPUT>>> {
-    return this.alter(Object.freeze);
+  readonly(): ReadonlyShape<this> {
+    return new ReadonlyShape(this);
   }
 
   protected _isAsync(): boolean {

--- a/src/main/shape/ArrayShape.ts
+++ b/src/main/shape/ArrayShape.ts
@@ -115,6 +115,13 @@ export class ArrayShape<HeadShapes extends readonly AnyShape[], RestShape extend
     return new ArrayShape<any, any>(headShapes, restShape, this._options);
   }
 
+  /**
+   * Marks array as readonly: array elements cannot be added, removed or updated at runtime.
+   */
+  readonly(): Shape<InferArray<HeadShapes, RestShape, INPUT>, Readonly<InferArray<HeadShapes, RestShape, OUTPUT>>> {
+    return this.alter(Object.freeze);
+  }
+
   protected _isAsync(): boolean {
     return isAsyncShapes(this.headShapes) || this.restShape?.isAsync || false;
   }

--- a/src/main/shape/ArrayShape.ts
+++ b/src/main/shape/ArrayShape.ts
@@ -116,7 +116,7 @@ export class ArrayShape<HeadShapes extends readonly AnyShape[], RestShape extend
   }
 
   /**
-   * Marks array as readonly: array elements cannot be added, removed or updated at runtime.
+   * Makes an array readonly: array elements cannot be added, removed or updated at runtime.
    */
   readonly(): Shape<InferArray<HeadShapes, RestShape, INPUT>, Readonly<InferArray<HeadShapes, RestShape, OUTPUT>>> {
     return this.alter(Object.freeze);

--- a/src/main/shape/MapShape.ts
+++ b/src/main/shape/MapShape.ts
@@ -6,7 +6,15 @@ import { Type } from '../Type';
 import { Issue, IssueOptions, Message, ParseOptions, Result } from '../types';
 import { createIssue } from '../utils';
 import { CoercibleShape } from './CoercibleShape';
-import { AnyShape, DeepPartialProtocol, DeepPartialShape, Input, OptionalDeepPartialShape, Output } from './Shape';
+import {
+  AnyShape,
+  DeepPartialProtocol,
+  DeepPartialShape,
+  Input,
+  OptionalDeepPartialShape,
+  Output,
+  Shape,
+} from './Shape';
 
 const mapInputs = Object.freeze([Type.MAP]);
 const mapCoercibleInputs = Object.freeze([Type.MAP, Type.OBJECT, Type.ARRAY]);
@@ -66,6 +74,15 @@ export class MapShape<KeyShape extends AnyShape, ValueShape extends AnyShape>
     const valueShape = toDeepPartialShape(this.valueShape).optional();
 
     return new MapShape<any, any>(keyShape, valueShape, this._options);
+  }
+
+  /**
+   * Marks {@link !Map} as readonly.
+   *
+   * **Note:** This doesn't have any effect at runtime.
+   */
+  readonly(): Shape<Map<Input<KeyShape>, Input<ValueShape>>, ReadonlyMap<Output<KeyShape>, Output<ValueShape>>> {
+    return this;
   }
 
   protected _isAsync(): boolean {

--- a/src/main/shape/MapShape.ts
+++ b/src/main/shape/MapShape.ts
@@ -6,15 +6,8 @@ import { Type } from '../Type';
 import { Issue, IssueOptions, Message, ParseOptions, Result } from '../types';
 import { createIssue } from '../utils';
 import { CoercibleShape } from './CoercibleShape';
-import {
-  AnyShape,
-  DeepPartialProtocol,
-  DeepPartialShape,
-  Input,
-  OptionalDeepPartialShape,
-  Output,
-  Shape,
-} from './Shape';
+import { ReadonlyShape } from './ReadonlyShape';
+import { AnyShape, DeepPartialProtocol, DeepPartialShape, Input, OptionalDeepPartialShape, Output } from './Shape';
 
 const mapInputs = Object.freeze([Type.MAP]);
 const mapCoercibleInputs = Object.freeze([Type.MAP, Type.OBJECT, Type.ARRAY]);
@@ -81,8 +74,8 @@ export class MapShape<KeyShape extends AnyShape, ValueShape extends AnyShape>
    *
    * **Note:** This doesn't have any effect at runtime.
    */
-  readonly(): Shape<Map<Input<KeyShape>, Input<ValueShape>>, ReadonlyMap<Output<KeyShape>, Output<ValueShape>>> {
-    return this;
+  readonly(): ReadonlyShape<this> {
+    return new ReadonlyShape(this);
   }
 
   protected _isAsync(): boolean {

--- a/src/main/shape/MapShape.ts
+++ b/src/main/shape/MapShape.ts
@@ -77,7 +77,7 @@ export class MapShape<KeyShape extends AnyShape, ValueShape extends AnyShape>
   }
 
   /**
-   * Marks {@link !Map} as readonly.
+   * Marks a {@link !Map} as readonly.
    *
    * **Note:** This doesn't have any effect at runtime.
    */

--- a/src/main/shape/ObjectShape.ts
+++ b/src/main/shape/ObjectShape.ts
@@ -353,6 +353,13 @@ export class ObjectShape<PropShapes extends ReadonlyDict<AnyShape>, RestShape ex
     return copyOperations(this, new ObjectShape(this.propShapes, restShape, this._options));
   }
 
+  /**
+   * Marks object as readonly: properties cannot be added, removed or updated at runtime.
+   */
+  readonly(): Shape<InferObject<PropShapes, RestShape, INPUT>, Readonly<InferObject<PropShapes, RestShape, OUTPUT>>> {
+    return this.alter(Object.freeze);
+  }
+
   protected _isAsync(): boolean {
     return this.restShape?.isAsync || isAsyncShapes(this.valueShapes);
   }

--- a/src/main/shape/ObjectShape.ts
+++ b/src/main/shape/ObjectShape.ts
@@ -354,7 +354,7 @@ export class ObjectShape<PropShapes extends ReadonlyDict<AnyShape>, RestShape ex
   }
 
   /**
-   * Marks object as readonly: properties cannot be added, removed or updated at runtime.
+   * Makes an object readonly: properties cannot be added, removed or updated at runtime.
    */
   readonly(): Shape<InferObject<PropShapes, RestShape, INPUT>, Readonly<InferObject<PropShapes, RestShape, OUTPUT>>> {
     return this.alter(Object.freeze);

--- a/src/main/shape/ObjectShape.ts
+++ b/src/main/shape/ObjectShape.ts
@@ -16,6 +16,7 @@ import { Type } from '../Type';
 import { Issue, IssueOptions, Message, ParseOptions, Result } from '../types';
 import { createIssue } from '../utils';
 import { EnumShape } from './EnumShape';
+import { ReadonlyShape } from './ReadonlyShape';
 import { AllowShape, AnyShape, DeepPartialProtocol, DenyShape, OptionalDeepPartialShape, Shape } from './Shape';
 
 const objectInputs = Object.freeze([Type.OBJECT]);
@@ -356,8 +357,8 @@ export class ObjectShape<PropShapes extends ReadonlyDict<AnyShape>, RestShape ex
   /**
    * Makes an object readonly: properties cannot be added, removed or updated at runtime.
    */
-  readonly(): Shape<InferObject<PropShapes, RestShape, INPUT>, Readonly<InferObject<PropShapes, RestShape, OUTPUT>>> {
-    return this.alter(Object.freeze);
+  readonly(): ReadonlyShape<this> {
+    return new ReadonlyShape(this);
   }
 
   protected _isAsync(): boolean {

--- a/src/main/shape/ReadonlyShape.ts
+++ b/src/main/shape/ReadonlyShape.ts
@@ -10,13 +10,32 @@ type ToReadonly<T> =
   T extends Array<infer V> ? readonly V[] :
   T extends Set<infer V> ? ReadonlySet<V> :
   T extends Map<infer K, infer V> ? ReadonlyMap<K, V> :
+  T extends object ? Readonly<T> :
   T;
 
+/**
+ * The shape that makes the output readonly. Only freezes plain objects and arrays at runtime, other object types are
+ * left intact.
+ *
+ * @template BaseShape The shape that parses the input.
+ * @group Shapes
+ */
 export class ReadonlyShape<BaseShape extends AnyShape>
   extends Shape<Input<BaseShape>, ToReadonly<Output<BaseShape>>>
   implements DeepPartialProtocol<ReadonlyShape<DeepPartialShape<BaseShape>>>
 {
-  constructor(readonly baseShape: BaseShape) {
+  /**
+   * Creates the new {@link ReadonlyShape} instance.
+   *
+   * @param baseShape The shape that parses the input.
+   * @template BaseShape The shape that parses the input.
+   */
+  constructor(
+    /**
+     * The shape that parses the input.
+     */
+    readonly baseShape: BaseShape
+  ) {
     super();
   }
 

--- a/src/main/shape/ReadonlyShape.ts
+++ b/src/main/shape/ReadonlyShape.ts
@@ -1,0 +1,52 @@
+import { isArray, isPlainObject } from '../internal/lang';
+import { cloneObject } from '../internal/objects';
+import { toDeepPartialShape } from '../internal/shapes';
+import { ParseOptions, Result } from '../types';
+import { AnyShape, DeepPartialProtocol, DeepPartialShape, Input, Output, Shape } from './Shape';
+
+// prettier-ignore
+type ToReadonly<T> =
+  T extends null | undefined ? T :
+  T extends Array<infer V> ? readonly V[] :
+  T extends Set<infer V> ? ReadonlySet<V> :
+  T extends Map<infer K, infer V> ? ReadonlyMap<K, V> :
+  T;
+
+export class ReadonlyShape<BaseShape extends AnyShape>
+  extends Shape<Input<BaseShape>, ToReadonly<Output<BaseShape>>>
+  implements DeepPartialProtocol<ReadonlyShape<DeepPartialShape<BaseShape>>>
+{
+  constructor(readonly baseShape: BaseShape) {
+    super();
+  }
+
+  deepPartial(): ReadonlyShape<DeepPartialShape<BaseShape>> {
+    return new ReadonlyShape(toDeepPartialShape(this.baseShape));
+  }
+
+  protected _isAsync(): boolean {
+    return this.baseShape.isAsync;
+  }
+
+  protected _getInputs(): readonly unknown[] {
+    return this.baseShape.inputs;
+  }
+
+  protected _apply(input: unknown, options: ParseOptions, nonce: number): Result<ToReadonly<Output<BaseShape>>> {
+    let output = input;
+    let result = this.baseShape['_apply'](input, options, nonce);
+
+    if (result !== null) {
+      if (isArray(result)) {
+        return result;
+      }
+      output = result.value;
+    }
+
+    if (isPlainObject(output) || isArray(output)) {
+      output = Object.freeze(output !== input ? output : isArray(output) ? output.slice(0) : cloneObject(output));
+    }
+
+    return this._applyOperations(input, output, options, null) as Result;
+  }
+}

--- a/src/main/shape/RecordShape.ts
+++ b/src/main/shape/RecordShape.ts
@@ -5,6 +5,7 @@ import { applyShape, concatIssues, INPUT, OUTPUT, toDeepPartialShape, unshiftIss
 import { Type } from '../Type';
 import { Issue, IssueOptions, Message, ParseOptions, Result } from '../types';
 import { createIssue } from '../utils';
+import { ReadonlyShape } from './ReadonlyShape';
 import { AnyShape, DeepPartialProtocol, OptionalDeepPartialShape, Shape } from './Shape';
 
 const recordInputs = Object.freeze([Type.OBJECT]);
@@ -66,11 +67,8 @@ export class RecordShape<KeysShape extends Shape<string, PropertyKey>, ValuesSha
   /**
    * Makes a record readonly: properties cannot be added, removed or updated at runtime.
    */
-  readonly(): Shape<
-    Record<KeysShape[INPUT], ValuesShape[INPUT]>,
-    Readonly<Record<KeysShape[OUTPUT], ValuesShape[OUTPUT]>>
-  > {
-    return this.alter(Object.freeze);
+  readonly(): ReadonlyShape<this> {
+    return new ReadonlyShape(this);
   }
 
   protected _isAsync(): boolean {

--- a/src/main/shape/RecordShape.ts
+++ b/src/main/shape/RecordShape.ts
@@ -63,6 +63,16 @@ export class RecordShape<KeysShape extends Shape<string, PropertyKey>, ValuesSha
     return new RecordShape<any, any>(this.keysShape, toDeepPartialShape(this.valuesShape).optional(), this._options);
   }
 
+  /**
+   * Marks record as readonly: properties cannot be added, removed or updated at runtime.
+   */
+  readonly(): Shape<
+    Record<KeysShape[INPUT], ValuesShape[INPUT]>,
+    Readonly<Record<KeysShape[OUTPUT], ValuesShape[OUTPUT]>>
+  > {
+    return this.alter(Object.freeze);
+  }
+
   protected _isAsync(): boolean {
     return this.keysShape?.isAsync || this.valuesShape.isAsync;
   }

--- a/src/main/shape/RecordShape.ts
+++ b/src/main/shape/RecordShape.ts
@@ -64,7 +64,7 @@ export class RecordShape<KeysShape extends Shape<string, PropertyKey>, ValuesSha
   }
 
   /**
-   * Marks record as readonly: properties cannot be added, removed or updated at runtime.
+   * Makes a record readonly: properties cannot be added, removed or updated at runtime.
    */
   readonly(): Shape<
     Record<KeysShape[INPUT], ValuesShape[INPUT]>,

--- a/src/main/shape/SetShape.ts
+++ b/src/main/shape/SetShape.ts
@@ -7,7 +7,8 @@ import { Type } from '../Type';
 import { Issue, IssueOptions, Message, ParseOptions, Result } from '../types';
 import { createIssue } from '../utils';
 import { CoercibleShape } from './CoercibleShape';
-import { AnyShape, DeepPartialProtocol, Input, OptionalDeepPartialShape, Output, Shape } from './Shape';
+import { ReadonlyShape } from './ReadonlyShape';
+import { AnyShape, DeepPartialProtocol, Input, OptionalDeepPartialShape, Output } from './Shape';
 
 const setInputs = Object.freeze([Type.SET]);
 
@@ -58,8 +59,8 @@ export class SetShape<ValueShape extends AnyShape>
    *
    * **Note:** This doesn't have any effect at runtime.
    */
-  readonly(): Shape<Set<Input<ValueShape>>, ReadonlySet<Output<ValueShape>>> {
-    return this;
+  readonly(): ReadonlyShape<this> {
+    return new ReadonlyShape(this);
   }
 
   protected _isAsync(): boolean {

--- a/src/main/shape/SetShape.ts
+++ b/src/main/shape/SetShape.ts
@@ -7,7 +7,7 @@ import { Type } from '../Type';
 import { Issue, IssueOptions, Message, ParseOptions, Result } from '../types';
 import { createIssue } from '../utils';
 import { CoercibleShape } from './CoercibleShape';
-import { AnyShape, DeepPartialProtocol, Input, OptionalDeepPartialShape, Output } from './Shape';
+import { AnyShape, DeepPartialProtocol, Input, OptionalDeepPartialShape, Output, Shape } from './Shape';
 
 const setInputs = Object.freeze([Type.SET]);
 
@@ -51,6 +51,15 @@ export class SetShape<ValueShape extends AnyShape>
 
   deepPartial(): SetShape<OptionalDeepPartialShape<ValueShape>> {
     return new SetShape<any>(toDeepPartialShape(this.valueShape).optional(), this._options);
+  }
+
+  /**
+   * Marks {@link !Set} as readonly.
+   *
+   * **Note:** This doesn't have any effect at runtime.
+   */
+  readonly(): Shape<Set<Input<ValueShape>>, ReadonlySet<Output<ValueShape>>> {
+    return this;
   }
 
   protected _isAsync(): boolean {

--- a/src/main/shape/SetShape.ts
+++ b/src/main/shape/SetShape.ts
@@ -54,7 +54,7 @@ export class SetShape<ValueShape extends AnyShape>
   }
 
   /**
-   * Marks {@link !Set} as readonly.
+   * Marks a {@link !Set} as readonly.
    *
    * **Note:** This doesn't have any effect at runtime.
    */

--- a/src/main/shape/Shape.ts
+++ b/src/main/shape/Shape.ts
@@ -1005,7 +1005,7 @@ export interface Shape<InputValue, OutputValue> {
   ): Promisify<OutputValue | DefaultValue>;
 }
 
-// Define getter separately for cleaner generated docs and overloaded signatures
+// Define getters separately for cleaner generated docs and overloaded signatures
 Object.defineProperties(Shape.prototype, {
   _applyOperations: {
     configurable: true,

--- a/src/test/dsl/array.test-d.ts
+++ b/src/test/dsl/array.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd';
+import { expectNotAssignable, expectType } from 'tsd';
 import * as d from '../../main';
 import { INPUT, OUTPUT } from '../../main/internal/shapes';
 
@@ -13,3 +13,9 @@ expectType<111[]>(d.array(d.const(111))[OUTPUT]);
 expectType<Array<number | undefined>>(d.array(d.number()).deepPartial()[OUTPUT]);
 
 expectType<Array<{ aaa?: number } | undefined>>(d.array(d.object({ aaa: d.number() })).deepPartial()[OUTPUT]);
+
+expectType<string[]>(d.array(d.string()).readonly()[INPUT]);
+
+expectNotAssignable<string[]>(d.array(d.string()).readonly()[OUTPUT]);
+
+expectType<readonly string[]>(d.array(d.string()).readonly()[OUTPUT]);

--- a/src/test/dsl/map.test-d.ts
+++ b/src/test/dsl/map.test-d.ts
@@ -1,6 +1,6 @@
-import { expectType } from 'tsd';
+import { expectNotAssignable, expectType } from 'tsd';
 import * as d from '../../main';
-import { OUTPUT } from '../../main/internal/shapes';
+import { INPUT, OUTPUT } from '../../main/internal/shapes';
 
 expectType<Map<string, number>>(d.map(d.string(), d.number())[OUTPUT]);
 
@@ -16,3 +16,9 @@ expectType<Map<string, number | undefined>>(d.map(d.string(), d.number()).deepPa
 expectType<Map<{ aaa?: string }, { bbb?: number } | undefined>>(
   d.map(d.object({ aaa: d.string() }), d.object({ bbb: d.number() })).deepPartial()[OUTPUT]
 );
+
+expectType<Map<string, string>>(d.map(d.string(), d.string()).readonly()[INPUT]);
+
+expectNotAssignable<Map<string, string>>(d.map(d.string(), d.string()).readonly()[OUTPUT]);
+
+expectType<ReadonlyMap<string, string>>(d.map(d.string(), d.string()).readonly()[OUTPUT]);

--- a/src/test/dsl/object.test-d.ts
+++ b/src/test/dsl/object.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd';
 import * as d from '../../main';
-import { OUTPUT } from '../../main/internal/shapes';
+import { INPUT, OUTPUT } from '../../main/internal/shapes';
 
 expectType<{ aaa?: string }>(
   d.object({
@@ -104,3 +104,9 @@ expectType<{ aaa: string; bbb: number }>(
 );
 
 d.object({ aaa: d.string(), bbb: d.number() }).notAllKeys(['bbb']);
+
+expectType<{ aaa: string; bbb: number }>(d.object({ aaa: d.string(), bbb: d.number() }).readonly()[INPUT]);
+
+expectType<{ readonly aaa: string; readonly bbb: number }>(
+  d.object({ aaa: d.string(), bbb: d.number() }).readonly()[OUTPUT]
+);

--- a/src/test/dsl/record.test-d.ts
+++ b/src/test/dsl/record.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd';
 import * as d from '../../main';
-import { OUTPUT } from '../../main/internal/shapes';
+import { INPUT, OUTPUT } from '../../main/internal/shapes';
 
 expectType<Record<string, number>>(d.record(d.number())[OUTPUT]);
 
@@ -21,3 +21,9 @@ d.record(
   d.string().convert(x => x as 'aaa' | 'bbb'),
   d.number()
 ).notAllKeys(['bbb']);
+
+d.record(d.number()).notAllKeys(['bbb']);
+
+expectType<{ [key: string]: number }>(d.record(d.number()).readonly()[INPUT]);
+
+expectType<{ readonly [key: string]: number }>(d.record(d.number()).readonly()[OUTPUT]);

--- a/src/test/dsl/set.test-d.ts
+++ b/src/test/dsl/set.test-d.ts
@@ -1,7 +1,13 @@
-import { expectType } from 'tsd';
+import { expectNotAssignable, expectType } from 'tsd';
 import * as d from '../../main';
-import { OUTPUT } from '../../main/internal/shapes';
+import { INPUT, OUTPUT } from '../../main/internal/shapes';
 
 expectType<Set<string | number>>(d.set(d.or([d.string(), d.number()]))[OUTPUT]);
 
 expectType<Set<111>>(d.set(d.const(111))[OUTPUT]);
+
+expectType<Set<string>>(d.set(d.string()).readonly()[INPUT]);
+
+expectNotAssignable<Set<string>>(d.set(d.string()).readonly()[OUTPUT]);
+
+expectType<ReadonlySet<string>>(d.set(d.string()).readonly()[OUTPUT]);

--- a/src/test/shape/ObjectShape.test.ts
+++ b/src/test/shape/ObjectShape.test.ts
@@ -318,6 +318,16 @@ describe('ObjectShape', () => {
     });
   });
 
+  describe('readonly', () => {
+    test('', () => {
+      const shape = new ObjectShape({}, null).readonly();
+      const input = {};
+
+      expect(Object.isFrozen(shape.parse(input))).toBe(true);
+      expect(shape.parse(input)).not.toBe(input);
+    });
+  });
+
   describe('_applyRestUnchecked', () => {
     test('checks known keys', () => {
       const valueShape1 = new MockShape();

--- a/src/test/shape/ReadonlyShape.test.ts
+++ b/src/test/shape/ReadonlyShape.test.ts
@@ -1,0 +1,87 @@
+import { ReadonlyShape, Shape, StringShape } from '../../main';
+import { CODE_TYPE_STRING, MESSAGE_TYPE_STRING } from '../../main/constants';
+
+describe('ReadonlyShape', () => {
+  test('returns the value from the base shape if parsing succeeds', () => {
+    expect(new ReadonlyShape(new StringShape()).parse('bbb')).toBe('bbb');
+  });
+
+  test('returns an error from the base shape', () => {
+    expect(new ReadonlyShape(new StringShape()).try(111)).toEqual({
+      ok: false,
+      issues: [{ code: CODE_TYPE_STRING, input: 111, message: MESSAGE_TYPE_STRING }],
+    });
+  });
+
+  test('returns primitives as is', () => {
+    expect(new ReadonlyShape(new Shape()).parse(null)).toBe(null);
+    expect(new ReadonlyShape(new Shape()).parse(undefined)).toBe(undefined);
+    expect(new ReadonlyShape(new Shape()).parse(111)).toBe(111);
+    expect(new ReadonlyShape(new Shape()).parse('aaa')).toBe('aaa');
+  });
+
+  test('freezes a plain object', () => {
+    const input = { key: 'aaa' };
+    const output = new ReadonlyShape(new Shape()).parse(input);
+
+    expect(output).not.toBe(input);
+    expect(output).toEqual(input);
+    expect(Object.isFrozen(input)).toBe(false);
+    expect(Object.isFrozen(output)).toBe(true);
+  });
+
+  test('freezes an object with null prototype', () => {
+    const input = Object.create(null);
+    input.key = 'aaa';
+
+    const output = new ReadonlyShape(new Shape()).parse(input);
+
+    expect(output).not.toBe(input);
+    expect(output).toEqual(input);
+    expect(Object.getPrototypeOf(output)).toBe(null);
+    expect(Object.isFrozen(input)).toBe(false);
+    expect(Object.isFrozen(output)).toBe(true);
+  });
+
+  test('freezes an array', () => {
+    const input = [111, 222];
+    const output = new ReadonlyShape(new Shape()).parse(input);
+
+    expect(output).not.toBe(input);
+    expect(output).toEqual(input);
+    expect(Object.isFrozen(input)).toBe(false);
+    expect(Object.isFrozen(output)).toBe(true);
+  });
+
+  test('does not freeze Map', () => {
+    const input = new Map();
+    const output = new ReadonlyShape(new Shape()).parse(input);
+
+    expect(output).toBe(input);
+    expect(Object.isFrozen(output)).toBe(false);
+  });
+
+  test('does not freeze Set', () => {
+    const input = new Set();
+    const output = new ReadonlyShape(new Shape()).parse(input);
+
+    expect(output).toBe(input);
+    expect(Object.isFrozen(output)).toBe(false);
+  });
+
+  test('does not freeze a class instance', () => {
+    const input = new (class {})();
+    const output = new ReadonlyShape(new Shape()).parse(input);
+
+    expect(output).toBe(input);
+    expect(Object.isFrozen(output)).toBe(false);
+  });
+
+  test('freezes an object returned from the base shape', () => {
+    const value = { key: 'aaa' };
+    const output = new ReadonlyShape(new Shape().convert(() => value)).parse(111);
+
+    expect(output).toBe(value);
+    expect(Object.isFrozen(output)).toBe(true);
+  });
+});

--- a/typedoc.json
+++ b/typedoc.json
@@ -80,6 +80,7 @@
     "RequiredPropShapes",
     "InferOrDefault",
     "ThisType",
+    "ToReadonly",
     "INPUT",
     "OUTPUT"
   ],


### PR DESCRIPTION
`readonly()` support for `ArrayShape`, `ObjectShape`, `RecordShape`, `MapShape`, and `SetShape`.