### PR TITLE
Added Standard Schema plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Runtime validation and transformation library.
 - [High performance and low memory consumption](#performance);
 - Zero dependencies;
 - [Pluggable architecture](#plugins);
+- Compatible with [Standard Schema](https://github.com/standard-schema/standard-schema#readme);
 - Tree-shakable: [3 — 12 kB gzipped](https://bundlephobia.com/result?p=doubter) depending on what features you use;
 - Check out the [Cookbook](#cookbook) for real-life examples!
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@badrap/valita": "^0.4.5",
+        "@standard-schema/spec": "^1.0.0",
         "@types/qs": "^6.14.0",
         "ajv": "^8.17.1",
         "myzod": "^1.12.1",
@@ -933,6 +934,13 @@
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
   "homepage": "https://github.com/smikhalevski/doubter#readme",
   "devDependencies": {
     "@badrap/valita": "^0.4.5",
+    "@standard-schema/spec": "^1.0.0",
     "@types/qs": "^6.14.0",
     "ajv": "^8.17.1",
     "myzod": "^1.12.1",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,6 +23,7 @@ export type * from './plugin/date-essentials.js';
 export type * from './plugin/number-essentials.js';
 export type * from './plugin/object-essentials.js';
 export type * from './plugin/set-essentials.js';
+export type * from './plugin/standard-schema.js';
 export type * from './plugin/string-essentials.js';
 
 export * from './core.js';

--- a/src/main/plugin/date-essentials.ts
+++ b/src/main/plugin/date-essentials.ts
@@ -13,7 +13,6 @@
 
 import { CODE_DATE_MAX, CODE_DATE_MIN, MESSAGE_DATE_MAX, MESSAGE_DATE_MIN } from '../constants.js';
 import { DateShape } from '../shape/DateShape.js';
-import { Shape } from '../shape/Shape.js';
 import { IssueOptions, Message } from '../types.js';
 import { createIssue } from '../utils.js';
 

--- a/src/main/plugin/object-essentials.ts
+++ b/src/main/plugin/object-essentials.ts
@@ -32,7 +32,7 @@ import { isPlainObject } from '../internal/lang.js';
 import { ReadonlyDict } from '../internal/objects.js';
 import { ObjectShape } from '../shape/ObjectShape.js';
 import { RecordShape } from '../shape/RecordShape.js';
-import { AnyShape, OUTPUT, Shape } from '../shape/Shape.js';
+import { AnyShape, OUTPUT } from '../shape/Shape.js';
 import { IssueOptions, Message } from '../types.js';
 import { createIssue } from '../utils.js';
 

--- a/src/main/plugin/standard-schema.ts
+++ b/src/main/plugin/standard-schema.ts
@@ -1,0 +1,43 @@
+/**
+ * The plugin that enables [Standard Schema](https://github.com/standard-schema/standard-schema#readme) support.
+ *
+ * ```ts
+ * import * as d from 'doubter/core';
+ * import 'doubter/plugin/standard-schema';
+ *
+ * d.array()['~standard'].validate(['hello']);
+ * ```
+ *
+ * @module plugin/standard-schema
+ */
+
+import { defineReadonlyProperty } from '../internal/objects.js';
+import { Shape } from '../shape/Shape.js';
+import { StandardSchemaV1 } from '../vendor/standard-schema.js';
+
+declare module '../core.js' {
+  export interface Shape<InputValue, OutputValue> extends StandardSchemaV1<InputValue, OutputValue> {
+    /**
+     * The Standard Schema properties.
+     *
+     * @plugin {@link plugin/standard-schema! plugin/standard-schema}
+     */
+    readonly '~standard': StandardSchemaV1.Props<InputValue, OutputValue>;
+  }
+}
+
+Object.defineProperty(Shape.prototype, '~standard', {
+  get(this: Shape) {
+    return defineReadonlyProperty(this, '~standard', {
+      vendor: 'doubter',
+      version: 1,
+
+      validate: (input: unknown) => {
+        // Doubter doesn't constrain validation issue message type, while standard schema requires every issue to have
+        // a _string_ message. By default, all issues produced by Doubter built-in plugins have string messages. So it's
+        // safe to assume full runtime compatibility up to the point where custom non-string messages are used.
+        return this.isAsync ? this.tryAsync(input) : this.try(input);
+      },
+    });
+  },
+});

--- a/src/main/vendor/standard-schema.ts
+++ b/src/main/vendor/standard-schema.ts
@@ -1,0 +1,100 @@
+/**
+ * The Standard Schema interface.
+ */
+export type StandardSchemaV1<Input = unknown, Output = Input> = {
+  /**
+   * The Standard Schema properties.
+   */
+  readonly '~standard': StandardSchemaV1.Props<Input, Output>;
+};
+
+export declare namespace StandardSchemaV1 {
+  /**
+   * The Standard Schema properties interface.
+   */
+  export interface Props<Input = unknown, Output = Input> {
+    /**
+     * The version number of the standard.
+     */
+    readonly version: 1;
+    /**
+     * The vendor name of the schema library.
+     */
+    readonly vendor: string;
+    /**
+     * Validates unknown input values.
+     */
+    readonly validate: (value: unknown) => Result<Output> | Promise<Result<Output>>;
+    /**
+     * Inferred types associated with the schema.
+     */
+    readonly types?: Types<Input, Output> | undefined;
+  }
+
+  /**
+   * The result interface of the validate function.
+   */
+  export type Result<Output> = SuccessResult<Output> | FailureResult;
+
+  /**
+   * The result interface if validation succeeds.
+   */
+  export interface SuccessResult<Output> {
+    /**
+     * The typed output value.
+     */
+    readonly value: Output;
+    /**
+     * The non-existent issues.
+     */
+    readonly issues?: undefined;
+  }
+
+  /**
+   * The result interface if validation fails.
+   */
+  export interface FailureResult {
+    /**
+     * The issues of failed validation.
+     */
+    readonly issues: ReadonlyArray<Issue>;
+  }
+
+  /**
+   * The issue interface of the failure output.
+   */
+  export interface Issue {
+    /**
+     * The error message of the issue.
+     */
+    readonly message: string;
+    /**
+     * The path of the issue, if any.
+     */
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
+  }
+
+  /**
+   * The path segment interface of the issue.
+   */
+  export interface PathSegment {
+    /**
+     * The key representing a path segment.
+     */
+    readonly key: PropertyKey;
+  }
+
+  /**
+   * The Standard Schema types interface.
+   */
+  export interface Types<Input = unknown, Output = Input> {
+    /**
+     * The input type of the schema.
+     */
+    readonly input: Input;
+    /**
+     * The output type of the schema.
+     */
+    readonly output: Output;
+  }
+}

--- a/src/test/plugin/standard-schema.test-d.ts
+++ b/src/test/plugin/standard-schema.test-d.ts
@@ -1,0 +1,9 @@
+import { StandardSchemaV1 } from '@standard-schema/spec';
+import { expectType } from 'tsd';
+import * as d from '../../main/index.js';
+
+const shape = d.array(d.const(111).convert(() => 'aaa'));
+
+expectType<111[]>(null! as StandardSchemaV1.InferInput<typeof shape>);
+
+expectType<string[]>(null! as StandardSchemaV1.InferOutput<typeof shape>);

--- a/src/test/plugin/standard-schema.test.ts
+++ b/src/test/plugin/standard-schema.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'vitest';
+import { CODE_STRING_MIN } from '../../main/constants.js';
+import { PromiseShape, StringShape } from '../../main/index.js';
+import '../../main/plugin/standard-schema.js';
+
+test('synchronously validates using a standard schema API', () => {
+  expect(new StringShape().min(2)['~standard'].validate('a')).toEqual({
+    ok: false,
+    issues: [{ code: CODE_STRING_MIN, input: 'a', param: 2, message: 'Must have the minimum length of 2' }],
+  });
+});
+
+test('asynchronously validates using a standard schema API', async () => {
+  const promise = new PromiseShape(new StringShape().min(2))['~standard'].validate(Promise.resolve('a'));
+
+  expect(promise).toBeInstanceOf(Promise);
+
+  await expect(promise).resolves.toEqual({
+    ok: false,
+    issues: [{ code: CODE_STRING_MIN, input: 'a', param: 2, message: 'Must have the minimum length of 2' }],
+  });
+});

--- a/typedoc.json
+++ b/typedoc.json
@@ -76,5 +76,10 @@
     "INPUT",
     "OUTPUT"
   ],
-  "plugin": ["typedoc-plugin-mdn-links"]
+  "plugin": ["typedoc-plugin-mdn-links"],
+  "externalSymbolLinkMappings": {
+    "doubter": {
+      "StandardSchemaV1.Props": "https://github.com/standard-schema/standard-schema#readme"
+    }
+  }
 }


### PR DESCRIPTION
Doubter is now compatible with [Standard Schema](https://github.com/standard-schema/standard-schema#readme):

```ts
import 'doubter/plugin/standard-schema';
```